### PR TITLE
Run GHA tests for Float32 and Float64

### DIFF
--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -82,8 +82,8 @@ function raindrops_limited_vars(
     L_rai = ρ * q_rai
     xr_0 = L_rai / N_rai
     xr_hat = max(xr_min, min(xr_max, xr_0))
-    N0 = max(N0_min, min(N0_max, N_rai * (π * ρw / xr_hat)^FT(1 / 3)))
-    λr = max(λ_min, min(λ_max, (π * ρw * N0 / L_rai)^FT(1 / 4)))
+    N0 = max(N0_min, min(N0_max, N_rai * (FT(π) * ρw / xr_hat)^FT(1 / 3)))
+    λr = max(λ_min, min(λ_max, (FT(π) * ρw * N0 / L_rai)^FT(1 / 4)))
     xr = max(xr_min, min(xr_max, L_rai * λr / N0))
 
     return (; λr, xr)
@@ -344,7 +344,7 @@ function rain_breakup(
     κbr::FT = CMP.κbr_SB2006(param_set)
 
     xr = raindrops_limited_vars(param_set, q_rai, ρ, N_rai).xr
-    Dr = (xr * 6 / π / ρw)^FT(1 / 3)
+    Dr = (xr * 6 / FT(π) / ρw)^FT(1 / 3)
     ΔD = Dr - Deq
     phi_br =
         (Dr < Dr_th) ? FT(-1) : ((ΔD <= 0) ? kbr * ΔD : 2 * (exp(κbr * ΔD) - 1))
@@ -516,7 +516,7 @@ function conv_q_liq_to_q_rai(
     scheme::CT.KK2000Type,
     q_liq::FT,
     ρ::FT;
-    N_d::FT = 1e8,
+    N_d::FT = FT(1e8),
 ) where {FT <: Real}
 
     q_liq = max(0, q_liq)
@@ -533,7 +533,7 @@ function conv_q_liq_to_q_rai(
     scheme::CT.B1994Type,
     q_liq::FT,
     ρ::FT;
-    N_d::FT = 1e8,
+    N_d::FT = FT(1e8),
     smooth_transition::Bool = false,
 ) where {FT <: Real}
 
@@ -565,7 +565,7 @@ function conv_q_liq_to_q_rai(
     scheme::CT.TC1980Type,
     q_liq::FT,
     ρ::FT;
-    N_d::FT = 1e8,
+    N_d::FT = FT(1e8),
     smooth_transition::Bool = false,
 ) where {FT <: Real}
     #TODO - The original paper is actually formulated for mixing ratios, not specific humidities
@@ -596,7 +596,7 @@ function conv_q_liq_to_q_rai(
     scheme::CT.LD2004Type,
     q_liq::FT,
     ρ::FT;
-    N_d::FT = 1e8,
+    N_d::FT = FT(1e8),
     smooth_transition::Bool = false,
 ) where {FT <: Real}
 
@@ -608,7 +608,7 @@ function conv_q_liq_to_q_rai(
         E_0::FT = CMP.E_0_LD2004(param_set)
 
         # Mean volume radius in microns (assuming spherical cloud droplets)
-        r_vol = (3 * (q_liq * ρ) / 4 / π / ρ_w / N_d)^FT(1 / 3) * 1e6
+        r_vol = (3 * (q_liq * ρ) / 4 / FT(π) / ρ_w / N_d)^FT(1 / 3) * 1e6
 
         # Assumed size distribution: modified gamma distribution
         β_6::FT = ((r_vol + 3) / r_vol)^FT(1 / 3)

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -69,7 +69,6 @@ Base.@kwdef struct CloudMicrophysicsParameters{FT, TP} <:
     E_ice_sno::FT
     E_rai_sno::FT
     ρ_cloud_ice::FT
-    gas_constant::FT
     thermo_params::TP
     D_acnv_TC1980::FT
     a_acnv_TC1980::FT
@@ -138,7 +137,7 @@ m0_ice(ps::CMPS{FT}) where {FT} =
     FT(4 / 3) * π * ps.ρ_cloud_ice * ps.r0_ice^ps.me_ice
 m0_rai(ps::CMPS{FT}) where {FT} =
     FT(4 / 3) * π * ps.ρ_cloud_liq * ps.r0_rai^ps.me_rai
-a0_rai(ps::CMPS) = π * ps.r0_rai^ps.ae_rai
+a0_rai(ps::CMPS{FT}) where {FT} = FT(π) * ps.r0_rai^ps.ae_rai
 m0_sno(ps::CMPS{FT}) where {FT} = FT(1e-1) * ps.r0_sno^ps.me_sno
 a0_sno(ps::CMPS{FT}) where {FT} = FT(0.3) * π * ps.r0_sno^ps.ae_sno
 v0_sno(ps::CMPS{FT}) where {FT} = FT(2^(9 / 4)) * ps.r0_sno^ps.ve_sno

--- a/test/aerosol_activation_tests.jl
+++ b/test/aerosol_activation_tests.jl
@@ -1,261 +1,273 @@
-import Test
+import Test as TT
 
-import CloudMicrophysics
-import CLIMAParameters
-import Thermodynamics
+import CloudMicrophysics as CM
+import CLIMAParameters as CP
+import Thermodynamics as TD
 
-const TT = Test
-const AM = CloudMicrophysics.AerosolModel
-const AA = CloudMicrophysics.AerosolActivation
-const CMP = CloudMicrophysics.Parameters
-const CP = CLIMAParameters
-const TD = Thermodynamics
+const AM = CM.AerosolModel
+const AA = CM.AerosolActivation
+const CMP = CM.Parameters
 
-include(joinpath(pkgdir(CloudMicrophysics), "test", "create_parameters.jl"))
-FT = Float64
-toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
-const param_set = cloud_microphysics_parameters(toml_dict)
-thermo_params = CMP.thermodynamics_params(param_set)
+include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
 
-# Atmospheric conditions
-T = 294.0       # air temperature K
-p = 100000.0    # air pressure Pa
-w = 0.5         # vertical velocity m/s
+function test_aerosol_activation(FT)
 
-# We need the phase partition here only so that we can compute the
-# moist air R_m and cp_m in aerosol activation module.
-# We are assuming here saturated conditions and no liquid water or ice.
-# This is consistent with the assumptions of the aerosol activation scheme.
-p_vs = TD.saturation_vapor_pressure(thermo_params, T, TD.Liquid())
-q_vs = 1 / (1 - CMP.molmass_ratio(param_set) * (p_vs - p) / p_vs)
-q = TD.PhasePartition(q_vs, 0.0, 0.0)
+    toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
+    param_set = cloud_microphysics_parameters(toml_dict)
+    thermo_params = CMP.thermodynamics_params(param_set)
 
-# Accumulation mode
-r_dry_accum = 0.243 * 1e-6 # m
-stdev_accum = 1.4          # -
-N_accum = 100.0 * 1e6      # 1/m3
+    # Atmospheric conditions
+    T = FT(294)    # air temperature K
+    p = FT(1e5)    # air pressure Pa
+    w = FT(0.5)    # vertical velocity m/s
 
-# Coarse Mode
-r_dry_coarse = 1.5 * 1e-6  # m
-stdev_coarse = 2.1         # -
-N_coarse = 1.0 * 1e6       # 1/m3
+    # We need the phase partition here only so that we can compute the
+    # moist air R_m and cp_m in aerosol activation module.
+    # We are assuming here saturated conditions and no liquid water or ice.
+    # This is consistent with the assumptions of the aerosol activation scheme.
+    p_vs = TD.saturation_vapor_pressure(thermo_params, T, TD.Liquid())
+    q_vs = 1 / (1 - CMP.molmass_ratio(param_set) * (p_vs - p) / p_vs)
+    q = TD.PhasePartition(q_vs)
 
-# Abdul-Razzak and Ghan 2000 mode
-r_dry_paper = 0.05 * 1e-6  # m
-stdev_paper = 2.0          # -
-N_1_paper = 100.0 * 1e6    # 1/m3
+    # Accumulation mode
+    r_dry_accum = FT(0.243 * 1e-6) # m
+    stdev_accum = FT(1.4)          # -
+    N_accum = FT(100 * 1e6)      # 1/m3
 
-# TODO - move areosol properties to CLIMAParameters
-# Sea Salt - universal parameters
-M_seasalt = 0.058443
-ρ_seasalt = 2170.0
-ϕ_seasalt = 0.9
-ν_seasalt = 2.0
-ϵ_seasalt = 1.0
-κ_seasalt = 1.12   # TODO - which value to take?
-# Sulfate - universal parameters
-M_sulfate = 0.132
-ρ_sulfate = 1770.0
-ϕ_sulfate = 1.0
-ν_sulfate = 3.0
-ϵ_sulfate = 1.0
-κ_sulfate = 0.53   # TODO - which value to take?
+    # Coarse Mode
+    r_dry_coarse = FT(1.5 * 1e-6)  # m
+    stdev_coarse = FT(2.1)         # -
+    N_coarse = FT(1e6)             # 1/m3
 
-# Aerosol size distribution modes
-accum_seasalt_B = AM.Mode_B(
-    r_dry_accum,
-    stdev_accum,
-    N_accum,
-    (1.0,),
-    (ϵ_seasalt,),
-    (ϕ_seasalt,),
-    (M_seasalt,),
-    (ν_seasalt,),
-    (ρ_seasalt,),
-    1,
-)
-accum_seasalt_κ = AM.Mode_κ(
-    r_dry_accum,
-    stdev_accum,
-    N_accum,
-    (1.0,),
-    (1.0,),
-    (M_seasalt,),
-    (κ_seasalt,),
-    1,
-)
+    # Abdul-Razzak and Ghan 2000 mode
+    r_dry_paper = FT(0.05 * 1e-6)  # m
+    stdev_paper = FT(2)            # -
+    N_1_paper = FT(100 * 1e6)      # 1/m3
 
-coarse_seasalt_B = AM.Mode_B(
-    r_dry_coarse,
-    stdev_coarse,
-    N_coarse,
-    (1.0,),
-    (ϵ_seasalt,),
-    (ϕ_seasalt,),
-    (M_seasalt,),
-    (ν_seasalt,),
-    (ρ_seasalt,),
-    1,
-)
-coarse_seasalt_κ = AM.Mode_κ(
-    r_dry_coarse,
-    stdev_coarse,
-    N_coarse,
-    (1.0,),
-    (1.0,),
-    (M_seasalt,),
-    (κ_seasalt,),
-    1,
-)
+    # TODO - move areosol properties to CLIMAParameters
+    # Sea Salt - universal parameters
+    M_seasalt = FT(0.058443)
+    ρ_seasalt = FT(2170)
+    ϕ_seasalt = FT(0.9)
+    ν_seasalt = FT(2)
+    ϵ_seasalt = FT(1)
+    κ_seasalt = FT(1.12)   # TODO - which value to take?
+    # Sulfate - universal parameters
+    M_sulfate = FT(0.132)
+    ρ_sulfate = FT(1770)
+    ϕ_sulfate = FT(1)
+    ν_sulfate = FT(3)
+    ϵ_sulfate = FT(1)
+    κ_sulfate = FT(0.53)   # TODO - which value to take?
 
-paper_mode_1_B = AM.Mode_B(
-    r_dry_paper,
-    stdev_paper,
-    N_1_paper,
-    (1.0,),
-    (ϵ_sulfate,),
-    (ϕ_sulfate,),
-    (M_sulfate,),
-    (ν_sulfate,),
-    (ρ_sulfate,),
-    1,
-)
-paper_mode_1_κ = AM.Mode_κ(
-    r_dry_paper,
-    stdev_paper,
-    N_1_paper,
-    (1.0,),
-    (1.0,),
-    (M_sulfate,),
-    (κ_sulfate,),
-    1,
-)
-
-# Aerosol size distributions
-AM_1_B = AM.AerosolDistribution((accum_seasalt_B,))
-AM_2_B = AM.AerosolDistribution((coarse_seasalt_B, accum_seasalt_B))
-AM_3_B = AM.AerosolDistribution((accum_seasalt_B, coarse_seasalt_B))
-
-AM_1_κ = AM.AerosolDistribution((accum_seasalt_κ,))
-AM_2_κ = AM.AerosolDistribution((coarse_seasalt_κ, accum_seasalt_κ))
-AM_3_κ = AM.AerosolDistribution((accum_seasalt_κ, coarse_seasalt_κ))
-
-TT.@testset "callable and positive" begin
-
-    for AM_t in (AM_3_B, AM_3_κ)
-        TT.@test all(AA.mean_hygroscopicity_parameter(param_set, AM_t) .> 0.0)
-        TT.@test AA.max_supersaturation(param_set, AM_t, T, p, w, q) > 0.0
-        TT.@test all(
-            AA.N_activated_per_mode(param_set, AM_t, T, p, w, q) .> 0.0,
-        )
-        TT.@test all(
-            AA.M_activated_per_mode(param_set, AM_t, T, p, w, q) .> 0.0,
-        )
-        TT.@test AA.total_N_activated(param_set, AM_t, T, p, w, q) > 0.0
-        TT.@test AA.total_M_activated(param_set, AM_t, T, p, w, q) > 0.0
-    end
-end
-
-TT.@testset "same mean hygroscopicity for the same aerosol" begin
-
-    TT.@test AA.mean_hygroscopicity_parameter(param_set, AM_3_B)[1] ==
-             AA.mean_hygroscopicity_parameter(param_set, AM_1_B)[1]
-
-    TT.@test AA.mean_hygroscopicity_parameter(param_set, AM_3_B)[2] ==
-             AA.mean_hygroscopicity_parameter(param_set, AM_1_B)[1]
-
-    TT.@test AA.mean_hygroscopicity_parameter(param_set, AM_3_κ)[1] ==
-             AA.mean_hygroscopicity_parameter(param_set, AM_1_κ)[1]
-
-    TT.@test AA.mean_hygroscopicity_parameter(param_set, AM_3_κ)[2] ==
-             AA.mean_hygroscopicity_parameter(param_set, AM_1_κ)[1]
-
-end
-
-TT.@testset "B and kappa hygroscopicities are equivalent" begin
-
-    TT.@test all(
-        isapprox(
-            AA.mean_hygroscopicity_parameter(param_set, AM_3_κ)[2],
-            AA.mean_hygroscopicity_parameter(param_set, AM_3_B)[2],
-            rtol = 0.1,
-        ),
+    # Aerosol size distribution modes
+    accum_seasalt_B = AM.Mode_B(
+        r_dry_accum,
+        stdev_accum,
+        N_accum,
+        (FT(1.0),),
+        (ϵ_seasalt,),
+        (ϕ_seasalt,),
+        (M_seasalt,),
+        (ν_seasalt,),
+        (ρ_seasalt,),
+        1,
     )
-end
+    accum_seasalt_κ = AM.Mode_κ(
+        r_dry_accum,
+        stdev_accum,
+        N_accum,
+        (FT(1.0),),
+        (FT(1.0),),
+        (M_seasalt,),
+        (κ_seasalt,),
+        1,
+    )
 
-TT.@testset "order of modes does not matter" begin
+    coarse_seasalt_B = AM.Mode_B(
+        r_dry_coarse,
+        stdev_coarse,
+        N_coarse,
+        (FT(1.0),),
+        (ϵ_seasalt,),
+        (ϕ_seasalt,),
+        (M_seasalt,),
+        (ν_seasalt,),
+        (ρ_seasalt,),
+        1,
+    )
+    coarse_seasalt_κ = AM.Mode_κ(
+        r_dry_coarse,
+        stdev_coarse,
+        N_coarse,
+        (FT(1.0),),
+        (FT(1.0),),
+        (M_seasalt,),
+        (κ_seasalt,),
+        1,
+    )
 
-    TT.@test AA.total_N_activated(param_set, AM_3_B, T, p, w, q) ==
-             AA.total_N_activated(param_set, AM_2_B, T, p, w, q)
-    TT.@test AA.total_M_activated(param_set, AM_3_B, T, p, w, q) ==
-             AA.total_M_activated(param_set, AM_2_B, T, p, w, q)
+    paper_mode_1_B = AM.Mode_B(
+        r_dry_paper,
+        stdev_paper,
+        N_1_paper,
+        (FT(1.0),),
+        (ϵ_sulfate,),
+        (ϕ_sulfate,),
+        (M_sulfate,),
+        (ν_sulfate,),
+        (ρ_sulfate,),
+        1,
+    )
+    paper_mode_1_κ = AM.Mode_κ(
+        r_dry_paper,
+        stdev_paper,
+        N_1_paper,
+        (FT(1.0),),
+        (FT(1.0),),
+        (M_sulfate,),
+        (κ_sulfate,),
+        1,
+    )
 
-    TT.@test AA.total_N_activated(param_set, AM_3_κ, T, p, w, q) ==
-             AA.total_N_activated(param_set, AM_2_κ, T, p, w, q)
-    TT.@test AA.total_M_activated(param_set, AM_3_κ, T, p, w, q) ==
-             AA.total_M_activated(param_set, AM_2_κ, T, p, w, q)
-end
+    # Aerosol size distributions
+    AM_1_B = AM.AerosolDistribution((accum_seasalt_B,))
+    AM_2_B = AM.AerosolDistribution((coarse_seasalt_B, accum_seasalt_B))
+    AM_3_B = AM.AerosolDistribution((accum_seasalt_B, coarse_seasalt_B))
 
-TT.@testset "Abdul-Razzak and Ghan 2000 Fig 1" begin
+    AM_1_κ = AM.AerosolDistribution((accum_seasalt_κ,))
+    AM_2_κ = AM.AerosolDistribution((coarse_seasalt_κ, accum_seasalt_κ))
+    AM_3_κ = AM.AerosolDistribution((accum_seasalt_κ, coarse_seasalt_κ))
 
-    # data read from Fig 1 in Abdul-Razzak and Ghan 2000
-    # using https://automeris.io/WebPlotDigitizer/
-    N_2_obs = [
-        18.74716810149539,
-        110.41572270049846,
-        416.00589034889026,
-        918.1014952424102,
-        1914.816492976891,
-        4919.913910285455,
-    ]
-    N_act_obs = [
-        0.7926937018577255,
-        0.7161078386950611,
-        0.5953670140462167,
-        0.4850589034888989,
-        0.34446080652469424,
-        0.162630267331219,
-    ]
+    TT.@testset "callable and positive" begin
 
-    N_act_frac_B = Vector{Float64}(undef, 6)
-    N_act_frac_κ = Vector{Float64}(undef, 6)
-
-    it = 1
-    for N_2_paper in N_2_obs
-        paper_mode_2_B = AM.Mode_B(
-            r_dry_paper,
-            stdev_paper,
-            N_2_paper * 1e6,
-            (1.0,),
-            (ϵ_sulfate,),
-            (ϕ_sulfate,),
-            (M_sulfate,),
-            (ν_sulfate,),
-            (ρ_sulfate,),
-            1,
-        )
-        paper_mode_2_κ = AM.Mode_κ(
-            r_dry_paper,
-            stdev_paper,
-            N_2_paper * 1e6,
-            (1.0,),
-            (1.0,),
-            (M_sulfate,),
-            (κ_sulfate,),
-            1,
-        )
-
-        AD_B = AM.AerosolDistribution((paper_mode_1_B, paper_mode_2_B))
-        AD_κ = AM.AerosolDistribution((paper_mode_1_κ, paper_mode_2_κ))
-
-        N_act_frac_B[it] =
-            AA.N_activated_per_mode(param_set, AD_B, T, p, w, q)[1] / N_1_paper
-        N_act_frac_κ[it] =
-            AA.N_activated_per_mode(param_set, AD_κ, T, p, w, q)[1] / N_1_paper
-        it += 1
+        for AM_t in (AM_3_B, AM_3_κ)
+            TT.@test all(
+                AA.mean_hygroscopicity_parameter(param_set, AM_t) .> 0.0,
+            )
+            TT.@test AA.max_supersaturation(param_set, AM_t, T, p, w, q) > 0.0
+            TT.@test all(
+                AA.N_activated_per_mode(param_set, AM_t, T, p, w, q) .> 0.0,
+            )
+            TT.@test all(
+                AA.M_activated_per_mode(param_set, AM_t, T, p, w, q) .> 0.0,
+            )
+            TT.@test AA.total_N_activated(param_set, AM_t, T, p, w, q) > 0.0
+            TT.@test AA.total_M_activated(param_set, AM_t, T, p, w, q) > 0.0
+        end
     end
 
-    TT.@test all(isapprox(N_act_frac_B, N_act_obs, rtol = 0.05))
-    TT.@test all(isapprox(N_act_frac_κ, N_act_obs, rtol = 0.1))
+    TT.@testset "same mean hygroscopicity for the same aerosol" begin
 
+        TT.@test AA.mean_hygroscopicity_parameter(param_set, AM_3_B)[1] ==
+                 AA.mean_hygroscopicity_parameter(param_set, AM_1_B)[1]
+
+        TT.@test AA.mean_hygroscopicity_parameter(param_set, AM_3_B)[2] ==
+                 AA.mean_hygroscopicity_parameter(param_set, AM_1_B)[1]
+
+        TT.@test AA.mean_hygroscopicity_parameter(param_set, AM_3_κ)[1] ==
+                 AA.mean_hygroscopicity_parameter(param_set, AM_1_κ)[1]
+
+        TT.@test AA.mean_hygroscopicity_parameter(param_set, AM_3_κ)[2] ==
+                 AA.mean_hygroscopicity_parameter(param_set, AM_1_κ)[1]
+
+    end
+
+    TT.@testset "B and kappa hygroscopicities are equivalent" begin
+
+        TT.@test all(
+            isapprox(
+                AA.mean_hygroscopicity_parameter(param_set, AM_3_κ)[2],
+                AA.mean_hygroscopicity_parameter(param_set, AM_3_B)[2],
+                rtol = 0.1,
+            ),
+        )
+    end
+
+    TT.@testset "order of modes does not matter" begin
+
+        TT.@test AA.total_N_activated(param_set, AM_3_B, T, p, w, q) ==
+                 AA.total_N_activated(param_set, AM_2_B, T, p, w, q)
+        TT.@test AA.total_M_activated(param_set, AM_3_B, T, p, w, q) ==
+                 AA.total_M_activated(param_set, AM_2_B, T, p, w, q)
+
+        TT.@test AA.total_N_activated(param_set, AM_3_κ, T, p, w, q) ==
+                 AA.total_N_activated(param_set, AM_2_κ, T, p, w, q)
+        TT.@test AA.total_M_activated(param_set, AM_3_κ, T, p, w, q) ==
+                 AA.total_M_activated(param_set, AM_2_κ, T, p, w, q)
+    end
+
+    TT.@testset "Abdul-Razzak and Ghan 2000 Fig 1" begin
+
+        # data read from Fig 1 in Abdul-Razzak and Ghan 2000
+        # using https://automeris.io/WebPlotDigitizer/
+        N_2_obs = [
+            FT(18.74716810149539),
+            FT(110.41572270049846),
+            FT(416.00589034889026),
+            FT(918.1014952424102),
+            FT(1914.816492976891),
+            FT(4919.913910285455),
+        ]
+        N_act_obs = [
+            FT(0.7926937018577255),
+            FT(0.7161078386950611),
+            FT(0.5953670140462167),
+            FT(0.4850589034888989),
+            FT(0.34446080652469424),
+            FT(0.162630267331219),
+        ]
+
+        N_act_frac_B = Vector{FT}(undef, 6)
+        N_act_frac_κ = Vector{FT}(undef, 6)
+
+        it = 1
+        for N_2_paper in N_2_obs
+            paper_mode_2_B = AM.Mode_B(
+                r_dry_paper,
+                stdev_paper,
+                N_2_paper * FT(1e6),
+                (FT(1.0),),
+                (ϵ_sulfate,),
+                (ϕ_sulfate,),
+                (M_sulfate,),
+                (ν_sulfate,),
+                (ρ_sulfate,),
+                1,
+            )
+            paper_mode_2_κ = AM.Mode_κ(
+                r_dry_paper,
+                stdev_paper,
+                N_2_paper * FT(1e6),
+                (FT(1.0),),
+                (FT(1.0),),
+                (M_sulfate,),
+                (κ_sulfate,),
+                1,
+            )
+
+            AD_B = AM.AerosolDistribution((paper_mode_1_B, paper_mode_2_B))
+            AD_κ = AM.AerosolDistribution((paper_mode_1_κ, paper_mode_2_κ))
+
+            N_act_frac_B[it] =
+                AA.N_activated_per_mode(param_set, AD_B, T, p, w, q)[1] /
+                N_1_paper
+            N_act_frac_κ[it] =
+                AA.N_activated_per_mode(param_set, AD_κ, T, p, w, q)[1] /
+                N_1_paper
+            it += 1
+        end
+
+        TT.@test all(isapprox(N_act_frac_B, N_act_obs, rtol = 0.05))
+        TT.@test all(isapprox(N_act_frac_κ, N_act_obs, rtol = 0.1))
+
+    end
 end
+
+println("")
+println("Testing Float64")
+test_aerosol_activation(Float64)
+
+println("")
+println("Testing Float32")
+test_aerosol_activation(Float32)

--- a/test/gpu_tests.jl
+++ b/test/gpu_tests.jl
@@ -1,25 +1,21 @@
 using Test
 using KernelAbstractions
-import CUDAKernels
-const CK = CUDAKernels
 
-import CloudMicrophysics
-import CLIMAParameters
-import Thermodynamics
+import CUDAKernels as CK
 
-const CP = CLIMAParameters
-const TD = Thermodynamics
-const CMP = CloudMicrophysics.Parameters
+import CloudMicrophysics as CM
+import CLIMAParameters as CP
+import Thermodynamics as TD
 
-include(joinpath(pkgdir(CloudMicrophysics), "test", "create_parameters.jl"))
-make_prs(::Type{FT}) where {FT} =
-    cloud_microphysics_parameters(CP.create_toml_dict(FT; dict_type = "alias"))
+const CMP = CM.Parameters
 
-const AM = CloudMicrophysics.AerosolModel
-const AA = CloudMicrophysics.AerosolActivation
-const CMT = CloudMicrophysics.CommonTypes
-const CM0 = CloudMicrophysics.Microphysics0M
-const CM1 = CloudMicrophysics.Microphysics1M
+include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
+
+const AM = CM.AerosolModel
+const AA = CM.AerosolActivation
+const CMT = CM.CommonTypes
+const CM0 = CM.Microphysics0M
+const CM1 = CM.Microphysics1M
 
 const liquid = CMT.LiquidType()
 const ice = CMT.IceType()
@@ -35,7 +31,6 @@ else
     ArrayType = Array
     device(::Type{T}) where {T <: Array} = CK.CPU()
 end
-
 @show ArrayType
 
 @kernel function test_aerosol_activation_kernel!(
@@ -53,39 +48,39 @@ end
 ) where {FT}
 
     i = @index(Group, Linear)
-    thermo_params = CMP.thermodynamics_params(param_set)
+    thermo_params = CMP.thermodynamics_params(prs)
     # atmospheric conditions (taken from aerosol activation tests)
-    T::FT = 294.0       # air temperature K
-    p::FT = 100000.0    # air pressure Pa
-    w::FT = 0.5         # vertical velocity m/s
-    p_vs::FT = TD.saturation_vapor_pressure(thermo_params, T, TD.Liquid())
-    q_vs::FT = 1 / (1 - CMP.molmass_ratio(prs) * (p_vs - p) / p_vs)
+    T = FT(294)      # air temperature K
+    p = FT(1e5)    # air pressure Pa
+    w = FT(0.5)         # vertical velocity m/s
+    p_vs = TD.saturation_vapor_pressure(thermo_params, T, TD.Liquid())
+    q_vs = 1 / (1 - CMP.molmass_ratio(prs) * (p_vs - p) / p_vs)
     # water vapor specific humidity (saturated)
-    q = TD.PhasePartition(q_vs, FT(0.0), FT(0.0))
+    q = TD.PhasePartition(q_vs)
 
     args = (T, p, w, q)
 
     @inbounds begin
         mode_B = AM.Mode_B(
-            FT(r[i]),
-            FT(stdev[i]),
-            FT(N[i]),
+            r[i],
+            stdev[i],
+            N[i],
             (FT(1.0),),
-            (FT(ϵ[i]),),
-            (FT(ϕ[i]),),
-            (FT(M[i]),),
-            (FT(ν[i]),),
-            (FT(ρ[i]),),
+            (ϵ[i],),
+            (ϕ[i],),
+            (M[i],),
+            (ν[i],),
+            (ρ[i],),
             1,
         )
         mode_κ = AM.Mode_κ(
-            FT(r[i]),
-            FT(stdev[i]),
-            FT(N[i]),
+            r[i],
+            stdev[i],
+            N[i],
             (FT(1.0),),
             (FT(1.0),),
-            (FT(M[i]),),
-            (FT(κ[i]),),
+            (M[i],),
+            (κ[i],),
             1,
         )
 
@@ -114,8 +109,8 @@ end
     i = @index(Group, Linear)
 
     @inbounds begin
-        ql::FT = qc[i] * liquid_frac[i]
-        qi::FT = (1 - liquid_frac[i]) * qc[i]
+        ql = qc[i] * liquid_frac[i]
+        qi = (1 - liquid_frac[i]) * qc[i]
         q = TD.PhasePartition(FT(qt[i]), ql, qi)
 
         output[1, i] = CM0.remove_precipitation(prs, q)
@@ -168,125 +163,159 @@ end
     end
 end
 
-@testset "Aerosol activation kernels" begin
-    FT = Float32
-    data_length = 2
-    output = ArrayType(Array{FT}(undef, 6, data_length))
-    fill!(output, -44.0)
+function test_gpu(FT)
 
-    dev = device(ArrayType)
-    work_groups = (1,)
-    ndrange = (data_length,)
-
-    r = ArrayType([0.243 * 1e-6, 1.5 * 1e-6])
-    stdev = ArrayType([1.4, 2.1])
-    N = ArrayType([100.0 * 1e6, 1.0 * 1e6])
-    ϵ = ArrayType([1.0, 1.0])
-    ϕ = ArrayType([1.0, 0.9])
-    M = ArrayType([0.132, 0.058443])
-    ν = ArrayType([3.0, 2.0])
-    ρ = ArrayType([1770.0, 2170.0])
-    κ = ArrayType([0.53, 1.12])
-
-    kernel! = test_aerosol_activation_kernel!(dev, work_groups)
-    event = kernel!(
-        make_prs(FT),
-        output,
-        r,
-        stdev,
-        N,
-        ϵ,
-        ϕ,
-        M,
-        ν,
-        ρ,
-        κ,
-        ndrange = ndrange,
+    make_prs(::Type{FT}) where {FT} = cloud_microphysics_parameters(
+        CP.create_toml_dict(FT; dict_type = "alias"),
     )
-    wait(dev, event)
 
-    # test if all aerosol activation output is positive
-    @test all(Array(output)[:, :] .>= FT(0))
-    # test if higroscopicity parameter is the same for κ and B modes
-    @test all(isapprox(Array(output)[1, :], Array(output)[2, :], rtol = 0.3))
-    # test if the number and mass activated are the same for κ and B modes
-    @test all(isapprox(Array(output)[3, :], Array(output)[4, :], rtol = 1e-5))
-    @test all(isapprox(Array(output)[5, :], Array(output)[6, :], rtol = 1e-5))
+    @testset "Aerosol activation kernels" begin
+        data_length = 2
+        output = ArrayType(Array{FT}(undef, 6, data_length))
+        fill!(output, FT(-44.0))
+
+        dev = device(ArrayType)
+        work_groups = (1,)
+        ndrange = (data_length,)
+
+        r = ArrayType([FT(0.243 * 1e-6), FT(1.5 * 1e-6)])
+        stdev = ArrayType([FT(1.4), FT(2.1)])
+        N = ArrayType([FT(100 * 1e6), FT(1 * 1e6)])
+        ϵ = ArrayType([FT(1), FT(1)])
+        ϕ = ArrayType([FT(1), FT(0.9)])
+        M = ArrayType([FT(0.132), FT(0.058443)])
+        ν = ArrayType([FT(3), FT(2)])
+        ρ = ArrayType([FT(1770), FT(2170)])
+        κ = ArrayType([FT(0.53), FT(1.12)])
+
+        kernel! = test_aerosol_activation_kernel!(dev, work_groups)
+        event = kernel!(
+            make_prs(FT),
+            output,
+            r,
+            stdev,
+            N,
+            ϵ,
+            ϕ,
+            M,
+            ν,
+            ρ,
+            κ,
+            ndrange = ndrange,
+        )
+        wait(dev, event)
+
+        # test if all aerosol activation output is positive
+        @test all(Array(output)[:, :] .>= FT(0))
+        # test if higroscopicity parameter is the same for κ and B modes
+        @test all(
+            isapprox(Array(output)[1, :], Array(output)[2, :], rtol = 0.3),
+        )
+        # test if the number and mass activated are the same for κ and B modes
+        @test all(
+            isapprox(Array(output)[3, :], Array(output)[4, :], rtol = 1e-5),
+        )
+        @test all(
+            isapprox(Array(output)[5, :], Array(output)[6, :], rtol = 1e-5),
+        )
+    end
+
+    @testset "0-moment microphysics kernels" begin
+        data_length = 3
+        output = ArrayType(Array{FT}(undef, 2, data_length))
+        fill!(output, FT(-44.0))
+
+        dev = device(ArrayType)
+        work_groups = (1,)
+        ndrange = (data_length,)
+
+        liquid_frac = ArrayType([FT(0), FT(0.5), FT(1)])
+        qt = ArrayType([FT(13e-3), FT(13e-3), FT(13e-3)])
+        qc = ArrayType([FT(3e-3), FT(4e-3), FT(5e-3)])
+
+        kernel! = test_0_moment_micro_kernel!(dev, work_groups)
+        event = kernel!(
+            make_prs(FT),
+            output,
+            liquid_frac,
+            qc,
+            qt,
+            ndrange = ndrange,
+        )
+        wait(dev, event)
+
+        # test 0-moment rain removal is callable and returns a reasonable value
+        @test all(isequal(Array(output)[1, :], Array(output)[2, :]))
+    end
+
+    @testset "1-moment microphysics kernels" begin
+        data_length = 2
+        output = ArrayType(Array{FT}(undef, 7, data_length))
+        fill!(output, FT(-44.0))
+
+        dev = device(ArrayType)
+        work_groups = (1,)
+        ndrange = (data_length,)
+
+        ρ = ArrayType([FT(1.2), FT(1.2)])
+        qt = ArrayType([FT(0), FT(20e-3)])
+        qi = ArrayType([FT(0), FT(5e-4)])
+        qs = ArrayType([FT(0), FT(5e-4)])
+        ql = ArrayType([FT(0), FT(5e-4)])
+        qr = ArrayType([FT(0), FT(5e-4)])
+
+        kernel! = test_1_moment_micro_accretion_kernel!(dev, work_groups)
+        event = kernel!(
+            make_prs(FT),
+            output,
+            ρ,
+            qt,
+            qi,
+            qs,
+            ql,
+            qr,
+            ndrange = ndrange,
+        )
+        wait(dev, event)
+
+        # test 1-moment accretion is callable and returns a reasonable value
+        @test all(Array(output)[:, 1] .== FT(0))
+        @test Array(output)[1, 2] ≈ FT(1.4150106417043544e-6)
+        @test Array(output)[2, 2] ≈ FT(2.453070979562392e-7)
+        @test Array(output)[3, 2] ≈ FT(2.453070979562392e-7)
+        @test Array(output)[4, 2] ≈ FT(1.768763302130443e-6)
+        @test Array(output)[5, 2] ≈ FT(3.085229094251214e-5)
+        @test Array(output)[6, 2] ≈ FT(2.1705865794293408e-4)
+        @test Array(output)[7, 2] ≈ FT(6.0118801860768854e-5)
+
+        data_length = 3
+        output = ArrayType(Array{FT}(undef, 1, data_length))
+        fill!(output, FT(-44.0))
+
+        dev = device(ArrayType)
+        work_groups = (1,)
+        ndrange = (data_length,)
+
+        ρ = ArrayType([FT(1.2), FT(1.2), FT(1.2)])
+        T = ArrayType([FT(273.15 + 2), FT(273.15 + 2), FT(273.15 - 2)])
+        qs = ArrayType([FT(1e-4), FT(0), FT(1e-4)])
+
+        kernel! = test_1_moment_micro_snow_melt_kernel!(dev, work_groups)
+        event = kernel!(make_prs(FT), output, ρ, T, qs, ndrange = ndrange)
+        wait(dev, event)
+
+        # test if 1-moment snow melt is callable and returns reasonable values
+        @test Array(output)[1] ≈ FT(9.518235437405256e-6)
+        @test Array(output)[2] ≈ FT(0)
+        @test Array(output)[3] ≈ FT(0)
+    end
 end
 
-@testset "0-moment microphysics kernels" begin
-    FT = Float32
-    data_length = 3
-    output = ArrayType(Array{FT}(undef, 2, data_length))
-    fill!(output, -44.0)
 
-    dev = device(ArrayType)
-    work_groups = (1,)
-    ndrange = (data_length,)
+println("")
+println("Testing Float64")
+test_gpu(Float64)
 
-    liquid_frac = ArrayType([0.0, 0.5, 1.0])
-    qt = ArrayType([13e-3, 13e-3, 13e-3])
-    qc = ArrayType([3e-3, 4e-3, 5e-3])
-
-    kernel! = test_0_moment_micro_kernel!(dev, work_groups)
-    event =
-        kernel!(make_prs(FT), output, liquid_frac, qc, qt, ndrange = ndrange)
-    wait(dev, event)
-
-    # test 0-moment rain removal is callable and returns a reasonable value
-    @test all(isequal(Array(output)[1, :], Array(output)[2, :]))
-end
-
-@testset "1-moment microphysics kernels" begin
-    FT = Float32
-    data_length = 2
-    output = ArrayType(Array{FT}(undef, 7, data_length))
-    fill!(output, -44.0)
-
-    dev = device(ArrayType)
-    work_groups = (1,)
-    ndrange = (data_length,)
-
-    ρ = ArrayType([1.2, 1.2])
-    qt = ArrayType([0.0, 20e-3])
-    qi = ArrayType([0.0, 5e-4])
-    qs = ArrayType([0.0, 5e-4])
-    ql = ArrayType([0.0, 5e-4])
-    qr = ArrayType([0.0, 5e-4])
-
-    kernel! = test_1_moment_micro_accretion_kernel!(dev, work_groups)
-    event =
-        kernel!(make_prs(FT), output, ρ, qt, qi, qs, ql, qr, ndrange = ndrange)
-    wait(dev, event)
-
-    # test 1-moment accretion is callable and returns a reasonable value
-    @test all(Array(output)[:, 1] .== FT(0))
-    @test Array(output)[1, 2] ≈ 1.4150106417043544e-6
-    @test Array(output)[2, 2] ≈ 2.453070979562392e-7
-    @test Array(output)[3, 2] ≈ 2.453070979562392e-7
-    @test Array(output)[4, 2] ≈ 1.768763302130443e-6
-    @test Array(output)[5, 2] ≈ 3.085229094251214e-5
-    @test Array(output)[6, 2] ≈ 2.1705865794293408e-4
-    @test Array(output)[7, 2] ≈ 6.0118801860768854e-5
-
-    data_length = 3
-    output = ArrayType(Array{FT}(undef, 1, data_length))
-    fill!(output, -44.0)
-
-    dev = device(ArrayType)
-    work_groups = (1,)
-    ndrange = (data_length,)
-
-    ρ = ArrayType([1.2, 1.2, 1.2])
-    T = ArrayType([273.15 + 2, 273.15 + 2, 273.15 - 2])
-    qs = ArrayType([1e-4, 0.0, 1e-4])
-
-    kernel! = test_1_moment_micro_snow_melt_kernel!(dev, work_groups)
-    event = kernel!(make_prs(FT), output, ρ, T, qs, ndrange = ndrange)
-    wait(dev, event)
-
-    # test if 1-moment snow melt is callable and returns reasonable values
-    @test Array(output)[1] ≈ 9.518235437405256e-6
-    @test Array(output)[2] ≈ 0.0
-    @test Array(output)[3] ≈ 0.0
-end
+println("")
+println("Testing Float32")
+test_gpu(Float32)

--- a/test/heterogeneous_ice_nucleation_tests.jl
+++ b/test/heterogeneous_ice_nucleation_tests.jl
@@ -1,53 +1,61 @@
-import Test
+import Test as TT
 
-import Thermodynamics
-import CloudMicrophysics
-import CLIMAParameters
-const CP = CLIMAParameters
+import Thermodynamics as TD
+import CloudMicrophysics as CM
+import CLIMAParameters as CP
 
-const TT = Test
-const TD = Thermodynamics
-const CMT = CloudMicrophysics.CommonTypes
-const CMI = CloudMicrophysics.HetIceNucleation
-
-include(joinpath(pkgdir(CloudMicrophysics), "test", "create_parameters.jl"))
-FT = Float64
-toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
-const prs = cloud_microphysics_parameters(toml_dict)
-
+const CMT = CM.CommonTypes
+const CMI = CM.HetIceNucleation
 const ArizonaTestDust = CMT.ArizonaTestDustType()
 const DesertDust = CMT.DesertDustType()
 
-TT.@testset "dust_activation" begin
+include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
 
-    T_warm = FT(250)
-    T_cold = FT(210)
+function test_dust_activation(FT)
+    toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
+    prs = cloud_microphysics_parameters(toml_dict)
 
-    Si_low = FT(1.01)
-    Si_med = FT(1.2)
-    Si_hgh = FT(1.34)
-    Si_too_hgh = FT(1.5)
+    TT.@testset "dust_activation" begin
 
-    # No activation below critical supersaturation
-    for dust in [ArizonaTestDust, DesertDust]
-        for T in [T_warm, T_cold]
-            TT.@test CMI.dust_activated_number_fraction(Si_low, T, dust) ==
-                     FT(0)
+        T_warm = FT(250)
+        T_cold = FT(210)
+        Si_low = FT(1.01)
+        Si_med = FT(1.2)
+        Si_hgh = FT(1.34)
+        Si_too_hgh = FT(1.5)
+
+        # No activation below critical supersaturation
+        for dust in [ArizonaTestDust, DesertDust]
+            for T in [T_warm, T_cold]
+                TT.@test CMI.dust_activated_number_fraction(Si_low, T, dust) ==
+                         FT(0)
+            end
         end
-    end
 
-    # Activate more in cold temperatures and higher supersaturations
-    for dust in [ArizonaTestDust, DesertDust]
-        TT.@test CMI.dust_activated_number_fraction(Si_hgh, T_warm, dust) >
-                 CMI.dust_activated_number_fraction(Si_med, T_warm, dust)
-        TT.@test CMI.dust_activated_number_fraction(Si_med, T_cold, dust) >
-                 CMI.dust_activated_number_fraction(Si_med, T_warm, dust)
-    end
+        # Activate more in cold temperatures and higher supersaturations
+        for dust in [ArizonaTestDust, DesertDust]
+            TT.@test CMI.dust_activated_number_fraction(Si_hgh, T_warm, dust) >
+                     CMI.dust_activated_number_fraction(Si_med, T_warm, dust)
+            TT.@test CMI.dust_activated_number_fraction(Si_med, T_cold, dust) >
+                     CMI.dust_activated_number_fraction(Si_med, T_warm, dust)
+        end
 
-    for dust in [ArizonaTestDust, DesertDust]
-        for T in [T_warm, T_cold]
-            TT.@test CMI.dust_activated_number_fraction(Si_too_hgh, T, dust) ==
-                     FT(0)
+        for dust in [ArizonaTestDust, DesertDust]
+            for T in [T_warm, T_cold]
+                TT.@test CMI.dust_activated_number_fraction(
+                    Si_too_hgh,
+                    T,
+                    dust,
+                ) == FT(0)
+            end
         end
     end
 end
+
+println("")
+println("Testing Float64")
+benchmark_test(Float64)
+
+println("")
+println("Testing Float32")
+benchmark_test(Float32)

--- a/test/microphysics_tests.jl
+++ b/test/microphysics_tests.jl
@@ -1,816 +1,897 @@
-import Test
+import Test as TT
 
-import Thermodynamics
-import CloudMicrophysics
-import CLIMAParameters
-const CP = CLIMAParameters
+import Thermodynamics as TD
+import CloudMicrophysics as CM
+import CLIMAParameters as CP
 
-const TT = Test
-const TD = Thermodynamics
-const CMT = CloudMicrophysics.CommonTypes
-const CMNe = CloudMicrophysics.MicrophysicsNonEq
-const CM0 = CloudMicrophysics.Microphysics0M
-const CM1 = CloudMicrophysics.Microphysics1M
-const CM2 = CloudMicrophysics.Microphysics2M
+const CMP = CM.Parameters
+const CMC = CM.Common
+const CMT = CM.CommonTypes
+const CMNe = CM.MicrophysicsNonEq
+const CM0 = CM.Microphysics0M
+const CM1 = CM.Microphysics1M
+const CM2 = CM.Microphysics2M
 
-include(joinpath(pkgdir(CloudMicrophysics), "test", "create_parameters.jl"))
-FT = Float64
-toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
-const prs = cloud_microphysics_parameters(toml_dict)
+include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
 
 const liquid = CMT.LiquidType()
 const ice = CMT.IceType()
 const rain = CMT.RainType()
 const snow = CMT.SnowType()
-
 const KK2000 = CMT.KK2000Type()
 const B1994 = CMT.B1994Type()
 const TC1980 = CMT.TC1980Type()
 const LD2004 = CMT.LD2004Type()
 
-TT.@testset "τ_relax" begin
+function test_microphysics(FT)
 
-    TT.@test CMNe.τ_relax(prs, liquid) ≈ 10
-    TT.@test CMNe.τ_relax(prs, ice) ≈ 10
+    toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
+    prs = cloud_microphysics_parameters(toml_dict)
 
-end
+    TT.@testset "τ_relax" begin
 
-TT.@testset "0M_microphysics" begin
-
-    _τ_precip = CMP.τ_precip(prs)
-    _qc_0 = CMP.qc_0(prs)
-    _S_0 = CMP.S_0(prs)
-
-    q_vap_sat = 10e-3
-    qc = 3e-3
-    q_tot = 13e-3
-    frac = [0.0, 0.5, 1.0]
-
-    # no rain if no cloud
-    q = TD.PhasePartition(q_tot, 0.0, 0.0)
-    TT.@test CM0.remove_precipitation(prs, q) ≈ 0
-    TT.@test CM0.remove_precipitation(prs, q, q_vap_sat) ≈ 0
-
-    # rain based on qc threshold
-    for lf in frac
-        q_liq = qc * lf
-        q_ice = (1 - lf) * qc
-
-        q = TD.PhasePartition(q_tot, q_liq, q_ice)
-
-        TT.@test CM0.remove_precipitation(prs, q) ≈
-                 -max(0, q_liq + q_ice - _qc_0) / _τ_precip
-    end
-
-    # rain based on supersaturation threshold
-    for lf in frac
-        q_liq = qc * lf
-        q_ice = (1 - lf) * qc
-
-        q = TD.PhasePartition(q_tot, q_liq, q_ice)
-
-        TT.@test CM0.remove_precipitation(prs, q, q_vap_sat) ≈
-                 -max(0, q_liq + q_ice - _S_0 * q_vap_sat) / _τ_precip
-    end
-end
-
-TT.@testset "RainFallSpeed" begin
-    # eq. 5d in [Grabowski1996](@cite)
-    function terminal_velocity_empir(
-        q_rai::FT,
-        q_tot::FT,
-        ρ::FT,
-        ρ_air_ground::FT,
-    ) where {FT <: Real}
-        rr = q_rai / (1 - q_tot)
-        vel = FT(14.34) * ρ_air_ground^FT(0.5) * ρ^-FT(0.3654) * rr^FT(0.1346)
-        return vel
-    end
-
-    # some example values
-    q_rain_range = range(1e-8, stop = 5e-3, length = 10)
-    ρ_air, q_tot, ρ_air_ground = 1.2, 20 * 1e-3, 1.22
-
-    for q_rai in q_rain_range
-        TT.@test CM1.terminal_velocity(prs, rain, ρ_air, q_rai) ≈
-                 terminal_velocity_empir(q_rai, q_tot, ρ_air, ρ_air_ground) atol =
-            0.2 * terminal_velocity_empir(q_rai, q_tot, ρ_air, ρ_air_ground)
+        TT.@test CMNe.τ_relax(prs, liquid) ≈ FT(10)
+        TT.@test CMNe.τ_relax(prs, ice) ≈ FT(10)
 
     end
-end
 
-TT.@testset "CloudLiquidCondEvap" begin
+    TT.@testset "0M_microphysics" begin
 
-    q_liq_sat = 5e-3
-    frac = [0.0, 0.5, 1.0, 1.5]
+        _τ_precip = CMP.τ_precip(prs)
+        _qc_0 = CMP.qc_0(prs)
+        _S_0 = CMP.S_0(prs)
 
-    _τ_cond_evap = CMNe.τ_relax(prs, liquid)
+        q_vap_sat = FT(10e-3)
+        qc = FT(3e-3)
+        q_tot = FT(13e-3)
+        frac = [FT(0), FT(0.5), FT(1.0)]
 
-    for fr in frac
-        q_liq = q_liq_sat * fr
+        # no rain if no cloud
+        q = TD.PhasePartition(q_tot)
+        TT.@test CM0.remove_precipitation(prs, q) ≈ FT(0)
+        TT.@test CM0.remove_precipitation(prs, q, q_vap_sat) ≈ FT(0)
 
-        TT.@test CMNe.conv_q_vap_to_q_liq_ice(
-            prs,
-            liquid,
-            TD.PhasePartition(0.0, q_liq_sat, 0.0),
-            TD.PhasePartition(0.0, q_liq, 0.0),
-        ) ≈ (1 - fr) * q_liq_sat / _τ_cond_evap
-    end
-end
+        # rain based on qc threshold
+        for lf in frac
+            q_liq = qc * lf
+            q_ice = (1 - lf) * qc
 
-TT.@testset "CloudIceCondEvap" begin
-
-    q_ice_sat = 2e-3
-    frac = [0.0, 0.5, 1.0, 1.5]
-
-    _τ_cond_evap = CMNe.τ_relax(prs, ice)
-
-    for fr in frac
-        q_ice = q_ice_sat * fr
-
-        TT.@test CMNe.conv_q_vap_to_q_liq_ice(
-            prs,
-            ice,
-            TD.PhasePartition(0.0, 0.0, q_ice_sat),
-            TD.PhasePartition(0.0, 0.0, q_ice),
-        ) ≈ (1 - fr) * q_ice_sat / _τ_cond_evap
-    end
-end
-
-TT.@testset "RainAutoconversion" begin
-
-    _q_liq_threshold = CMP.q_liq_threshold(prs)
-    _τ_acnv_rai = CMP.τ_acnv_rai(prs)
-
-    q_liq_small = 0.5 * _q_liq_threshold
-    TT.@test CM1.conv_q_liq_to_q_rai(prs, q_liq_small) == 0.0
-
-    TT.@test CM1.conv_q_liq_to_q_rai(
-        prs,
-        q_liq_small,
-        smooth_transition = true,
-    ) ≈ 0.0 atol = 0.15 * _q_liq_threshold / _τ_acnv_rai
-
-    q_liq_big = 1.5 * _q_liq_threshold
-    TT.@test CM1.conv_q_liq_to_q_rai(prs, q_liq_big) ==
-             0.5 * _q_liq_threshold / _τ_acnv_rai
-
-    TT.@test CM1.conv_q_liq_to_q_rai(prs, q_liq_big, smooth_transition = true) ≈
-             0.5 * _q_liq_threshold / _τ_acnv_rai atol =
-        0.15 * _q_liq_threshold / _τ_acnv_rai
-
-end
-
-TT.@testset "SnowAutoconversionNoSupersat" begin
-
-    _q_ice_threshold = CMP.q_ice_threshold(prs)
-    _τ_acnv_sno = CMP.τ_acnv_sno(prs)
-
-    q_ice_small = 0.5 * _q_ice_threshold
-    TT.@test CM1.conv_q_ice_to_q_sno_no_supersat(prs, q_ice_small) == 0.0
-
-    TT.@test CM1.conv_q_ice_to_q_sno_no_supersat(
-        prs,
-        q_ice_small,
-        smooth_transition = true,
-    ) ≈ 0.0 atol = 0.15 * _q_ice_threshold / _τ_acnv_sno
-
-    q_ice_big = 1.5 * _q_ice_threshold
-    TT.@test CM1.conv_q_ice_to_q_sno_no_supersat(prs, q_ice_big) ≈
-             0.5 * _q_ice_threshold / _τ_acnv_sno
-
-    TT.@test CM1.conv_q_ice_to_q_sno_no_supersat(
-        prs,
-        q_ice_big,
-        smooth_transition = true,
-    ) ≈ 0.5 * _q_ice_threshold / _τ_acnv_sno atol =
-        0.15 * _q_ice_threshold / _τ_acnv_sno
-end
-
-TT.@testset "SnowAutoconversion" begin
-
-    thermo_params = CMP.thermodynamics_params(prs)
-    ρ = 1.0
-
-    # above freezing temperatures -> no snow
-    q = TD.PhasePartition(15e-3, 2e-3, 1e-3)
-    T = 273.15 + 30
-    TT.@test CM1.conv_q_ice_to_q_sno(prs, q, ρ, T) == 0.0
-
-    # no ice -> no snow
-    q = TD.PhasePartition(15e-3, 2e-3, 0.0)
-    T = 273.15 - 30
-    TT.@test CM1.conv_q_ice_to_q_sno(prs, q, ρ, T) == 0.0
-
-    # no supersaturation -> no snow
-    T = 273.15 - 5
-    q_sat_ice = TD.q_vap_saturation_generic(thermo_params, T, ρ, TD.Ice())
-    q = TD.PhasePartition(q_sat_ice, 2e-3, 3e-3)
-    TT.@test CM1.conv_q_ice_to_q_sno(prs, q, ρ, T) == 0.0
-
-    # TODO - coudnt find a plot of what it should be from the original paper
-    # just chacking if the number stays the same
-    T = 273.15 - 10
-    q_vap = 1.02 * TD.q_vap_saturation_generic(thermo_params, T, ρ, TD.Ice())
-    q_liq = 0.0
-    q_ice = 0.03 * q_vap
-    q = TD.PhasePartition(q_vap + q_liq + q_ice, q_liq, q_ice)
-    TT.@test CM1.conv_q_ice_to_q_sno(prs, q, ρ, T) ≈ 1.8512022335645584e-9
-
-end
-
-TT.@testset "RainLiquidAccretion" begin
-
-    # eq. 5b in [Grabowski1996](@cite)
-    function accretion_empir(q_rai::FT, q_liq::FT, q_tot::FT) where {FT <: Real}
-        rr = q_rai / (FT(1) - q_tot)
-        rl = q_liq / (FT(1) - q_tot)
-        return FT(2.2) * rl * rr^FT(7 / 8)
-    end
-
-    # some example values
-    q_rain_range = range(1e-8, stop = 5e-3, length = 10)
-    ρ_air, q_liq, q_tot = 1.2, 5e-4, 20e-3
-
-    for q_rai in q_rain_range
-        TT.@test CM1.accretion(prs, liquid, rain, q_liq, q_rai, ρ_air) ≈
-                 accretion_empir(q_rai, q_liq, q_tot) atol =
-            (0.1 * accretion_empir(q_rai, q_liq, q_tot))
-    end
-end
-
-TT.@testset "Accretion" begin
-    # TODO - coudnt find a plot of what it should be from the original paper
-    # just chacking if the number stays the same
-
-    # some example values
-    ρ = 1.2
-    q_tot = 20e-3
-    q_ice = 5e-4
-    q_sno = 5e-4
-    q_liq = 5e-4
-    q_rai = 5e-4
-
-    TT.@test CM1.accretion(prs, liquid, rain, q_liq, q_rai, ρ) ≈
-             1.4150106417043544e-6
-    TT.@test CM1.accretion(prs, ice, snow, q_ice, q_sno, ρ) ≈
-             2.453070979562392e-7
-    TT.@test CM1.accretion(prs, liquid, snow, q_liq, q_sno, ρ) ≈
-             2.453070979562392e-7
-    TT.@test CM1.accretion(prs, ice, rain, q_ice, q_rai, ρ) ≈
-             1.768763302130443e-6
-
-    TT.@test CM1.accretion_rain_sink(prs, q_ice, q_rai, ρ) ≈
-             3.085229094251214e-5
-
-    TT.@test CM1.accretion_snow_rain(prs, snow, rain, q_sno, q_rai, ρ) ≈
-             2.1705865794293408e-4
-    TT.@test CM1.accretion_snow_rain(prs, rain, snow, q_rai, q_sno, ρ) ≈
-             6.0118801860768854e-5
-end
-
-TT.@testset "RainEvaporation" begin
-
-    # eq. 5c in [Grabowski1996](@cite)
-    function rain_evap_empir(
-        prs::CMP.AbstractCloudMicrophysicsParameters,
-        q_rai::FT,
-        q::TD.PhasePartition,
-        T::FT,
-        p::FT,
-        ρ::FT,
-    ) where {FT <: Real}
-
-        thermo_params = CMP.thermodynamics_params(prs)
-        q_sat = TD.q_vap_saturation_generic(thermo_params, T, ρ, TD.Liquid())
-        q_vap = q.tot - q.liq
-        rr = q_rai / (1 - q.tot)
-        rv_sat = q_sat / (1 - q.tot)
-        S = q_vap / q_sat - 1
-
-        ag, bg = FT(5.4 * 1e2), FT(2.55 * 1e5)
-        G = FT(1) / (ag + bg / p / rv_sat) / ρ
-
-        av, bv = FT(1.6), FT(124.9)
-        F =
-            av * (ρ / FT(1e3))^FT(0.525) * rr^FT(0.525) +
-            bv * (ρ / FT(1e3))^FT(0.7296) * rr^FT(0.7296)
-
-        return 1 / (1 - q.tot) * S * F * G
-    end
-
-    thermo_params = CMP.thermodynamics_params(prs)
-    # example values
-    T, p = 273.15 + 15, 90000.0
-    ϵ = 1.0 / CMP.molmass_ratio(prs)
-    p_sat = TD.saturation_vapor_pressure(thermo_params, T, TD.Liquid())
-    q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1.0))
-    q_rain_range = range(1e-8, stop = 5e-3, length = 10)
-    q_tot = 15e-3
-    q_vap = 0.15 * q_sat
-    q_ice = 0.0
-    q_liq = q_tot - q_vap - q_ice
-    q = TD.PhasePartition(q_tot, q_liq, q_ice)
-    R = TD.gas_constant_air(thermo_params, q)
-    ρ = p / R / T
-
-    for q_rai in q_rain_range
-        TT.@test CM1.evaporation_sublimation(prs, rain, q, q_rai, ρ, T) ≈
-                 rain_evap_empir(prs, q_rai, q, T, p, ρ) atol =
-            -0.5 * rain_evap_empir(prs, q_rai, q, T, p, ρ)
-    end
-
-    # no condensational growth for rain
-    T, p = 273.15 + 15, 90000.0
-    ϵ = 1.0 / CMP.molmass_ratio(prs)
-    p_sat = TD.saturation_vapor_pressure(thermo_params, T, TD.Liquid())
-    q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1.0))
-    q_rai = 1e-4
-    q_tot = 15e-3
-    q_vap = 1.15 * q_sat
-    q_ice = 0.0
-    q_liq = q_tot - q_vap - q_ice
-    q = TD.PhasePartition(q_tot, q_liq, q_ice)
-    R = TD.gas_constant_air(thermo_params, q)
-    ρ = p / R / T
-
-    TT.@test CM1.evaporation_sublimation(prs, rain, q, q_rai, ρ, T) ≈ 0.0
-
-end
-
-TT.@testset "SnowSublimation" begin
-    # TODO - coudnt find a plot of what it should be from the original paper
-    # just chacking if the number stays the same
-
-    thermo_params = CMP.thermodynamics_params(prs)
-    cnt = 0
-    ref_val = [
-        -1.9756907119482267e-7,
-        1.9751292385808357e-7,
-        -1.6641552112891826e-7,
-        1.663814937710236e-7,
-    ]
-    # some example values
-    for T in [273.15 + 2, 273.15 - 2]
-        p = 90000.0
-        ϵ = 1.0 / CMP.molmass_ratio(prs)
-        p_sat = TD.saturation_vapor_pressure(thermo_params, T, TD.Ice())
-        q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1.0))
-
-        for eps in [0.95, 1.05]
-            cnt += 1
-
-            q_tot = eps * q_sat
-            q_ice = 0.0
-            q_liq = 0.0
             q = TD.PhasePartition(q_tot, q_liq, q_ice)
 
