### PR TITLE
Update Thermodynamics compat, bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
@@ -13,5 +13,5 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 CLIMAParameters = "0.2"
 DocStringExtensions = "0.8"
 SpecialFunctions = "1"
-Thermodynamics = "0.3"
+Thermodynamics = "0.4"
 julia = "1.5"


### PR DESCRIPTION
We should have bumped the thermo compat, right now, no packages can `resolve` to use the latest version because the version of thermodynamics that this package limits us to uses an older version of CLIMAParameters :(

I found this out when trying to update ClimateMachine.jl..