### PR TITLE
smooth transitioning at thresholds of autoconversion rates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.1"
+version = "0.8.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,7 @@ pages = Any[
     "1-moment precipitation microphysics" => "Microphysics1M.md",
     "2-moment precipitation microphysics" => "Microphysics2M.md",
     "Non-equilibrium cloud formation" => "MicrophysicsNonEq.md",
+    "Smooth transition at thresholds" => "ThresholdsTransition.md",
     "Aerosol activation" => "AerosolActivation.md",
     "ARG2000 activation example" => "ARG2000_example.md",
     "API" => "API.md",

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -75,6 +75,8 @@ AerosolActivation.total_M_activated
 ```@docs
 Common
 Common.G_func
+Common.logistic_function
+Common.logistic_function_integral
 ```
 
 # Common utility types

--- a/docs/src/ThresholdsTransition.md
+++ b/docs/src/ThresholdsTransition.md
@@ -1,0 +1,113 @@
+# Smooth transition at thresholds
+
+To avoid abrupt change of values at thresholds we can use the logistic function to make the transition smooth. The logistic function is defined as
+```math
+f(t, k) = \frac{1}{1+e^{-kt}}
+```
+where
+- ``t`` is the independent parameter,
+- and ``k`` is the growth rate of the curve characterizing the steepness of the transition.
+
+The value of the logistic function changes from zero at ``t \rightarrow -\infty`` to one at ``t \rightarrow \infty`` with the majority of the change happening around ``t = 0``. In our microphysics applications, the independent parameter (typically specific humidities) takes only non-negative values, and when this parameter is zero the function should return zero. Thus, we use the change of variable ``t = x/x_0 - x_0/x``, where ``x_0`` is the threshold value of ``x``. Therefore, the logistic function for smooth transitioning from ``f(x) = 0``, for ``x < x_0``, to ``f(x)=1``, for ``x > x_0``, is defined as
+```math
+f(x, x_0, k) = \frac{1}{1+e^{-k(x/x_0 - x_0/x)}}
+```
+Note that when both ``x`` and ``x_0`` are zero the value given by the above equation is undefined. In this case we return a zero value instead.
+
+## Smooth transition of derivative at thresholds
+
+When the function itself is continuous but its derivative changes abruptly at a threshold we can use the indefinite integral of the logistic function for smooth transitioning. In this case, the following function can be used
+
+```math
+f(x, x_0, k) = \frac{x_0}{k} \ln\left(1+e^{k(x/x_0 - 1 + a_{trnslt})} \right) - a_{trnslt} x_0
+```
+where ``a`` is a fixed value that is defined to enforce zero at ``x=0``:
+```math
+a_{trnslt} = -\frac{1}{k}\ln\left(1 - e^{-k}\right)
+```
+The curve defined by the above equation smoothly transition from ``f(x) = 0``, for ``x < x_0``, to ``f(x)=x-x_0``, for ``x > x_0``. Note that when both ``x`` and ``x_0`` are zero the value of the function is undefined. In this case we return a zero value instead.
+
+## Example figures
+
+```@example example_figures
+import Plots
+import CloudMicrophysics
+import CLIMAParameters
+
+const PL = Plots
+const CM1 = CloudMicrophysics.Microphysics1M
+const CM2 = CloudMicrophysics.Microphysics2M
+const CP = CLIMAParameters
+
+include(joinpath(pkgdir(CloudMicrophysics), "test", "create_parameters.jl"))
+FT = Float64
+
+param_set=[]
+k_thrshld_stpnss_values = [5.0, 2.0, 12.0]
+for i in 1:3
+    override_file = joinpath("override_dict.toml")
+    open(override_file, "w") do io
+        println(io, "[threshold_smooth_transition_steepness]")
+        println(io, "alias = \"k_thrshld_stpnss\"")
+        println(io, "value = " * string(k_thrshld_stpnss_values[i]))
+        println(io, "type = \"float\"")
+    end
+    toml_dict = CP.create_toml_dict(FT; override_file, dict_type="alias")
+    isfile(override_file) && rm(override_file; force=true)
+    push!(param_set, cloud_microphysics_parameters(toml_dict))
+end
+
+# example values
+q_liq_range  = range(1e-8, stop=1.5e-3, length=1000)
+N_d_range = range(1e7, stop=1e9, length=1000)
+ρ_air = 1.0 # kg m^-3
+
+q_liq_K1969 = [CM1.conv_q_liq_to_q_rai(param_set[1], q_liq) for q_liq in q_liq_range]
+q_liq_K1969_s = [CM1.conv_q_liq_to_q_rai(param_set[1], q_liq, smooth_transition = true) for q_liq in q_liq_range]
+
+q_liq_TC1980 = [CM2.conv_q_liq_to_q_rai_TC1980(param_set[2], q_liq, ρ_air) for q_liq in q_liq_range]
+q_liq_TC1980_s = [CM2.conv_q_liq_to_q_rai_TC1980(param_set[2], q_liq, ρ_air, smooth_transition = true) for q_liq in q_liq_range]
+q_liq_LD2004 = [CM2.conv_q_liq_to_q_rai_LD2004(param_set[2], q_liq, ρ_air) for q_liq in q_liq_range]
+q_liq_LD2004_s = [CM2.conv_q_liq_to_q_rai_LD2004(param_set[2], q_liq, ρ_air, smooth_transition = true) for q_liq in q_liq_range]
+
+N_d_B1994 = [CM2.conv_q_liq_to_q_rai_B1994(param_set[3], 5e-4, ρ_air, N_d = N_d) for N_d in N_d_range]
+N_d_B1994_s = [CM2.conv_q_liq_to_q_rai_B1994(param_set[3], 5e-4, ρ_air, N_d = N_d, smooth_transition = true) for N_d in N_d_range]
+
+
+PL.plot(q_liq_range * 1e3, q_liq_K1969,
+    linewidth=2,
+    xlabel="q_liq [g/kg]",
+    ylabel="autoconversion rate [1/s]",
+    label="K1969 without smoothing"
+)
+PL.plot!(q_liq_range * 1e3, q_liq_K1969_s, linewidth=2, label="K1969 with smoothing")
+PL.savefig("q_liq_K1969.svg") # hide
+
+PL.plot(q_liq_range * 1e3, q_liq_TC1980,
+    linewidth=2,
+    xlabel="q_liq [g/kg]",
+    ylabel="autoconversion rate [1/s]",
+    label="TC1980 without smoothing",
+    yaxis=:log,
+    ylim=(1e-10, 1e-5)
+)
+PL.plot!(q_liq_range * 1e3, q_liq_TC1980_s, linewidth=2, label="TC1980 with smoothing")
+PL.plot!(q_liq_range * 1e3, q_liq_LD2004, linewidth=2, label="LD2004 without smoothing")
+PL.plot!(q_liq_range * 1e3, q_liq_LD2004_s, linewidth=2, label="LD2004 with smoothing")
+PL.savefig("q_liq_TC1980_LD2004.svg") # hide
+
+PL.plot(N_d_range * 1e-6, N_d_B1994,
+    linewidth=2,
+    xlabel="N_d [1/cm3]",
+    ylabel="autoconversion rate [1/s]",
+    label="B1994 without smoothing",
+    xaxis=:log,
+    yaxis=:log,
+    ylim=(1e-13, 1e-5)
+)
+PL.plot!(N_d_range * 1e-6, N_d_B1994_s, linewidth=2, label="B1994 with smoothing")
+PL.savefig("N_d_B1994.svg") # hide
+```
+![](q_liq_K1969.svg)
+![](q_liq_TC1980_LD2004.svg)
+![](N_d_B1994.svg)