-            q_sno = 1e-4
+            TT.@test CM0.remove_precipitation(prs, q) ≈
+                     -max(0, q_liq + q_ice - _qc_0) / _τ_precip
+        end
 
-            R = TD.gas_constant_air(thermo_params, q)
-            ρ = p / R / T
+        # rain based on supersaturation threshold
+        for lf in frac
+            q_liq = qc * lf
+            q_ice = (1 - lf) * qc
 
-            TT.@test CM1.evaporation_sublimation(prs, snow, q, q_sno, ρ, T) ≈
-                     ref_val[cnt]
+            q = TD.PhasePartition(q_tot, q_liq, q_ice)
+
+            TT.@test CM0.remove_precipitation(prs, q, q_vap_sat) ≈
+                     -max(0, q_liq + q_ice - _S_0 * q_vap_sat) / _τ_precip
+        end
+    end
+
+    TT.@testset "RainFallSpeed" begin
+        # eq. 5d in [Grabowski1996](@cite)
+        function terminal_velocity_empir(
+            q_rai::FT,
+            q_tot::FT,
+            ρ::FT,
+            ρ_air_ground::FT,
+        ) where {FT <: Real}
+            rr = q_rai / (1 - q_tot)
+            vel =
+                FT(14.34) * ρ_air_ground^FT(0.5) * ρ^-FT(0.3654) * rr^FT(0.1346)
+            return vel
+        end
+
+        # some example values
+        q_rain_range = range(FT(1e-8), stop = FT(5e-3), length = 10)
+        ρ_air, q_tot, ρ_air_ground = FT(1.2), FT(20 * 1e-3), FT(1.22)
+
+        for q_rai in q_rain_range
+            TT.@test CM1.terminal_velocity(prs, rain, ρ_air, q_rai) ≈
+                     terminal_velocity_empir(q_rai, q_tot, ρ_air, ρ_air_ground) atol =
+                0.2 * terminal_velocity_empir(q_rai, q_tot, ρ_air, ρ_air_ground)
 
         end
     end
