### PR TITLE
Docstring typofix

### DIFF
--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -486,7 +486,7 @@ end
  - `i` - snow for temperatures below freezing
          or rain for temperatures above freezing
  - `j` - rain for temperatures below freezing
-         or rain for temperatures above freezing
+         or snow for temperatures above freezing
  - `param_set` - abstract set with Earth parameters
  - `type_i`, `type_j` - a type for snow or rain
  - `q_` - specific humidity of snow or rain


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
I just spotted this typo while reading this docstring

## Benefits and Risks
Improve the API docs

## Linked Issues


## PR Checklist
- [ ] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