--- a/src/Common.jl
+++ b/src/Common.jl
@@ -51,4 +51,62 @@ function G_func(param_set::APS, T::FT, ::TD.Ice) where {FT <: Real}
     )
 end
 
+"""
+    logistic_function(x, x_0, k)
+
+ - `x` - independent variable
+ - `x_0` - threshold value for x
+ - `k` - growth rate of the curve, characterizing steepness of the transition
+
+Returns the value of the logistic function for smooth transitioning at thresholds. This is
+a normalized curve changing from 0 to 1 while x varies from 0 to Inf (for positive k). For
+x < 0 the value at x = 0 (zero) is returned. For x_0 = 0 H(x) is returned.
+"""
+function logistic_function(x::FT, x_0::FT, k::FT) where {FT <: Real}
+
+    @assert k > 0
+    @assert x_0 >= 0
+    x = max(0, x)
+
+    if abs(x) < eps(FT)
+        return FT(0)
+    elseif abs(x_0) < eps(FT)
+        return FT(1)
+    end
+
+    return 1 / (1 + exp(-k * (x / x_0 - x_0 / x)))
+end
+
+"""
+    logistic_function_integral(x, x_0, k)
+
+ - `x` - independent variable
+ - `x_0` - threshold value for x
+ - `k` - growth rate of the logistic function, characterizing steepness of the transition
+
+Returns the value of the indefinite integral of the logistic function, for smooth transitioning
+of piecewise linear profiles at thresholds. This curve smoothly transition from y = 0
+for 0 < x < x_0 to y = x - x_0 for x_0 < x.
+"""
+function logistic_function_integral(x::FT, x_0::FT, k::FT) where {FT <: Real}
+
+    @assert k > 0
+    @assert x_0 >= 0
+    x = max(0, x)
+
+    if abs(x) < eps(FT)
+        return FT(0)
+    elseif abs(x_0) < eps(FT)
+        return x
+    end
+
+    # translation of the curve in x and y to enforce zero at x = 0
+    _trnslt::FT = -log(1 - exp(-k)) / k
+
+    _kt::FT = k * (x / x_0 - 1 + _trnslt)
+    _result::FT =
+        (_kt > 40.0) ? x - x_0 : (log(1 + exp(_kt)) / k - _trnslt) * x_0
+    return _result
+end
+
 end