-end
 
-TT.@testset "SnowMelt" begin
+    TT.@testset "CloudLiquidCondEvap" begin
 
-    # TODO - find a good reference to compare with
-    T = 273.15 + 2
-    ρ = 1.2
-    q_sno = 1e-4
-    TT.@test CM1.snow_melt(prs, q_sno, ρ, T) ≈ 9.518235437405256e-6
+        q_liq_sat = FT(5e-3)
+        frac = [FT(0), FT(0.5), FT(1), FT(1.5)]
 
-    # no snow -> no snow melt
-    T = 273.15 + 2
-    ρ = 1.2
-    q_sno = 0.0
-    TT.@test CM1.snow_melt(prs, q_sno, ρ, T) ≈ 0
+        _τ_cond_evap = CMNe.τ_relax(prs, liquid)
 
-    # T < T_freeze -> no snow melt
-    T = 273.15 - 2
-    ρ = 1.2
-    q_sno = 1e-4
-    TT.@test CM1.snow_melt(prs, q_sno, ρ, T) ≈ 0
+        for fr in frac
+            q_liq = q_liq_sat * fr
 
-end
-
-TT.@testset "2M_microphysics - unit tests" begin
-
-    ρ = 1.0
-
-    # no reference data available - checking if callable and not NaN
-    q_liq = 0.5e-3
-    q_rai = 1e-6
-    TT.@test CM2.accretion(prs, KK2000, q_liq, q_rai, ρ) != NaN
-    TT.@test CM2.accretion(prs, B1994, q_liq, q_rai, ρ) != NaN
-    TT.@test CM2.accretion(prs, TC1980, q_liq, q_rai) != NaN
-
-    # output should be zero if either q_liq or q_rai are zero
-    q_liq = 0.0
-    q_rai = 1e-6
-    TT.@test CM2.conv_q_liq_to_q_rai(prs, KK2000, q_liq, ρ) == 0.0
-    TT.@test CM2.conv_q_liq_to_q_rai(prs, B1994, q_liq, ρ) == 0.0
-    TT.@test CM2.conv_q_liq_to_q_rai(prs, TC1980, q_liq, ρ) == 0.0
-    TT.@test CM2.conv_q_liq_to_q_rai(prs, LD2004, q_liq, ρ) == 0.0
-    TT.@test CM2.accretion(prs, KK2000, q_liq, q_rai, ρ) == 0.0
-    TT.@test CM2.accretion(prs, B1994, q_liq, q_rai, ρ) == 0.0
-    TT.@test CM2.accretion(prs, TC1980, q_liq, q_rai) == 0.0
-    q_liq = 0.5e-3
-    q_rai = 0.0
-    TT.@test CM2.accretion(prs, KK2000, q_liq, q_rai, ρ) == 0.0
-    TT.@test CM2.accretion(prs, B1994, q_liq, q_rai, ρ) == 0.0
-    TT.@test CM2.accretion(prs, TC1980, q_liq, q_rai) == 0.0
-
-    # far from threshold points, autoconversion with and without smooth transition should
-    # be approximately equal
-    q_liq = 0.5e-3
-    TT.@test CM2.conv_q_liq_to_q_rai(
-        prs,
-        B1994,
-        q_liq,
-        ρ,
-        smooth_transition = true,
-    ) ≈ CM2.conv_q_liq_to_q_rai(
-        prs,
-        B1994,
-        q_liq,
-        ρ,
-        smooth_transition = false,
-    ) rtol = 0.2
-    TT.@test CM2.conv_q_liq_to_q_rai(
-        prs,
-        TC1980,
-        q_liq,
-        ρ,
-        smooth_transition = true,
-    ) ≈ CM2.conv_q_liq_to_q_rai(
-        prs,
-        TC1980,
-        q_liq,
-        ρ,
-        smooth_transition = false,
-    ) rtol = 0.2
-    TT.@test CM2.conv_q_liq_to_q_rai(
-        prs,
-        LD2004,
-        q_liq,
-        ρ,
-        smooth_transition = true,
-    ) ≈ CM2.conv_q_liq_to_q_rai(
-        prs,
-        LD2004,
-        q_liq,
-        ρ,
-        smooth_transition = false,
-    ) rtol = 0.2
-
-end
-
-TT.@testset "2M_microphysics - compare with Wood_2005" begin
-
-    ρ = 1.0
-    q_liq = 0.5e-3
-
-    # compare with Wood 2005 Fig 1 panel a
-    function compare(scheme, input, output; eps = 0.1)
-        TT.@test CM2.conv_q_liq_to_q_rai(prs, scheme, input * 1e-3, ρ) ≈ output atol =
-            eps * output
+            TT.@test CMNe.conv_q_vap_to_q_liq_ice(
+                prs,
+                liquid,
+                TD.PhasePartition(FT(0), q_liq_sat, FT(0)),
+                TD.PhasePartition(FT(0), q_liq, FT(0)),
+            ) ≈ (1 - fr) * q_liq_sat / _τ_cond_evap
+        end
     end
