### PR TITLE
Upgrade to new Thermodynamics, bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
@@ -13,5 +13,5 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 CLIMAParameters = "0.2"
 DocStringExtensions = "0.8"
 SpecialFunctions = "1"
-Thermodynamics = "0.4"
+Thermodynamics = "0.5"
 julia = "1.5"


### PR DESCRIPTION
So that we can start using this in TC.jl! I think it's okay for us to bump the minor version here, since the breaking version in Thermodynamics only applies to packages that use `PhaseEquil_pTq`/`PhaseEquil_pθq`.