--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -277,12 +277,24 @@ end
 Returns the q_rai tendency due to collisions between cloud droplets
 (autoconversion), parametrized following Kessler (1995).
 """
-function conv_q_liq_to_q_rai(param_set::APS, q_liq::FT) where {FT <: Real}
+function conv_q_liq_to_q_rai(
+    param_set::APS,
+    q_liq::FT;
+    smooth_transition::Bool = false,
+) where {FT <: Real}
 
     _τ_acnv_rai::FT = CMP.τ_acnv_rai(param_set)
     _q_liq_threshold::FT = CMP.q_liq_threshold(param_set)
 
-    return max(0, q_liq - _q_liq_threshold) / _τ_acnv_rai
+    _output::FT = FT(0)
+    if smooth_transition
+        _k::FT = CMP.k_thrshld_stpnss(param_set)
+        _output = CO.logistic_function_integral(q_liq, _q_liq_threshold, _k)
+    else
+        _output = max(0, q_liq - _q_liq_threshold)
+    end
+    return _output / _τ_acnv_rai
+
 end
 
 """
@@ -298,13 +310,22 @@ simulations where there is no supersaturation
 """
 function conv_q_ice_to_q_sno_no_supersat(
     param_set::APS,
-    q_ice::FT,
+    q_ice::FT;
+    smooth_transition::Bool = false,
 ) where {FT <: Real}
 
     _τ_acnv_sno::FT = CMP.τ_acnv_sno(param_set)
     _q_ice_threshold::FT = CMP.q_ice_threshold(param_set)
 
-    return max(0, q_ice - _q_ice_threshold) / _τ_acnv_sno
+    _output::FT = FT(0)
+    if smooth_transition
+        _k::FT = CMP.k_thrshld_stpnss(param_set)
+        _output = CO.logistic_function_integral(q_ice, _q_ice_threshold, _k)
+    else
+        _output = max(0, q_ice - _q_ice_threshold)
+    end
+    return _output / _τ_acnv_sno
+
 end
 
 """

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -93,6 +93,7 @@ Base.@kwdef struct CloudMicrophysicsParameters{FT, TP} <:
     b_acc_KK2000::FT
     R_6C_coeff_LD2004::FT
     E_0_LD2004::FT