-    compare(KK2000, 0.03138461538461537, 2.636846054348105e-12)
-    compare(KK2000, 0.8738461538461537, 9.491665962977648e-9)
-    compare(B1994, 0.13999999999999999, 4.584323122458155e-12, eps = 1)
-    compare(B1994, 0.9000000000000006, 5.4940586176564715e-8, eps = 1)
-    compare(TC1980, 0.2700000000000001, 3.2768635256661366e-8)
-    compare(TC1980, 0.9000000000000006, 5.340418612468997e-7)
-    compare(LD2004, 0.3700000000000002, 8.697439193234471e-9)
-    compare(LD2004, 0.9000000000000006, 1.1325570516983242e-7)
 
-    # compare with Wood 2005 Fig 1 panel b
-    function compare_Nd(scheme, input, output; eps = 0.1)
+    TT.@testset "CloudIceCondEvap" begin
+
+        q_ice_sat = FT(2e-3)
+        frac = [FT(0), FT(0.5), FT(1), FT(1.5)]
+
+        _τ_cond_evap = CMNe.τ_relax(prs, ice)
+
+        for fr in frac
+            q_ice = q_ice_sat * fr
+
+            TT.@test CMNe.conv_q_vap_to_q_liq_ice(
+                prs,
+                ice,
+                TD.PhasePartition(FT(0), FT(0), q_ice_sat),
+                TD.PhasePartition(FT(0), FT(0), q_ice),
+            ) ≈ (1 - fr) * q_ice_sat / _τ_cond_evap
+        end
+    end
+
+    TT.@testset "RainAutoconversion" begin
+
+        _q_liq_threshold = CMP.q_liq_threshold(prs)
+        _τ_acnv_rai = CMP.τ_acnv_rai(prs)
+
+        q_liq_small = FT(0.5) * _q_liq_threshold
+        TT.@test CM1.conv_q_liq_to_q_rai(prs, q_liq_small) == FT(0)
+
+        TT.@test CM1.conv_q_liq_to_q_rai(
+            prs,
+            q_liq_small,
+            smooth_transition = true,
+        ) ≈ FT(0.0) atol = 0.15 * _q_liq_threshold / _τ_acnv_rai
+
+        q_liq_big = 1.5 * _q_liq_threshold
+        TT.@test CM1.conv_q_liq_to_q_rai(prs, q_liq_big) ==
+                 0.5 * _q_liq_threshold / _τ_acnv_rai
+
+        TT.@test CM1.conv_q_liq_to_q_rai(
+            prs,
+            q_liq_big,
+            smooth_transition = true,
+        ) ≈ 0.5 * _q_liq_threshold / _τ_acnv_rai atol =
+            0.15 * _q_liq_threshold / _τ_acnv_rai
+
+    end
+
+    TT.@testset "SnowAutoconversionNoSupersat" begin
+
+        _q_ice_threshold = CMP.q_ice_threshold(prs)
+        _τ_acnv_sno = CMP.τ_acnv_sno(prs)
+
+        q_ice_small = 0.5 * _q_ice_threshold
+        TT.@test CM1.conv_q_ice_to_q_sno_no_supersat(prs, q_ice_small) == FT(0)
+
+        TT.@test CM1.conv_q_ice_to_q_sno_no_supersat(
+            prs,
+            q_ice_small,
+            smooth_transition = true,
+        ) ≈ FT(0.0) atol = 0.15 * _q_ice_threshold / _τ_acnv_sno
+
+        q_ice_big = 1.5 * _q_ice_threshold
+        TT.@test CM1.conv_q_ice_to_q_sno_no_supersat(prs, q_ice_big) ≈
+                 0.5 * _q_ice_threshold / _τ_acnv_sno
+
+        TT.@test CM1.conv_q_ice_to_q_sno_no_supersat(
+            prs,
+            q_ice_big,
+            smooth_transition = true,
+        ) ≈ 0.5 * _q_ice_threshold / _τ_acnv_sno atol =
+            0.15 * _q_ice_threshold / _τ_acnv_sno
+    end
+
+    TT.@testset "SnowAutoconversion" begin
+
+        thermo_params = CMP.thermodynamics_params(prs)
+        ρ = FT(1.0)
+
+        # above freezing temperatures -> no snow
+        q = TD.PhasePartition(FT(15e-3), FT(2e-3), FT(1e-3))
+        T = FT(273.15 + 30)
+        TT.@test CM1.conv_q_ice_to_q_sno(prs, q, ρ, T) == FT(0)
+
+        # no ice -> no snow
+        q = TD.PhasePartition(FT(15e-3), FT(2e-3), FT(0))
+        T = FT(273.15 - 30)
+        TT.@test CM1.conv_q_ice_to_q_sno(prs, q, ρ, T) == FT(0)
+
+        # no supersaturation -> no snow
+        T = FT(273.15 - 5)
+        q_sat_ice = TD.q_vap_saturation_generic(thermo_params, T, ρ, TD.Ice())
+        q = TD.PhasePartition(q_sat_ice, FT(2e-3), FT(3e-3))
+        TT.@test CM1.conv_q_ice_to_q_sno(prs, q, ρ, T) == FT(0)
+
+        # TODO - coudnt find a plot of what it should be from the original paper
+        # just chacking if the number stays the same
+        T = FT(273.15 - 10)
+        q_vap =
+            FT(1.02) *
+            TD.q_vap_saturation_generic(thermo_params, T, ρ, TD.Ice())
+        q_liq = FT(0)
+        q_ice = FT(0.03) * q_vap
+        q = TD.PhasePartition(q_vap + q_liq + q_ice, q_liq, q_ice)
+
+        TT.@test CM1.conv_q_ice_to_q_sno(prs, q, ρ, T) ≈
+                 FT(1.8512022335645584e-9)
+    end
+
+    TT.@testset "RainLiquidAccretion" begin
+
+        # eq. 5b in [Grabowski1996](@cite)
+        function accretion_empir(
+            q_rai::FT,
+            q_liq::FT,
+            q_tot::FT,
+        ) where {FT <: Real}
+            rr = q_rai / (FT(1) - q_tot)
+            rl = q_liq / (FT(1) - q_tot)
+            return FT(2.2) * rl * rr^FT(7 / 8)
+        end
+
+        # some example values
+        q_rain_range = range(FT(1e-8), stop = FT(5e-3), length = 10)
+        ρ_air, q_liq, q_tot = FT(1.2), FT(5e-4), FT(20e-3)
+
+        for q_rai in q_rain_range
+            TT.@test CM1.accretion(prs, liquid, rain, q_liq, q_rai, ρ_air) ≈
+                     accretion_empir(q_rai, q_liq, q_tot) atol =
+                (0.1 * accretion_empir(q_rai, q_liq, q_tot))
+        end
+    end
+
+    TT.@testset "Accretion" begin
+        # TODO - coudnt find a plot of what it should be from the original paper
+        # just chacking if the number stays the same
+
+        # some example values
+        ρ = FT(1.2)
+        q_tot = FT(20e-3)
+        q_ice = FT(5e-4)
+        q_sno = FT(5e-4)
+        q_liq = FT(5e-4)
+        q_rai = FT(5e-4)
+
+        TT.@test CM1.accretion(prs, liquid, rain, q_liq, q_rai, ρ) ≈
+                 FT(1.4150106417043544e-6)
+        TT.@test CM1.accretion(prs, ice, snow, q_ice, q_sno, ρ) ≈
+                 FT(2.453070979562392e-7)
+        TT.@test CM1.accretion(prs, liquid, snow, q_liq, q_sno, ρ) ≈
+                 FT(2.453070979562392e-7)
+        TT.@test CM1.accretion(prs, ice, rain, q_ice, q_rai, ρ) ≈
+                 FT(1.768763302130443e-6)
+
+        TT.@test CM1.accretion_rain_sink(prs, q_ice, q_rai, ρ) ≈
+                 FT(3.085229094251214e-5)
+
+        TT.@test CM1.accretion_snow_rain(prs, snow, rain, q_sno, q_rai, ρ) ≈
+                 FT(2.1705865794293408e-4)
+        TT.@test CM1.accretion_snow_rain(prs, rain, snow, q_rai, q_sno, ρ) ≈
+                 FT(6.0118801860768854e-5)
+    end
+
+    TT.@testset "RainEvaporation" begin
+
+        # eq. 5c in [Grabowski1996](@cite)
+        function rain_evap_empir(
+            prs::CMP.AbstractCloudMicrophysicsParameters,
+            q_rai::FT,
+            q::TD.PhasePartition,
+            T::FT,
+            p::FT,
+            ρ::FT,
+        ) where {FT <: Real}
+
+            thermo_params = CMP.thermodynamics_params(prs)
+            q_sat =
+                TD.q_vap_saturation_generic(thermo_params, T, ρ, TD.Liquid())
+            q_vap = q.tot - q.liq
+            rr = q_rai / (1 - q.tot)
+            rv_sat = q_sat / (1 - q.tot)
+            S = q_vap / q_sat - 1
+
+            ag, bg = FT(5.4 * 1e2), FT(2.55 * 1e5)
+            G = FT(1) / (ag + bg / p / rv_sat) / ρ
+
+            av, bv = FT(1.6), FT(124.9)
+            F =
+                av * (ρ / FT(1e3))^FT(0.525) * rr^FT(0.525) +
+                bv * (ρ / FT(1e3))^FT(0.7296) * rr^FT(0.7296)
+
+            return 1 / (1 - q.tot) * S * F * G
+        end
+
+        thermo_params = CMP.thermodynamics_params(prs)
+        # example values
+        T, p = FT(273.15 + 15), FT(90000)
+        ϵ = 1 / CMP.molmass_ratio(prs)
+        p_sat = TD.saturation_vapor_pressure(thermo_params, T, TD.Liquid())
+        q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1))
+        q_rain_range = range(FT(1e-8), stop = FT(5e-3), length = 10)
+        q_tot = FT(15e-3)
+        q_vap = FT(0.15) * q_sat
+        q_ice = FT(0)
+        q_liq = q_tot - q_vap - q_ice
+        q = TD.PhasePartition(q_tot, q_liq, q_ice)
+        R = TD.gas_constant_air(thermo_params, q)
+        ρ = p / R / T
+
+        for q_rai in q_rain_range
+            TT.@test CM1.evaporation_sublimation(prs, rain, q, q_rai, ρ, T) ≈
+                     rain_evap_empir(prs, q_rai, q, T, p, ρ) atol =
+                -0.5 * rain_evap_empir(prs, q_rai, q, T, p, ρ)
+        end
+
+        # no condensational growth for rain
+        T, p = FT(273.15 + 15), FT(90000)
+        ϵ = 1 / CMP.molmass_ratio(prs)
+        p_sat = TD.saturation_vapor_pressure(thermo_params, T, TD.Liquid())
+        q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1))
+        q_rai = FT(1e-4)
+        q_tot = FT(15e-3)
+        q_vap = FT(1.15) * q_sat
+        q_ice = FT(0)
+        q_liq = q_tot - q_vap - q_ice
+        q = TD.PhasePartition(q_tot, q_liq, q_ice)
+        R = TD.gas_constant_air(thermo_params, q)
+        ρ = p / R / T
+
+        TT.@test CM1.evaporation_sublimation(prs, rain, q, q_rai, ρ, T) ≈ FT(0)
+
+    end
+
+    TT.@testset "SnowSublimation" begin
+        # TODO - coudnt find a plot of what it should be from the original paper
+        # just chacking if the number stays the same
+
+        thermo_params = CMP.thermodynamics_params(prs)
+        cnt = 0
+        ref_val = [
+            FT(-1.9756907119482267e-7),
+            FT(1.9751292385808357e-7),
+            FT(-1.6641552112891826e-7),
+            FT(1.663814937710236e-7),
+        ]
+        # some example values
+        for T in [FT(273.15 + 2), FT(273.15 - 2)]
+            p = FT(90000)
+            ϵ = 1 / CMP.molmass_ratio(prs)
+            p_sat = TD.saturation_vapor_pressure(thermo_params, T, TD.Ice())
+            q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1))
+
+            for eps in [FT(0.95), FT(1.05)]
+                cnt += 1
+
+                q_tot = eps * q_sat
+                q_ice = FT(0)
+                q_liq = FT(0)
+                q = TD.PhasePartition(q_tot, q_liq, q_ice)
+
+                q_sno = FT(1e-4)
+
+                R = TD.gas_constant_air(thermo_params, q)
+                ρ = p / R / T
+
+                TT.@test CM1.evaporation_sublimation(
+                    prs,
+                    snow,
+                    q,
+                    q_sno,
+                    ρ,
+                    T,
+                ) ≈ ref_val[cnt]
+
+            end
+        end
+    end
+
+    TT.@testset "SnowMelt" begin
+
+        # TODO - find a good reference to compare with
+        T = FT(273.15 + 2)
+        ρ = FT(1.2)
+        q_sno = FT(1e-4)
+        TT.@test CM1.snow_melt(prs, q_sno, ρ, T) ≈ FT(9.518235437405256e-6)
+
+        # no snow -> no snow melt
+        T = FT(273.15 + 2)
+        ρ = FT(1.2)
+        q_sno = FT(0)
+        TT.@test CM1.snow_melt(prs, q_sno, ρ, T) ≈ FT(0)
+
+        # T < T_freeze -> no snow melt
+        T = FT(273.15 - 2)
+        ρ = FT(1.2)
+        q_sno = FT(1e-4)
+        TT.@test CM1.snow_melt(prs, q_sno, ρ, T) ≈ FT(0)
+
+    end
+
+    TT.@testset "2M_microphysics - unit tests" begin
+
+        ρ = FT(1)
+
+        # no reference data available - checking if callable and not NaN
+        q_liq = FT(0.5e-3)
+        q_rai = FT(1e-6)
+        TT.@test CM2.accretion(prs, KK2000, q_liq, q_rai, ρ) != NaN
+        TT.@test CM2.accretion(prs, B1994, q_liq, q_rai, ρ) != NaN
+        TT.@test CM2.accretion(prs, TC1980, q_liq, q_rai) != NaN
+
+        # output should be zero if either q_liq or q_rai are zero
+        q_liq = FT(0)
+        q_rai = FT(1e-6)
+
+        TT.@test CM2.conv_q_liq_to_q_rai(prs, KK2000, q_liq, ρ) == FT(0)
+        TT.@test CM2.conv_q_liq_to_q_rai(prs, B1994, q_liq, ρ) == FT(0)
+        TT.@test CM2.conv_q_liq_to_q_rai(prs, TC1980, q_liq, ρ) == FT(0)
+        TT.@test CM2.conv_q_liq_to_q_rai(prs, LD2004, q_liq, ρ) == FT(0)
+        TT.@test CM2.accretion(prs, KK2000, q_liq, q_rai, ρ) == FT(0)
+        TT.@test CM2.accretion(prs, B1994, q_liq, q_rai, ρ) == FT(0)
+        TT.@test CM2.accretion(prs, TC1980, q_liq, q_rai) == FT(0)
+        q_liq = FT(0.5e-3)
+        q_rai = FT(0)
+        TT.@test CM2.accretion(prs, KK2000, q_liq, q_rai, ρ) == FT(0)
+        TT.@test CM2.accretion(prs, B1994, q_liq, q_rai, ρ) == FT(0)
+        TT.@test CM2.accretion(prs, TC1980, q_liq, q_rai) == FT(0)
+
+        # far from threshold points, autoconversion with and without smooth transition should
+        # be approximately equal
+        q_liq = FT(0.5e-3)
         TT.@test CM2.conv_q_liq_to_q_rai(
             prs,
-            scheme,
+            B1994,
             q_liq,
-            N_d = input * 1e6,
             ρ,
-        ) ≈ output atol = eps * output
+            smooth_transition = true,
+        ) ≈ CM2.conv_q_liq_to_q_rai(
+            prs,
+            B1994,
+            q_liq,
+            ρ,
+            smooth_transition = false,
+        ) rtol = 0.2
+        TT.@test CM2.conv_q_liq_to_q_rai(
+            prs,
+            TC1980,
+            q_liq,
+            ρ,
+            smooth_transition = true,
+        ) ≈ CM2.conv_q_liq_to_q_rai(
+            prs,
+            TC1980,
+            q_liq,
+            ρ,
+            smooth_transition = false,
+        ) rtol = 0.2
+        TT.@test CM2.conv_q_liq_to_q_rai(
+            prs,
+            LD2004,
+            q_liq,
+            ρ,
+            smooth_transition = true,
+        ) ≈ CM2.conv_q_liq_to_q_rai(
+            prs,
+            LD2004,
+            q_liq,
+            ρ,
+            smooth_transition = false,
+        ) rtol = 0.2
+
     end
