### PR TITLE
Sa/seifert beheng2006

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -275,13 +275,14 @@
   year = {2005}
 }
 
-@article{SeifertBeheng2001,
-  title={A double-moment parameterization for simulating autoconversion, accretion and selfcollection},
-  author={Seifert, Axel and Beheng, Klaus D},
-  journal={Atmospheric research},
-  volume={59},
-  pages={265--281},
-  doi = {https://doi.org/10.1016/S0169-8095(01)00126-0},
-  year={2001},
-  publisher={Elsevier}
+@article{SeifertBeheng2006,
+  title={A two-moment cloud microphysics parameterization for mixed-phase clouds. Part 1: Model description},
+  author={Seifert, Axel and Beheng, Klaus Dieter},
+  journal={Meteorology and atmospheric physics},
+  volume={92},
+  number={1-2},
+  pages={45--66},
+  doi = {https://doi.org/10.1007/s00703-005-0112-4},
+  year={2006},
+  publisher={Springer}
 }

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -41,10 +41,16 @@ Microphysics1M.snow_melt
 ```@docs
 Microphysics2M
 Microphysics2M.LiqRaiRates
+Microphysics2M.raindrops_limited_vars
 Microphysics2M.autoconversion
 Microphysics2M.accretion
 Microphysics2M.liquid_self_collection
+Microphysics2M.autoconversion_and_liquid_self_collection
 Microphysics2M.rain_self_collection
+Microphysics2M.rain_breakup
+Microphysics2M.rain_self_collection_and_breakup
+Microphysics2M.rain_terminal_velocity
+Microphysics2M.rain_evaporation
 Microphysics2M.conv_q_liq_to_q_rai
 ```
 
@@ -94,5 +100,5 @@ CommonTypes.KK2000Type
 CommonTypes.B1994Type
 CommonTypes.TC1980Type
 CommonTypes.LD2004Type
-CommonTypes.SB2001Type
+CommonTypes.SB2006Type
 ```

--- a/src/CommonTypes.jl
+++ b/src/CommonTypes.jl
@@ -17,6 +17,7 @@ export KK2000Type
 export B1994Type
 export TC1980Type
 export LD2004Type
+export SB2006Type
 
 """
     AbstractAerosolDistribution
@@ -103,10 +104,10 @@ The type for 2-moment precipitation formation by Liu and Daum (2004)
 struct LD2004Type <: Abstract2MPrecipType end
 
 """
-    SB2001Type
+    SB2006Type
 
-The type for 2-moment precipitation formation by Seifert and Beheng (2001)
+The type for 2-moment precipitation formation by Seifert and Beheng (2006)
 """
-struct SB2001Type <: Abstract2MPrecipType end
+struct SB2006Type <: Abstract2MPrecipType end
 
-end #module CommoniTypes.jl
+end #module CommonTypes.jl

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -1,6 +1,7 @@
 """
 Double-moment bulk microphysics parametrizations including:
- - autoconversion, accretion, and self-collection rates from Seifert and Beheng 2001,
+ - autoconversion, accretion, self-collection, breakup, mean terminal velocity of raindrops and rain 
+    evaporation rates from Seifert and Beheng 2006,
  - additional double-moment bulk microphysics autoconversion and accretion rates
    from: Khairoutdinov and Kogan 2000, Beheng 1994, Tripoli and Cotton 1980, and 
    Liu and Daum 2004.
@@ -26,7 +27,12 @@ const APS = CMP.AbstractCloudMicrophysicsParameters
 export autoconversion
 export accretion
 export liquid_self_collection
+export autoconversion_and_liquid_self_collection
 export rain_self_collection
+export rain_breakup
+export rain_self_collection_and_breakup
+export rain_terminal_velocity
+export rain_evaporation
 export conv_q_liq_to_q_rai
 
 """
@@ -44,8 +50,44 @@ Base.@kwdef struct LiqRaiRates{FT <: Real}
     dN_rai_dt::FT
 end
 
-# Double-moment bulk microphysics autoconversion, accretion, and self-collection
-# rates from Seifert and Beheng 2001
+# Double-moment bulk microphysics autoconversion, accretion, self-collection, breakup,
+# mean terminal velocity of raindrops, and rain evaporation rates from Seifert and Beheng 2001
+
+"""
+    raindrops_limited_vars(param_set, q_rai, ρ, N_rai)
+
+ - `param_set` - abstract set with Earth parameters
+ - `q_rai` - rain water specific humidity
+ - `ρ` - air density
+ - `N_rai` raindrops number density
+
+Returns a named tupple containing the mean mass of raindrops, xr, and the rate parameter of the assumed
+size distribution of raindrops (based on drops diameter), λr, limited within prescribed ranges
+"""
+function raindrops_limited_vars(
+    param_set::APS,
+    q_rai::FT,
+    ρ::FT,
+    N_rai::FT,
+) where {FT <: Real}
+
+    xr_min::FT = CMP.xr_min_SB2006(param_set)
+    xr_max::FT = CMP.xr_max_SB2006(param_set)
+    N0_min::FT = CMP.N0_min_SB2006(param_set)
+    N0_max::FT = CMP.N0_max_SB2006(param_set)
+    λ_min::FT = CMP.λ_min_SB2006(param_set)
+    λ_max::FT = CMP.λ_max_SB2006(param_set)
+    ρw::FT = CMP.ρ_cloud_liq(param_set)
+
+    L_rai = ρ * q_rai
+    xr_0 = L_rai / N_rai
+    xr_hat = max(xr_min, min(xr_max, xr_0))
+    N0 = max(N0_min, min(N0_max, N_rai * (π * ρw / xr_hat)^FT(1 / 3)))
+    λr = max(λ_min, min(λ_max, (π * ρw * N0 / L_rai)^FT(1 / 4)))
+    xr = max(xr_min, min(xr_max, L_rai * λr / N0))
+
+    return (; λr, xr)
+end
 
 """
     autoconversion(param_set, scheme, q_liq, q_rai, ρ, N_liq)
@@ -58,11 +100,11 @@ end
  - `N_liq` - cloud droplet number density
 
 Returns a LiqRaiRates object containing `q_liq`, `N_liq`, `q_rai`, `N_rai` tendencies due to
-collisions between cloud droplets (autoconversion) for `scheme == SB2001Type`
+collisions between cloud droplets (autoconversion) for `scheme == SB2006Type`
 """
 function autoconversion(
     param_set::APS,
-    scheme::CT.SB2001Type,
+    scheme::CT.SB2006Type,
     q_liq::FT,
     q_rai::FT,
     ρ::FT,
@@ -78,24 +120,27 @@ function autoconversion(
         )
     end
 
-    kc::FT = CMP.kc_SB2001(param_set)
-    ν::FT = CMP.ν_SB2001(param_set)
-    xstar::FT = CMP.xstar_SB2001(param_set)
-    A::FT = CMP.A_phi_au_SB2001(param_set)
-    a::FT = CMP.a_phi_au_SB2001(param_set)
-    b::FT = CMP.b_phi_au_SB2001(param_set)
+    kcc::FT = CMP.kcc_SB2006(param_set)
+    νc::FT = CMP.νc_SB2006(param_set)
+    x_star::FT = CMP.xr_min_SB2006(param_set)
+    ρ0::FT = CMP.ρ0_SB2006(param_set)
+    A::FT = CMP.A_phi_au_SB2006(param_set)
+    a::FT = CMP.a_phi_au_SB2006(param_set)
+    b::FT = CMP.b_phi_au_SB2006(param_set)
 
     L_liq = ρ * q_liq
-    x_liq = L_liq / N_liq
+    x_liq = min(x_star, L_liq / N_liq)
+    q_rai = max(FT(0), q_rai)
     τ = FT(1) - q_liq / (q_liq + q_rai)
     ϕ_au = A * τ^a * (FT(1) - τ^a)^b
 
     dL_rai_dt =
-        kc / 20 / xstar * (ν + 2) * (ν + 4) / (ν + 1)^2 *
+        kcc / 20 / x_star * (νc + 2) * (νc + 4) / (νc + 1)^2 *
         L_liq^2 *
         x_liq^2 *
-        (1 + ϕ_au / (1 - τ)^2)
-    dN_rai_dt = dL_rai_dt / xstar
+        (1 + ϕ_au / (1 - τ)^2) *
+        ρ0 / ρ
+    dN_rai_dt = dL_rai_dt / x_star
     dL_liq_dt = -dL_rai_dt
     dN_liq_dt = -2 * dN_rai_dt
 
@@ -108,7 +153,7 @@ function autoconversion(
 end
 
 """
-    accretion(param_set, scheme, q_liq, q_rai, ρ)
+    accretion(param_set, scheme, q_liq, q_rai, ρ, N_liq)
 
  - `param_set` - abstract set with Earth parameters
  - `scheme` - type for 2-moment accretion parameterization
@@ -118,11 +163,11 @@ end
  - `N_liq` - cloud droplet number density
 
 Returns a LiqRaiRates object containing `q_liq`, `N_liq`, `q_rai`, `N_rai` tendencies due to
-collisions between raindrops and cloud droplets (accretion) for `scheme == SB2001Type`
+collisions between raindrops and cloud droplets (accretion) for `scheme == SB2006Type`
 """
 function accretion(
     param_set::APS,
-    scheme::CT.SB2001Type,
+    scheme::CT.SB2006Type,
     q_liq::FT,
     q_rai::FT,
     ρ::FT,
@@ -138,9 +183,10 @@ function accretion(
         )
     end
 
-    kr::FT = CMP.kr_SB2001(param_set)
-    τ0::FT = CMP.τ_0_phi_ac_SB2001(param_set)
-    c::FT = CMP.c_phi_ac_SB2001(param_set)
+    kcr::FT = CMP.kcr_SB2006(param_set)
+    τ0::FT = CMP.τ0_phi_ac_SB2006(param_set)
+    ρ0::FT = CMP.ρ0_SB2006(param_set)
+    c::FT = CMP.c_phi_ac_SB2006(param_set)
 
     L_liq = ρ * q_liq
     L_rai = ρ * q_rai
@@ -148,7 +194,7 @@ function accretion(
     τ = FT(1) - q_liq / (q_liq + q_rai)
     ϕ_ac = (τ / (τ + τ0))^c
 
-    dL_rai_dt = kr * L_liq * L_rai * ϕ_ac
+    dL_rai_dt = kcr * L_liq * L_rai * ϕ_ac * sqrt(ρ0 / ρ)
     dN_rai_dt = FT(0)
     dL_liq_dt = -dL_rai_dt
     dN_liq_dt = dL_liq_dt / x_liq
@@ -171,11 +217,11 @@ end
  - `dN_liq_dt_au` - rate of change of cloud droplets number density due to autoconversion
 
 Returns the cloud droplets number density tendency due to collisions of cloud droplets
-that produce larger cloud droplets (self-collection) for `scheme == SB2001Type`
+that produce larger cloud droplets (self-collection) for `scheme == SB2006Type`
 """
 function liquid_self_collection(
     param_set::APS,
-    scheme::CT.SB2001Type,
+    scheme::CT.SB2006Type,
     q_liq::FT,
     ρ::FT,
     dN_liq_dt_au::FT,
@@ -185,14 +231,44 @@ function liquid_self_collection(
         return FT(0)
     end
 
-    kc::FT = CMP.kc_SB2001(param_set)
-    ν::FT = CMP.ν_SB2001(param_set)
+    kcc::FT = CMP.kcc_SB2006(param_set)
+    ρ0::FT = CMP.ρ0_SB2006(param_set)
+    νc::FT = CMP.νc_SB2006(param_set)
 
     L_liq = ρ * q_liq
 
-    dN_liq_dt_sc = -kc * (ν + 2) / (ν + 1) * L_liq^2 - dN_liq_dt_au
+    dN_liq_dt_sc =
+        -kcc * (νc + 2) / (νc + 1) * (ρ0 / ρ) * L_liq^2 - dN_liq_dt_au
 
     return dN_liq_dt_sc
+end
+
+"""
+    autoconversion_and_liquid_self_collection(param_set, scheme, q_liq, q_rai, ρ, N_liq)
+
+ - `param_set` - abstract set with Earth parameters
+ - `scheme` - type for 2-moment rain autoconversion parameterization
+ - `q_liq` - cloud water specific humidity
+ - `q_rai` - rain water specific humidity
+ - `ρ` - air density
+ - `N_liq` - cloud droplet number density
+
+Returns a named tupple containing a LiqRaiRates object for the autoconversion rate and
+the liquid self-collection rate for `scheme == SB2006Type`
+"""
+function autoconversion_and_liquid_self_collection(
+    param_set::APS,
+    scheme::CT.SB2006Type,
+    q_liq::FT,
+    q_rai::FT,
+    ρ::FT,
+    N_liq::FT,
+) where {FT <: Real}
+
+    au = autoconversion(param_set, scheme, q_liq, q_rai, ρ, N_liq)
+    sc = liquid_self_collection(param_set, scheme, q_liq, ρ, au.dN_liq_dt)
+
+    return (; au, sc)
 end
 
 """
@@ -205,11 +281,11 @@ end
  - `N_rai` - raindrops number density
 
 Returns the raindrops number density tendency due to collisions of raindrops
-that produce larger raindrops (self-collection) for `scheme == SB2001Type`
+that produce larger raindrops (self-collection) for `scheme == SB2006Type`
 """
 function rain_self_collection(
     param_set::APS,
-    scheme::CT.SB2001Type,
+    scheme::CT.SB2006Type,
     q_rai::FT,
     ρ::FT,
     N_rai::FT,
@@ -219,13 +295,191 @@ function rain_self_collection(
         return FT(0)
     end
 
-    kr::FT = CMP.kr_SB2001(param_set)
+    krr::FT = CMP.krr_SB2006(param_set)
+    κrr::FT = CMP.κrr_SB2006(param_set)
+    d::FT = CMP.d_sc_SB2006(param_set)
+    ρw::FT = CMP.ρ_cloud_liq(param_set)
+    ρ0::FT = CMP.ρ0_SB2006(param_set)
 
     L_rai = ρ * q_rai
+    λr =
+        raindrops_limited_vars(param_set, q_rai, ρ, N_rai).λr *
+        (SF.gamma(4) / FT(π) / ρw)^FT(1 / 3)
 
-    dN_rai_dt_sc = -kr * N_rai * L_rai
+    dN_rai_dt_sc = -krr * N_rai * L_rai * sqrt(ρ0 / ρ) * (1 + κrr / λr)^d
 
     return dN_rai_dt_sc
+end
+
+"""
+    rain_breakup(param_set, scheme, q_rai, ρ, dN_rai_dt_sc)
+
+ - `param_set` - abstract set with Earth parameters
+ - `scheme` - type for 2-moment liquid self-collection parameterization
+ - `q_rai` - rain water specific humidity
+ - `ρ` - air density
+ - `N_rai` - raindrops number density
+ - `dN_rai_dt_sc` - rate of change of raindrops number density due to self-collection
+
+Returns the raindrops number density tendency due to breakup of raindrops
+that produce smaller raindrops for `scheme == SB2006Type`
+"""
+function rain_breakup(
+    param_set::APS,
+    scheme::CT.SB2006Type,
+    q_rai::FT,
+    ρ::FT,
+    N_rai::FT,
+    dN_rai_dt_sc::FT,
+) where {FT <: Real}
+
+    if q_rai < eps(FT)
+        return FT(0)
+    end
+
+    ρw::FT = CMP.ρ_cloud_liq(param_set)
+    Deq::FT = CMP.Deq_br_SB2006(param_set)
+    Dr_th::FT = CMP.Dr_th_br_SB2006(param_set)
+    kbr::FT = CMP.kbr_SB2006(param_set)
+    κbr::FT = CMP.κbr_SB2006(param_set)
+
+    xr = raindrops_limited_vars(param_set, q_rai, ρ, N_rai).xr
+    Dr = (xr * 6 / π / ρw)^FT(1 / 3)
+    ΔD = Dr - Deq
+    phi_br =
+        (Dr < Dr_th) ? FT(-1) : ((ΔD <= 0) ? kbr * ΔD : 2 * (exp(κbr * ΔD) - 1))
+    dN_rai_dt_br = -(phi_br + 1) * dN_rai_dt_sc
+
+    return dN_rai_dt_br
+end
+
+"""
+    rain_sef_collection_and_breakup(param_set, scheme, q_rai, ρ)
+
+ - `param_set` - abstract set with Earth parameters
+ - `scheme` - type for 2-moment liquid self-collection parameterization
+ - `q_rai` - rain water specific humidity
+ - `ρ` - air density
+ - `N_rai` - raindrops number density
+
+Returns a named tupple containing the raindrops self-collection and breakup rates
+for `scheme == SB2006Type`
+"""
+function rain_self_collection_and_breakup(
+    param_set::APS,
+    scheme::CT.SB2006Type,
+    q_rai::FT,
+    ρ::FT,
+    N_rai::FT,
+) where {FT <: Real}
+
+    sc = rain_self_collection(param_set, scheme, q_rai, ρ, N_rai)
+    br = rain_breakup(param_set, scheme, q_rai, ρ, N_rai, sc)
+
+    return (; sc, br)
+end
+
+"""
+    rain_terminal_velocity(param_set, scheme, q_rai, ρ, N_rai)
+
+ - `param_set` - abstract set with Earth parameters
+ - `scheme` - type for 2-moment liquid self-collection parameterization
+ - `q_rai` - rain water specific humidity
+ - `ρ` - air density
+ - `N_rai` - raindrops number density
+
+Returns a tuple containing the number and mass weigthed mean fall velocities of raindrops,
+assuming an empirical relation similar to Rogers (1993) for fall velocity of individual drops
+and an exponential size distribution, for `scheme == SB2006Type`
+"""
+function rain_terminal_velocity(
+    param_set::APS,
+    scheme::CT.SB2006Type,
+    q_rai::FT,
+    ρ::FT,
+    N_rai::FT,
+) where {FT <: Real}
+
+    if q_rai < eps(FT)
+        return (FT(0), FT(0))
+    end
+
+    ρ0::FT = CMP.ρ0_SB2006(param_set)
+    aR::FT = CMP.aR_tv_SB2006(param_set)
+    bR::FT = CMP.bR_tv_SB2006(param_set)
+    cR::FT = CMP.cR_tv_SB2006(param_set)
+
+    λr = raindrops_limited_vars(param_set, q_rai, ρ, N_rai).λr
+    vt0 = max(FT(0), sqrt(ρ0 / ρ) * (aR - bR / (1 + cR / λr)))
+    vt1 = max(FT(0), sqrt(ρ0 / ρ) * (aR - bR / (1 + cR / λr)^FT(4)))
+
+    return (vt0, vt1)
+end
+
+"""
+    rain_evaporation(param_set, scheme, q, q_rai, ρ, N_rai, T)
+
+ - `param_set` - abstract set with Earth parameters
+ - `scheme` - type for 2-moment liquid self-collection parameterization
+ - `q` - phase partition
+ - `q_rai` - rain specific humidity
+ - `ρ` - air density
+ - `N_rai` - raindrops number density
+ - `T` - air temperature
+   
+Returns a tupple containing the tendency of raindrops number density and rain water 
+specific humidity due to rain rain_evaporation, assuming a power law velocity relation for 
+fall velocity of individual drops and an exponential size distribution, for `scheme == SB2006Type`
+"""
+function rain_evaporation(
+    param_set::APS,
+    scheme::CT.SB2006Type,
+    q::TD.PhasePartition{FT},
+    q_rai::FT,
+    ρ::FT,
+    N_rai::FT,
+    T::FT,
+) where {FT <: Real}
+
+    evap_rate_0 = FT(0)
+    evap_rate_1 = FT(0)
+    thermo_params = CMP.thermodynamics_params(param_set)
+    S::FT = TD.supersaturation(thermo_params, q, ρ, T, TD.Liquid())
+
+    if (q_rai > FT(0) && S < FT(0))
+
+        ν_air::FT = CMP.ν_air(param_set)
+        D_vapor::FT = CMP.D_vapor(param_set)
+        ρw::FT = CMP.ρ_cloud_liq(param_set)
+        ρ0::FT = CMP.ρ0_SB2006(param_set)
+        av::FT = CMP.av_evap_SB2006(param_set)
+        bv::FT = CMP.bv_evap_SB2006(param_set)
+        α::FT = CMP.α_evap_SB2006(param_set)
+        β::FT = CMP.β_evap_SB2006(param_set)
+        x_star::FT = CMP.xr_min_SB2006(param_set)
+
+        G::FT = CO.G_func(param_set, T, TD.Liquid())
+
+        xr = raindrops_limited_vars(param_set, q_rai, ρ, N_rai).xr
+        Dr = (FT(6) / FT(π) / ρw)^FT(1 / 3) * xr^FT(1 / 3)
+        t_star = (FT(6) * x_star / xr)^FT(1 / 3)
+        a_vent_0::FT = av * SF.gamma(FT(-1), t_star) / FT(6)^FT(-2 / 3)
+        b_vent_0::FT =
+            bv * SF.gamma(FT(-1 / 2) + FT(3 / 2) * β, t_star) /
+            FT(6)^FT(β / 2 - 1 / 2)
+        a_vent_1::FT = av * SF.gamma(FT(2)) / FT(6)^FT(1 / 3)
+        b_vent_1::FT =
+            bv * SF.gamma(FT(5 / 2) + FT(3 / 2) * β) / FT(6)^FT(β / 2 + 1 / 2)
+
+        N_Re = α * xr^β * sqrt(ρ0 / ρ) * Dr / ν_air
+        Fv0::FT = a_vent_0 + b_vent_0 * (ν_air / D_vapor)^FT(1 / 3) * sqrt(N_Re)
+        Fv1::FT = a_vent_1 + b_vent_1 * (ν_air / D_vapor)^FT(1 / 3) * sqrt(N_Re)
+
+        evap_rate_0 = min(0, 2 * FT(π) * G * S * N_rai * Dr * Fv0 / xr)
+        evap_rate_1 = min(0, 2 * FT(π) * G * S * N_rai * Dr * Fv1 / ρ)
+    end
+
+    return (evap_rate_0, evap_rate_1)
 end
 
 # Additional double moment autoconversion and accretion parametrizations:

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -95,15 +95,35 @@ Base.@kwdef struct CloudMicrophysicsParameters{FT, TP} <:
     R_6C_coeff_LD2004::FT
     E_0_LD2004::FT
     k_thrshld_stpnss::FT
-    kc_SB2001::FT
-    kr_SB2001::FT
-    xstar_SB2001::FT
-    ν_SB2001::FT
-    A_phi_au_SB2001::FT
-    a_phi_au_SB2001::FT
-    b_phi_au_SB2001::FT
-    τ_0_phi_ac_SB2001::FT
-    c_phi_ac_SB2001::FT
+    kcc_SB2006::FT
+    kcr_SB2006::FT
+    krr_SB2006::FT
+    κrr_SB2006::FT
+    xr_min_SB2006::FT
+    xr_max_SB2006::FT
+    νc_SB2006::FT
+    ρ0_SB2006::FT
+    A_phi_au_SB2006::FT
+    a_phi_au_SB2006::FT
+    b_phi_au_SB2006::FT
+    τ0_phi_ac_SB2006::FT
+    c_phi_ac_SB2006::FT
+    d_sc_SB2006::FT
+    Deq_br_SB2006::FT
+    Dr_th_br_SB2006::FT
+    kbr_SB2006::FT
+    κbr_SB2006::FT
+    aR_tv_SB2006::FT
+    bR_tv_SB2006::FT
+    cR_tv_SB2006::FT
+    av_evap_SB2006::FT
+    bv_evap_SB2006::FT
+    α_evap_SB2006::FT
+    β_evap_SB2006::FT
+    N0_min_SB2006::FT
+    N0_max_SB2006::FT
+    λ_min_SB2006::FT
+    λ_max_SB2006::FT
 end
 
 Base.eltype(::CloudMicrophysicsParameters{FT}) where {FT} = FT


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add 2M parametrization of Seifert and Beheng (2006). We already have SF2001 implemented. This PR implements SF2006 which is based on and expands SF2001. 2M parametrizations for raindrops breakup, terminal velocity and rain evaporation are added.

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.
- I have read and checked the items on the review checklist.