+    k_thrshld_stpnss::FT
 end
 
 const CMPS = CloudMicrophysicsParameters

--- a/test/common_functions_tests.jl
+++ b/test/common_functions_tests.jl
@@ -1,0 +1,45 @@
+import Test
+
+import CloudMicrophysics
+const CO = CloudMicrophysics.Common
+
+
+TT.@testset "logistic_function unit tests" begin
+
+    TT.@test CO.logistic_function(-1.0, 1.0, 2.0) == 0.0
+    TT.@test CO.logistic_function(0.0, 1.0, 2.0) == 0.0
+    TT.@test CO.logistic_function(1.0, 1.0, 2.0) == 0.5
+    TT.@test CO.logistic_function(2.0, 1.0, 2.0) ≈ 0.9525 atol = 1e-4
+
+    TT.@test CO.logistic_function(1.0, 0.0, 2.0) == 1.0
+    TT.@test CO.logistic_function(0.0, 0.0, 2.0) == 0.0
+    TT.@test_throws AssertionError("x_0 >= 0") CO.logistic_function(
+        1.0,
+        -1.0,
+        2.0,
+    )
+    TT.@test_throws AssertionError("k > 0") CO.logistic_function(1.0, 1.0, 0.0)
+
+end
+
+TT.@testset "logistic_function_integral unit tests" begin
+
+    TT.@test CO.logistic_function_integral(-1.0, 1.0, 2.0) == 0.0
+    TT.@test CO.logistic_function_integral(0.0, 1.0, 2.0) == 0.0
+    TT.@test CO.logistic_function_integral(1.0, 1.0, 2.0) ≈ 0.3115 atol = 1e-4
+    TT.@test CO.logistic_function_integral(3.0, 1.0, 2.0) ≈ 2.0 atol = 1e-2
+
+    TT.@test CO.logistic_function_integral(1.0, 0.0, 2.0) == 1.0
+    TT.@test CO.logistic_function_integral(0.0, 0.0, 2.0) == 0.0
+    TT.@test_throws AssertionError("x_0 >= 0") CO.logistic_function_integral(
+        1.0,
+        -1.0,
+        2.0,
+    )
+    TT.@test_throws AssertionError("k > 0") CO.logistic_function_integral(
+        1.0,
+        1.0,
+        0.0,
+    )
+
+end

--- a/test/microphysics_tests.jl
+++ b/test/microphysics_tests.jl
@@ -140,9 +140,20 @@ TT.@testset "RainAutoconversion" begin
     q_liq_small = 0.5 * _q_liq_threshold
     TT.@test CM1.conv_q_liq_to_q_rai(prs, q_liq_small) == 0.0
 
+    TT.@test CM1.conv_q_liq_to_q_rai(
+        prs,
+        q_liq_small,
+        smooth_transition = true,
+    ) ≈ 0.0 atol = 0.15 * _q_liq_threshold / _τ_acnv_rai
+
     q_liq_big = 1.5 * _q_liq_threshold
     TT.@test CM1.conv_q_liq_to_q_rai(prs, q_liq_big) ==
              0.5 * _q_liq_threshold / _τ_acnv_rai
+
+    TT.@test CM1.conv_q_liq_to_q_rai(prs, q_liq_big, smooth_transition = true) ≈
+             0.5 * _q_liq_threshold / _τ_acnv_rai atol =
+        0.15 * _q_liq_threshold / _τ_acnv_rai
+
 end
 
 TT.@testset "SnowAutoconversionNoSupersat" begin
