### PR TITLE
Broadcast parameters with Tuples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -5,7 +5,7 @@ const TD = Thermodynamics
 const TDPS = TD.Parameters.ThermodynamicsParameters
 
 abstract type AbstractCloudMicrophysicsParameters end
-Base.broadcastable(ps::AbstractCloudMicrophysicsParameters) = Ref(ps)
+Base.broadcastable(ps::AbstractCloudMicrophysicsParameters) = tuple(ps)
 
 # TODO: add doc strings
 # Cloud microphysics parameters


### PR DESCRIPTION
This PR changes broadcasting of thermodynamic parameters from Refs to Tuples, as they are immutable and can be stack allocated to avoid dynamic allocations.

This is technically a breaking change, but only to users who use the package with broadcasting