-    compare_Nd(KK2000, 16.13564081404141, 6.457285532394289e-8)
-    compare_Nd(KK2000, 652.093931356625, 8.604011482409198e-11)
-    compare_Nd(B1994, 14.47851799831075, 4.2829062386778675e-7)
-    compare_Nd(B1994, 693.0425211336465, 6.076294746898778e-12)
-    compare_Nd(TC1980, 13.658073017575544, 2.7110779872658386e-7)
-    compare_Nd(TC1980, 205.0970632305975, 1.0928660431622176e-7)
-    compare_Nd(LD2004, 15.122629721719655, 1.1647783461546477e-7)
-    compare_Nd(LD2004, 149.01220754857331, 1.3917890403908125e-8, eps = 1)
 
-end
+    TT.@testset "2M_microphysics - compare with Wood_2005" begin
 
-# 2M_microphysics - Seifert and Beheng 2006 double moment scheme tests
-TT.@testset "limiting lambda_r and x_r - Seifert and Beheng 2006" begin
-    #setup
-    q_rai = [0.0, 1e-4, 1e-2]
-    N_rai = [1e1, 1e3, 1e5]
-    ρ = 1.0
+        ρ = FT(1)
+        q_liq = FT(0.5e-3)
 
-    xr_min = 2.6e-10
-    xr_max = 5e-6
-    λ_min = 1e3
-    λ_max = 1e4
-
-    for Nr in N_rai
-        for qr in q_rai
-            #action
-            λ = CM2.raindrops_limited_vars(param_set, qr, ρ, Nr).λr
-            xr = CM2.raindrops_limited_vars(param_set, qr, ρ, Nr).xr
-
-            #test
-            TT.@test λ_min <= λ <= λ_max
-            TT.@test xr_min <= xr <= xr_max
+        # compare with Wood 2005 Fig 1 panel a
+        function compare(scheme, input, output; eps = 0.1)
+            TT.@test CM2.conv_q_liq_to_q_rai(prs, scheme, input * FT(1e-3), ρ) ≈
+                     output atol = eps * output
         end