@@ -153,9 +164,22 @@ TT.@testset "SnowAutoconversionNoSupersat" begin
     q_ice_small = 0.5 * _q_ice_threshold
     TT.@test CM1.conv_q_ice_to_q_sno_no_supersat(prs, q_ice_small) == 0.0
 
+    TT.@test CM1.conv_q_ice_to_q_sno_no_supersat(
+        prs,
+        q_ice_small,
+        smooth_transition = true,
+    ) ≈ 0.0 atol = 0.15 * _q_ice_threshold / _τ_acnv_sno
+
     q_ice_big = 1.5 * _q_ice_threshold
     TT.@test CM1.conv_q_ice_to_q_sno_no_supersat(prs, q_ice_big) ≈
              0.5 * _q_ice_threshold / _τ_acnv_sno
+
+    TT.@test CM1.conv_q_ice_to_q_sno_no_supersat(
+        prs,
+        q_ice_big,
+        smooth_transition = true,
+    ) ≈ 0.5 * _q_ice_threshold / _τ_acnv_sno atol =
+        0.15 * _q_ice_threshold / _τ_acnv_sno
 end
 
 TT.@testset "SnowAutoconversion" begin
@@ -396,6 +420,44 @@ TT.@testset "2M_microphysics - unit tests" begin
     TT.@test CM2.accretion_KK2000(prs, q_liq, q_rai, ρ) == 0.0
     TT.@test CM2.accretion_B1994(prs, q_liq, q_rai, ρ) == 0.0
     TT.@test CM2.accretion_TC1980(prs, q_liq, q_rai) == 0.0
+
+    # far from threshold points, autoconversion with and without smooth transition should 
+    # be approximately equal
+    q_liq = 0.5e-3
+    TT.@test CM2.conv_q_liq_to_q_rai_B1994(
+        prs,
+        q_liq,
+        ρ,
+        smooth_transition = true,
+    ) ≈ CM2.conv_q_liq_to_q_rai_B1994(
+        prs,
+        q_liq,
+        ρ,
+        smooth_transition = false,
+    ) rtol = 0.2
+    TT.@test CM2.conv_q_liq_to_q_rai_TC1980(
+        prs,
+        q_liq,
+        ρ,
+        smooth_transition = true,
+    ) ≈ CM2.conv_q_liq_to_q_rai_TC1980(
+        prs,
+        q_liq,
+        ρ,
+        smooth_transition = false,
+    ) rtol = 0.2
+    TT.@test CM2.conv_q_liq_to_q_rai_LD2004(
+        prs,
+        q_liq,
+        ρ,
+        smooth_transition = true,
+    ) ≈ CM2.conv_q_liq_to_q_rai_LD2004(
+        prs,
+        q_liq,
+        ρ,
+        smooth_transition = false,
+    ) rtol = 0.2
+
 end
 
 TT.@testset "2M_microphysics - compare with Wood_2005" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,3 +2,4 @@
 include("aerosol_activation_tests.jl")
 include("microphysics_tests.jl")
 include("gpu_tests.jl")
+include("common_functions_tests.jl")


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
Auto conversion rates in CM1 and CM2 are modified by using logistic functions to make transition between different parameter regimes at thresholds smooth.

## Benefits and Risks
This will prevent abrupt changes of process rates in different parameter regimes. No risk: functions by default return the old process rates unless a boolean is changed, so the code modification will not cause contradictory results.

## PR Checklist
- This PR has a corresponding issue OR is linked to an SDI.
- I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- I linted my code on my local machine prior to submission OR N/A.
- Unit tests are included OR N/A.
- Code used in an integration test OR N/A.
- All tests ran successfully on my local machine OR N/A.
- All classes, modules, and function contain docstrings OR N/A.
- Documentation has been added/updated OR N/A.