+        compare(KK2000, FT(0.03138461538461537), FT(2.636846054348105e-12))
+        compare(KK2000, FT(0.8738461538461537), FT(9.491665962977648e-9))
+        compare(
+            B1994,
+            FT(0.13999999999999999),
+            FT(4.584323122458155e-12),
+            eps = 1,
+        )
+        compare(
+            B1994,
+            FT(0.9000000000000006),
+            FT(5.4940586176564715e-8),
+            eps = 1,
+        )
+        compare(TC1980, FT(0.2700000000000001), FT(3.2768635256661366e-8))
+        compare(TC1980, FT(0.9000000000000006), FT(5.340418612468997e-7))
+        compare(LD2004, FT(0.3700000000000002), FT(8.697439193234471e-9))
+        compare(LD2004, FT(0.9000000000000006), FT(1.1325570516983242e-7))
+
+        # compare with Wood 2005 Fig 1 panel b
+        function compare_Nd(scheme, input, output; eps = 0.1)
+            TT.@test CM2.conv_q_liq_to_q_rai(
+                prs,
+                scheme,
+                q_liq,
+                N_d = input * FT(1e6),
+                ρ,
+            ) ≈ output atol = eps * output
+        end
+        compare_Nd(KK2000, FT(16.13564081404141), FT(6.457285532394289e-8))
+        compare_Nd(KK2000, FT(652.093931356625), FT(8.604011482409198e-11))
+        compare_Nd(B1994, FT(14.47851799831075), FT(4.2829062386778675e-7))
+        compare_Nd(B1994, FT(693.0425211336465), FT(6.076294746898778e-12))
+        compare_Nd(TC1980, FT(13.658073017575544), FT(2.7110779872658386e-7))
+        compare_Nd(TC1980, FT(205.0970632305975), FT(1.0928660431622176e-7))
+        compare_Nd(LD2004, FT(15.122629721719655), FT(1.1647783461546477e-7))
+        compare_Nd(
+            LD2004,
+            FT(149.01220754857331),
+            FT(1.3917890403908125e-8),
+            eps = 1,
+        )
+
     end
 
+    # 2M_microphysics - Seifert and Beheng 2006 double moment scheme tests
+    TT.@testset "limiting lambda_r and x_r - Seifert and Beheng 2006" begin
+        #setup
+        q_rai = [FT(0), FT(1e-4), FT(1e-2)]
+        N_rai = [FT(1e1), FT(1e3), FT(1e5)]
+        ρ = FT(1)
+
+        xr_min = FT(2.6e-10)
+        xr_max = FT(5e-6)
+        λ_min = FT(1e3)
+        λ_max = FT(1e4)
+
+        for Nr in N_rai
+            for qr in q_rai
+                #action
+                λ = CM2.raindrops_limited_vars(prs, qr, ρ, Nr).λr
+                xr = CM2.raindrops_limited_vars(prs, qr, ρ, Nr).xr
+
+                #test
+                TT.@test λ_min <= λ <= λ_max
+                TT.@test xr_min <= xr <= xr_max
+            end
+        end
+
+    end
+
+    TT.@testset "2M_microphysics - Seifert and Beheng 2006 autoconversion and liquid self-collection" begin
+        #setup
+        ρ = FT(1)
+        q_liq = FT(0.5e-3)
+        N_liq = FT(1e8)
+        q_rai = FT(1e-6)
+
+        kcc = FT(4.44e9)
+        xstar = FT(2.6e-10)
+        νc = FT(2.0)
+        ρ0 = FT(1.225)
+
+        #action
+        au = CM2.autoconversion(prs, CMT.SB2006Type(), q_liq, q_rai, ρ, N_liq)
+        sc = CM2.liquid_self_collection(
+            prs,
+            CMT.SB2006Type(),
+            q_liq,
+            ρ,
+            au.dN_liq_dt,
+        )
+        au_sc = CM2.autoconversion_and_liquid_self_collection(
+            prs,
+            CMT.SB2006Type(),
+            q_liq,
+            q_rai,
+            ρ,
+            N_liq,
+        )
+
+        Lc = ρ * q_liq
+        Lr = ρ * q_rai
+        xc = min(xstar, Lc / N_liq)
+        τ = 1 - Lc / (Lc + Lr)
+        ϕ_au = 400 * τ^0.7 * (1 - τ^0.7)^3
+        dqrdt_au =
+            kcc / 20 / xstar * (νc + 2) * (νc + 4) / (νc + 1)^2 *
+            Lc^2 *
+            xc^2 *
+            (1 + ϕ_au / (1 - τ)^2) *
+            (ρ0 / ρ) / ρ
+        dqcdt_au = -dqrdt_au
+        dNcdt_au = 2 / xstar * ρ * dqcdt_au
+        dNrdt_au = -0.5 * dNcdt_au
+        dNcdt_sc = -kcc * (νc + 2) / (νc + 1) * (ρ0 / ρ) * Lc^2 - au.dN_liq_dt
+
+        #test
+        TT.@test au isa CM2.LiqRaiRates
+        TT.@test au.dq_liq_dt ≈ dqcdt_au rtol = 1e-6
+        TT.@test au.dq_rai_dt ≈ dqrdt_au rtol = 1e-6
+        TT.@test au.dN_liq_dt ≈ dNcdt_au rtol = 1e-6
+        TT.@test au.dN_rai_dt ≈ dNrdt_au rtol = 1e-6
+        TT.@test sc ≈ dNcdt_sc rtol = 1e-6
+        TT.@test au_sc isa NamedTuple
+        TT.@test au_sc.au.dq_liq_dt ≈ dqcdt_au rtol = 1e-6
+        TT.@test au_sc.au.dq_rai_dt ≈ dqrdt_au rtol = 1e-6
+        TT.@test au_sc.au.dN_liq_dt ≈ dNcdt_au rtol = 1e-6
+        TT.@test au_sc.au.dN_rai_dt ≈ dNrdt_au rtol = 1e-6
+        TT.@test au_sc.sc ≈ dNcdt_sc rtol = 1e-6
+
+        #action
+        au = CM2.autoconversion(prs, CMT.SB2006Type(), FT(0), FT(0), ρ, N_liq)
+        sc = CM2.liquid_self_collection(
+            prs,
+            CMT.SB2006Type(),
+            FT(0),
+            ρ,
+            au.dN_liq_dt,
+        )
+        au_sc = CM2.autoconversion_and_liquid_self_collection(
+            prs,
+            CMT.SB2006Type(),
+            FT(0),
+            FT(0),
+            ρ,
+            N_liq,
+        )
+
+        #test
+        TT.@test au.dq_liq_dt ≈ FT(0) atol = eps(FT)
+        TT.@test au.dq_rai_dt ≈ FT(0) atol = eps(FT)
+        TT.@test au.dN_liq_dt ≈ FT(0) atol = eps(FT)
+        TT.@test au.dN_rai_dt ≈ FT(0) atol = eps(FT)
+        TT.@test sc ≈ FT(0) atol = eps(FT)
+        TT.@test au_sc.au.dq_liq_dt ≈ FT(0) atol = eps(FT)
+        TT.@test au_sc.au.dq_rai_dt ≈ FT(0) atol = eps(FT)
+        TT.@test au_sc.au.dN_liq_dt ≈ FT(0) atol = eps(FT)
+        TT.@test au_sc.au.dN_rai_dt ≈ FT(0) atol = eps(FT)
+        TT.@test au_sc.sc ≈ FT(0) atol = eps(FT)
+    end
+
+    TT.@testset "2M_microphysics - Seifert and Beheng 2006 accretion" begin
+        #setup
+        ρ = FT(1.1)
+        q_liq = FT(0.5e-3)
+        N_liq = FT(1e8)
+        q_rai = FT(1e-6)
+        N_rai = FT(1e4)
+
+        kcr = FT(5.25)
+        ρ0 = FT(1.225)
+
+        #action
+        ac = CM2.accretion(prs, CMT.SB2006Type(), q_liq, q_rai, ρ, N_liq)
+
+        Lc = ρ * q_liq
+        Lr = ρ * q_rai
+        xc = Lc / N_liq
+        τ = 1 - Lc / (Lc + Lr)
+        ϕ_ac = (τ / (τ + 5e-5))^4
+
+        dqrdt_ac = kcr * Lc * Lr * ϕ_ac * sqrt(ρ0 / ρ) / ρ
+        dqcdt_ac = -dqrdt_ac
+        dNcdt_ac = 1 / xc * ρ * dqcdt_ac
+        dNrdt_ac = FT(0)
+
+        #test
+        TT.@test ac isa CM2.LiqRaiRates
+        TT.@test ac.dq_liq_dt ≈ dqcdt_ac rtol = FT(1e-6)
+        TT.@test ac.dq_rai_dt ≈ dqrdt_ac rtol = FT(1e-6)
+        TT.@test ac.dN_liq_dt ≈ dNcdt_ac rtol = FT(1e-6)
+        TT.@test ac.dN_rai_dt ≈ dNrdt_ac rtol = FT(1e-6)
+
+        #action
+        ac = CM2.accretion(prs, CMT.SB2006Type(), FT(0), FT(0), ρ, N_liq)
+
+        #test
+        TT.@test ac.dq_liq_dt ≈ FT(0) atol = eps(FT)
+        TT.@test ac.dq_rai_dt ≈ FT(0) atol = eps(FT)
+        TT.@test ac.dN_liq_dt ≈ FT(0) atol = eps(FT)
+        TT.@test ac.dN_rai_dt ≈ FT(0) atol = eps(FT)
+    end
+
+    TT.@testset "2M_microphysics - Seifert and Beheng 2006 rain self-collection and breakup" begin
+        #setup
+        ρ = FT(1.1)
+        q_rai = FT(1e-6)
+        N_rai = FT(1e4)
+
+        krr = FT(7.12)
+        κrr = FT(60.7)
+        Deq = FT(9e-4)
+        Dr_th = FT(3.5e-4)
+        kbr = FT(1000)
+        κbr = FT(2300)
+        ρ0 = FT(1.225)
+
+        #action
+        sc_rai =
+            CM2.rain_self_collection(prs, CMT.SB2006Type(), q_rai, ρ, N_rai)
+        br_rai =
+            CM2.rain_breakup(prs, CMT.SB2006Type(), q_rai, ρ, N_rai, sc_rai)
+        sc_br_rai = CM2.rain_self_collection_and_breakup(
+            prs,
+            CMT.SB2006Type(),
+            q_rai,
+            ρ,
+            N_rai,
+        )
+
+        λr =
+            CM2.raindrops_limited_vars(prs, q_rai, ρ, N_rai).λr *
+            FT(6 / π / 1000)^FT(1 / 3)
+        dNrdt_sc = -krr * N_rai * ρ * q_rai * (1 + κrr / λr)^-5 * sqrt(ρ0 / ρ)
+
+        Dr =
+            (
+                CM2.raindrops_limited_vars(prs, q_rai, ρ, N_rai).xr / 1000 /
+                FT(π) * 6
+            )^FT(1 / 3)
+        ΔDr = Dr - Deq
+        ϕ_br =
+            Dr < 0.35e-3 ? FT(-1) :
+            ((Dr < 0.9e-3) ? kbr * ΔDr : 2 * (exp(κbr * ΔDr) - 1))
+
+        dNrdt_br = -(ϕ_br + 1) * sc_rai
+
+        #test
+        TT.@test sc_rai ≈ dNrdt_sc rtol = 1e-6
+        TT.@test CM2.rain_self_collection(
+            prs,
+            CMT.SB2006Type(),
+            FT(0),
+            ρ,
+            N_rai,
+        ) ≈ FT(0) atol = eps(FT)
+        TT.@test br_rai ≈ dNrdt_br rtol = 1e-6
+        TT.@test sc_br_rai isa NamedTuple
+        TT.@test sc_br_rai.sc ≈ dNrdt_sc rtol = 1e-6
+        TT.@test sc_br_rai.br ≈ dNrdt_br rtol = 1e-6
+
+        #setup
+        q_rai = FT(0)
+
+        #action
+        sc_rai =
+            CM2.rain_self_collection(prs, CMT.SB2006Type(), q_rai, ρ, N_rai)
+        br_rai =
+            CM2.rain_breakup(prs, CMT.SB2006Type(), q_rai, ρ, N_rai, sc_rai)
+        sc_br_rai = CM2.rain_self_collection_and_breakup(
+            prs,
+            CMT.SB2006Type(),
+            q_rai,
+            ρ,
+            N_rai,
+        )
+
+        #test
+        TT.@test sc_rai ≈ FT(0) atol = eps(FT)
+        TT.@test br_rai ≈ FT(0) atol = eps(FT)
+        TT.@test sc_br_rai.sc ≈ FT(0) atol = eps(FT)
+        TT.@test sc_br_rai.br ≈ FT(0) atol = eps(FT)
+    end
+
+    TT.@testset "2M_microphysics - Seifert and Beheng 2006 rain terminal velocity" begin
+        #setup
+        ρ = FT(1.1)
+        q_rai = FT(1e-6)
+        N_rai = FT(1e4)
+
+        ρ0 = FT(1.225)
+        aR = FT(9.65)
+        bR = FT(10.3)
+        cR = FT(600)
+
+        #action
+        vt_rai =
+            CM2.rain_terminal_velocity(prs, CMT.SB2006Type(), q_rai, ρ, N_rai)
+
+        λr = CM2.raindrops_limited_vars(prs, q_rai, ρ, N_rai).λr
+        vt0 = max(0, sqrt(ρ0 / ρ) * (aR - bR / (1 + cR / λr)))
+        vt1 = max(0, sqrt(ρ0 / ρ) * (aR - bR / (1 + cR / λr)^4))
+
+        #test
+        TT.@test vt_rai isa Tuple
+        TT.@test vt_rai[1] ≈ vt0 rtol = 1e-6
+        TT.@test vt_rai[2] ≈ vt1 rtol = 1e-6
+        TT.@test CM2.rain_terminal_velocity(
+            prs,
+            CMT.SB2006Type(),
+            FT(0),
+            ρ,
+            N_rai,
+        )[1] ≈ 0 atol = eps(FT)
+        TT.@test CM2.rain_terminal_velocity(
+            prs,
+            CMT.SB2006Type(),
+            FT(0),
+            ρ,
+            N_rai,
+        )[2] ≈ 0 atol = eps(FT)
+    end
+
+    TT.@testset "2M_microphysics - Seifert and Beheng 2006 rain evaporation" begin
+        #setup
+        ρ = FT(1.1)
+        q_rai = FT(1e-6)
+        N_rai = FT(1e4)
+        T = FT(288.15)
+        q_tot = FT(1e-3)
+        q = TD.PhasePartition(q_tot)
+
+        av = FT(0.78)
+        bv = FT(0.308)
+        α = FT(159.0)
+        β = FT(0.266)
+        ν_air = CMP.ν_air(prs)
+        D_vapor = CMP.D_vapor(prs)
+        ρ0 = FT(1.225)
+
+        #action
+        evap =
+            CM2.rain_evaporation(prs, CMT.SB2006Type(), q, q_rai, ρ, N_rai, T)
+
+        G = CMC.G_func(prs, T, TD.Liquid())
+        thermo_params = CMP.thermodynamics_params(prs)
+        S = TD.supersaturation(thermo_params, q, ρ, T, TD.Liquid())
+
+        xr = CM2.raindrops_limited_vars(prs, q_rai, ρ, N_rai).xr
+        Dr = FT(6 / π / 1000.0)^FT(1 / 3) * xr^FT(1 / 3)
+        N_Re = α * xr^β * sqrt(ρ0 / ρ) * Dr / ν_air
+
+        a_vent_0 = av * FT(0.1915222379058504)
+        b_vent_0 = bv * FT(0.2040123897555518)
+        Fv0 = a_vent_0 + b_vent_0 * (ν_air / D_vapor)^FT(1 / 3) * sqrt(N_Re)
+        a_vent_1 = av * FT(0.5503212081491045)
+        b_vent_1 = bv * FT(0.5873135598802672)
+        Fv1 = a_vent_1 + b_vent_1 * (ν_air / D_vapor)^FT(1 / 3) * sqrt(N_Re)
+
+        evap0 = 2 * FT(π) * G * S * N_rai * Dr * Fv0 / xr
+        evap1 = 2 * FT(π) * G * S * N_rai * Dr * Fv1 / ρ
+
+        #test
+        TT.@test evap isa Tuple
+        TT.@test evap[1] ≈ evap0 rtol = 1e-5
+        TT.@test evap[2] ≈ evap1 rtol = 1e-5
+        TT.@test CM2.rain_evaporation(
+            prs,
+            CMT.SB2006Type(),
+            q,
+            FT(0),
+            ρ,
+            N_rai,
+            T,
+        )[1] ≈ 0 atol = eps(FT)
+        TT.@test CM2.rain_evaporation(
+            prs,
+            CMT.SB2006Type(),
+            q,
+            FT(0),
+            ρ,
+            N_rai,
+            T,
+        )[2] ≈ 0 atol = eps(FT)
+    end
 end
 
-TT.@testset "2M_microphysics - Seifert and Beheng 2006 autoconversion and liquid self-collection" begin
-    #setup
-    ρ = 1.1
-    q_liq = 0.5e-3
-    N_liq = 1e8
-    q_rai = 1e-6
+println("")
+println("Testing Float64")
+test_microphysics(Float64)
 
-    kcc = 4.44e9
-    xstar = 2.6e-10
-    νc = 2.0
-    ρ0 = 1.225
-
-    #action
-    au = CM2.autoconversion(prs, CMT.SB2006Type(), q_liq, q_rai, ρ, N_liq)
-    sc = CM2.liquid_self_collection(
-        prs,
-        CMT.SB2006Type(),
-        q_liq,
-        ρ,
-        au.dN_liq_dt,
-    )
-    au_sc = CM2.autoconversion_and_liquid_self_collection(
-        prs,
-        CMT.SB2006Type(),
-        q_liq,
-        q_rai,
-        ρ,
-        N_liq,
-    )
-
-    Lc = ρ * q_liq
-    Lr = ρ * q_rai
-    xc = min(xstar, Lc / N_liq)
-    τ = 1 - Lc / (Lc + Lr)
-    ϕ_au = 400 * τ^0.7 * (1 - τ^0.7)^3
-    dqrdt_au =
-        kcc / 20 / xstar * (νc + 2) * (νc + 4) / (νc + 1)^2 *
-        Lc^2 *
-        xc^2 *
-        (1 + ϕ_au / (1 - τ)^2) *
-        (ρ0 / ρ) / ρ
-    dqcdt_au = -dqrdt_au
-    dNcdt_au = 2 / xstar * ρ * dqcdt_au
-    dNrdt_au = -0.5 * dNcdt_au
-    dNcdt_sc = -kcc * (νc + 2) / (νc + 1) * (ρ0 / ρ) * Lc^2 - au.dN_liq_dt
-
-    #test
-    TT.@test au isa CM2.LiqRaiRates
-    TT.@test au.dq_liq_dt ≈ dqcdt_au rtol = 1e-6
-    TT.@test au.dq_rai_dt ≈ dqrdt_au rtol = 1e-6
-    TT.@test au.dN_liq_dt ≈ dNcdt_au rtol = 1e-6
-    TT.@test au.dN_rai_dt ≈ dNrdt_au rtol = 1e-6
-    TT.@test sc isa Float64
-    TT.@test sc ≈ dNcdt_sc rtol = 1e-6
-    TT.@test au_sc isa NamedTuple
-    TT.@test au_sc.au.dq_liq_dt ≈ dqcdt_au rtol = 1e-6
-    TT.@test au_sc.au.dq_rai_dt ≈ dqrdt_au rtol = 1e-6
-    TT.@test au_sc.au.dN_liq_dt ≈ dNcdt_au rtol = 1e-6
-    TT.@test au_sc.au.dN_rai_dt ≈ dNrdt_au rtol = 1e-6
-    TT.@test au_sc.sc ≈ dNcdt_sc rtol = 1e-6
-
-    #action
-    au = CM2.autoconversion(prs, CMT.SB2006Type(), 0.0, 0.0, ρ, N_liq)
-    sc = CM2.liquid_self_collection(prs, CMT.SB2006Type(), 0.0, ρ, au.dN_liq_dt)
-    au_sc = CM2.autoconversion_and_liquid_self_collection(
-        prs,
-        CMT.SB2006Type(),
-        0.0,
-        0.0,
-        ρ,
-        N_liq,
-    )
-
-    #test
-    TT.@test au.dq_liq_dt ≈ 0 atol = eps(Float64)
-    TT.@test au.dq_rai_dt ≈ 0 atol = eps(Float64)
-    TT.@test au.dN_liq_dt ≈ 0 atol = eps(Float64)
-    TT.@test au.dN_rai_dt ≈ 0 atol = eps(Float64)
-    TT.@test sc ≈ 0 atol = eps(Float64)
-    TT.@test au_sc.au.dq_liq_dt ≈ 0 atol = eps(Float64)
-    TT.@test au_sc.au.dq_rai_dt ≈ 0 atol = eps(Float64)
-    TT.@test au_sc.au.dN_liq_dt ≈ 0 atol = eps(Float64)
-    TT.@test au_sc.au.dN_rai_dt ≈ 0 atol = eps(Float64)
-    TT.@test au_sc.sc ≈ 0 atol = eps(Float64)
-end
-
-TT.@testset "2M_microphysics - Seifert and Beheng 2006 accretion" begin
-    #setup
-    ρ = 1.1
-    q_liq = 0.5e-3
-    N_liq = 1e8
-    q_rai = 1e-6
-    N_rai = 1e4
-
-    kcr = 5.25
-    ρ0 = 1.225
-
-    #action
-    ac = CM2.accretion(prs, CMT.SB2006Type(), q_liq, q_rai, ρ, N_liq)
-
-    Lc = ρ * q_liq
-    Lr = ρ * q_rai
-    xc = Lc / N_liq
-    τ = 1 - Lc / (Lc + Lr)
-    ϕ_ac = (τ / (τ + 5e-5))^4
-
-    dqrdt_ac = kcr * Lc * Lr * ϕ_ac * sqrt(ρ0 / ρ) / ρ
-    dqcdt_ac = -dqrdt_ac
-    dNcdt_ac = 1 / xc * ρ * dqcdt_ac
-    dNrdt_ac = 0.0
-
-
-    #test
-    TT.@test ac isa CM2.LiqRaiRates
-    TT.@test ac.dq_liq_dt ≈ dqcdt_ac rtol = 1e-6
-    TT.@test ac.dq_rai_dt ≈ dqrdt_ac rtol = 1e-6
-    TT.@test ac.dN_liq_dt ≈ dNcdt_ac rtol = 1e-6
-    TT.@test ac.dN_rai_dt ≈ dNrdt_ac rtol = 1e-6
-
-    #action
-    ac = CM2.accretion(prs, CMT.SB2006Type(), 0.0, 0.0, ρ, N_liq)
-
-    #test
-    TT.@test ac.dq_liq_dt ≈ 0 atol = eps(Float64)
-    TT.@test ac.dq_rai_dt ≈ 0 atol = eps(Float64)
-    TT.@test ac.dN_liq_dt ≈ 0 atol = eps(Float64)
-    TT.@test ac.dN_rai_dt ≈ 0 atol = eps(Float64)
-end
-
-TT.@testset "2M_microphysics - Seifert and Beheng 2006 rain self-collection and breakup" begin
-    #setup
-    ρ = 1.1
-    q_rai = 1e-6
-    N_rai = 1e4
-
-    krr = 7.12
-    κrr = 60.7
-    Deq = 9e-4
-    Dr_th = 3.5e-4
-    kbr = 1000.0
-    κbr = 2300.0
-    ρ0 = 1.225
-
-    #action
-    sc_rai = CM2.rain_self_collection(prs, CMT.SB2006Type(), q_rai, ρ, N_rai)
-    br_rai = CM2.rain_breakup(prs, CMT.SB2006Type(), q_rai, ρ, N_rai, sc_rai)
-    sc_br_rai = CM2.rain_self_collection_and_breakup(
-        prs,
-        CMT.SB2006Type(),
-        q_rai,
-        ρ,
-        N_rai,
-    )
-
-    λr =
-        CM2.raindrops_limited_vars(param_set, q_rai, ρ, N_rai).λr *
-        (6 / π / 1000.0)^(1 / 3)
-    dNrdt_sc = -krr * N_rai * ρ * q_rai * (1 + κrr / λr)^-5 * sqrt(ρ0 / ρ)
-
-    Dr =
-        (
-            CM2.raindrops_limited_vars(prs, q_rai, ρ, N_rai).xr / 1000 / π * 6
-        )^(1 / 3)
-    ΔDr = Dr - Deq
-    ϕ_br =
-        Dr < 0.35e-3 ? -1.0 :
-        ((Dr < 0.9e-3) ? kbr * ΔDr : 2 * (exp(κbr * ΔDr) - 1))
-
-    dNrdt_br = -(ϕ_br + 1) * sc_rai
-
-    #test
-    TT.@test sc_rai isa Float64
-    TT.@test sc_rai ≈ dNrdt_sc rtol = 1e-6
-    TT.@test CM2.rain_self_collection(prs, CMT.SB2006Type(), 0.0, ρ, N_rai) ≈ 0 atol =
-        eps(Float64)
-    TT.@test br_rai isa Float64
-    TT.@test br_rai ≈ dNrdt_br rtol = 1e-6
-    TT.@test sc_br_rai isa NamedTuple
-    TT.@test sc_br_rai.sc ≈ dNrdt_sc rtol = 1e-6
-    TT.@test sc_br_rai.br ≈ dNrdt_br rtol = 1e-6
-
-    #setup
-    q_rai = 0.0
-
-    #action
-    sc_rai = CM2.rain_self_collection(prs, CMT.SB2006Type(), q_rai, ρ, N_rai)
-    br_rai = CM2.rain_breakup(prs, CMT.SB2006Type(), q_rai, ρ, N_rai, sc_rai)
-    sc_br_rai = CM2.rain_self_collection_and_breakup(
-        prs,
-        CMT.SB2006Type(),
-        q_rai,
-        ρ,
-        N_rai,
-    )
-
-    #test
-    TT.@test sc_rai ≈ 0 atol = eps(Float64)
-    TT.@test br_rai ≈ 0 atol = eps(Float64)
-    TT.@test sc_br_rai.sc ≈ 0 atol = eps(Float64)
-    TT.@test sc_br_rai.br ≈ 0 atol = eps(Float64)
-end
-
-TT.@testset "2M_microphysics - Seifert and Beheng 2006 rain terminal velocity" begin
-    #setup
-    ρ = 1.1
-    q_rai = 1e-6
-    N_rai = 1e4
-
-    ρ0 = 1.225
-    aR = 9.65
-    bR = 10.3
-    cR = 600.0
-
-    #action
-    vt_rai = CM2.rain_terminal_velocity(prs, CMT.SB2006Type(), q_rai, ρ, N_rai)
-
-    λr = CM2.raindrops_limited_vars(prs, q_rai, ρ, N_rai).λr
-    vt0 = max(0, sqrt(ρ0 / ρ) * (aR - bR / (1 + cR / λr)))
-    vt1 = max(0, sqrt(ρ0 / ρ) * (aR - bR / (1 + cR / λr)^4))
-
-    #test
-    TT.@test vt_rai isa Tuple
-    TT.@test vt_rai[1] ≈ vt0 rtol = 1e-6
-    TT.@test vt_rai[2] ≈ vt1 rtol = 1e-6
-    TT.@test CM2.rain_terminal_velocity(prs, CMT.SB2006Type(), 0.0, ρ, N_rai)[1] ≈
-             0 atol = eps(Float64)
-    TT.@test CM2.rain_terminal_velocity(prs, CMT.SB2006Type(), 0.0, ρ, N_rai)[2] ≈
-             0 atol = eps(Float64)
-end
-
-TT.@testset "2M_microphysics - Seifert and Beheng 2006 rain evaporation" begin
-    #setup
-    ρ = 1.1
-    q_rai = 1e-6
-    N_rai = 1e4
-    T = 288.15
-    q_tot = 1e-3
-    q = TD.PhasePartition(q_tot, 0.0, 0.0)
-
-    av = 0.78
-    bv = 0.308
-    α = 159.0
-    β = 0.266
-    ν_air = CMP.ν_air(param_set)
-    D_vapor = CMP.D_vapor(param_set)
-    ρ0 = 1.225
-
-    #action
-    evap = CM2.rain_evaporation(prs, CMT.SB2006Type(), q, q_rai, ρ, N_rai, T)
-
-    G = CloudMicrophysics.Common.G_func(param_set, T, TD.Liquid())
-    thermo_params = CMP.thermodynamics_params(prs)
-    S = TD.supersaturation(thermo_params, q, ρ, T, TD.Liquid())
-
-    xr = CM2.raindrops_limited_vars(param_set, q_rai, ρ, N_rai).xr
-    Dr = (6 / π / 1000.0)^(1 / 3) * xr^(1 / 3)
-    N_Re = α * xr^β * sqrt(ρ0 / ρ) * Dr / ν_air
-
-    a_vent_0 = av * 0.1915222379058504
-    b_vent_0 = bv * 0.2040123897555518
-    Fv0 = a_vent_0 + b_vent_0 * (ν_air / D_vapor)^(1 / 3) * sqrt(N_Re)
-    a_vent_1 = av * 0.5503212081491045
-    b_vent_1 = bv * 0.5873135598802672
-    Fv1 = a_vent_1 + b_vent_1 * (ν_air / D_vapor)^(1 / 3) * sqrt(N_Re)
-
-    evap0 = 2 * π * G * S * N_rai * Dr * Fv0 / xr
-    evap1 = 2 * π * G * S * N_rai * Dr * Fv1 / ρ
-
-    #test
-    TT.@test evap isa Tuple
-    TT.@test evap[1] ≈ evap0 rtol = 1e-6
-    TT.@test evap[2] ≈ evap1 rtol = 1e-6
-    TT.@test CM2.rain_evaporation(prs, CMT.SB2006Type(), q, 0.0, ρ, N_rai, T)[1] ≈
-             0 atol = eps(Float64)
-    TT.@test CM2.rain_evaporation(prs, CMT.SB2006Type(), q, 0.0, ρ, N_rai, T)[2] ≈
-             0 atol = eps(Float64)
-end
+println("")
+println("Testing Float32")
+test_microphysics(Float32)

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -113,5 +113,10 @@ function benchmark_test(FT)
 
 end
 
+println("")
+println("Testing Float64")
 benchmark_test(Float64)
+
+println("")
+println("Testing Float32")
 benchmark_test(Float32)


### PR DESCRIPTION
Closes https://github.com/CliMA/CloudMicrophysics.jl/issues/111

GitHub comparison makes this PR look much longer than it actually is. I just replaced

```
FT=Float64
function test_all_the_things()
```
with


```
function test_all_the_things(FT)
test_all_the_things(Float32)
test_all_the_things(Float64)
```

and fixed all the issues that I found along the way. (Like for example the fact that `2 * \pi` ends up being a `Float64`)