### PR TITLE
Initial implementation of precipitation susceptibility tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 CUDAKernels = "72cfdca4-0801-4ab0-bf6a-d52aa10adc57"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -58,6 +58,19 @@
   doi = {10.1126/science.aaf2649}
 }
 
+@article{Glassmeier2016,
+  author = {Franziska Glassmeier and Ulrike Lohmann},
+  title = {Constraining Precipitation Susceptibility of Warm-, Ice-, and Mixed-Phase Clouds with Microphysical Equations},
+  journal = {Journal of the Atmospheric Sciences},
+  year = {2016},
+  publisher = {American Meteorological Society},
+  address = {Boston MA, USA},
+  volume = {73},
+  number = {12},
+  doi = {https://doi.org/10.1175/JAS-D-16-0008.1},
+  pages = {5003 - 5023}
+}
+
 @article{Grabowski1996,
   title = {Two-time-level semi-Lagrangian modeling of precipitating clouds},
   author = {Grabowski, Wojciech W and Smolarkiewicz, Piotr K},

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,6 +18,7 @@ pages = Any[
     "Ice Nucleation" => "IceNucleation.md",
     "Box model ice nucleation example" => "IceNucleationBox.md",
     "Aerosol Nucleation" => "AerosolNucleation.md",
+    "Precipitation Susceptibility" => "PrecipitationSusceptibility.md",
     "API" => "API.md",
     "References" => "References.md",
 ]

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -119,3 +119,10 @@ CommonTypes.AbstractAerosolType
 CommonTypes.ArizonaTestDustType
 CommonTypes.DesertDustType
 ```
+
+# Precipitation susceptibility
+
+```@docs
+PrecipitationSusceptibility.precipitation_susceptibility_autoconversion
+PrecipitationSusceptibility.precipitation_susceptibility_accretion
+```

--- a/docs/src/PrecipitationSusceptibility.md
+++ b/docs/src/PrecipitationSusceptibility.md
@@ -1,0 +1,31 @@
+# Precipitation Susceptibility
+
+The `PrecipitationSusceptibility.jl` module contains functions for determining
+the precipitation susceptibility rates due to various processes for 2-moment
+microphysics schemes, as described in [Glassmeier2016](@cite).
+
+The precipitation susceptibility describes the rate of change of precipitation
+production due to some moment of the particle size distribution:
+
+For some partial moment $X$, such as $q_{liq}$, $q_{rai}$, $N_{liq}$, or $N_{rai}$
+and some process rate of precipitation production $r$, such as autoconversion,
+accretion, etc, this is defined as:
+```math
+\frac{\partial \ln r}{\partial \ln X}
+```
+
+The total precipitation susceptibility, then, is
+```math
+\frac{\partial \ln PP}{\partial \ln X} = \sum_{r \in R}
+    \frac{r}{PP} \frac{\partial \ln r}{\partial \ln X}
+```
+
+Where $R$ is the set of all process rates that contribute to precipitation production.
+
+
+Example reproducing Fig. 2 From [Glassmeier2016](@cite):
+
+```@example
+include("PrecipitationSusceptibilityPlots.jl")
+```
+![](Glassmeier-Lohmann_Fig2.svg)

--- a/docs/src/PrecipitationSusceptibilityPlots.jl
+++ b/docs/src/PrecipitationSusceptibilityPlots.jl
@@ -1,0 +1,71 @@
+using CairoMakie
+CairoMakie.activate!(type = "svg")
+
+import CloudMicrophysics as CM
+import CloudMicrophysics.CommonTypes as CMT
+import CloudMicrophysics.PrecipitationSusceptibility as CMPS
+
+include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
+
+const FT = Float64
+
+toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
+prs = cloud_microphysics_parameters(toml_dict)
+
+scheme = CMT.SB2006Type()
+
+q_tot = FT(0.5e-3)
+
+# Start from small nonzero value to more clearly see the asymptotes
+q_rai = range(0.0001 * q_tot, q_tot, 1000)
+q_liq = q_tot .- q_rai
+
+N_liq = FT(1e8)
+ρ = FT(1)
+
+τ = q_rai ./ q_tot
+
+aut_rates =
+    CMPS.precipitation_susceptibility_autoconversion.(
+        Ref(prs),
+        Ref(scheme),
+        q_liq,
+        q_rai,
+        Ref(ρ),
+        Ref(N_liq),
+    )
+
+acc_rates =
+    CMPS.precipitation_susceptibility_accretion.(
+        Ref(prs),
+        Ref(scheme),
+        q_liq,
+        q_rai,
+        Ref(ρ),
+        Ref(N_liq),
+    )
+
+fig = Figure()
+
+ax = Axis(fig[1, 1])
+
+ax.xlabel = "q_rai / (q_liq + q_rai)"
+ax.ylabel = "Precipitation susceptibility"
+
+l1 = lines!(ax, τ, [r.d_ln_pp_d_ln_q_liq for r in aut_rates], color = :red)
+l2 = lines!(ax, τ, [r.d_ln_pp_d_ln_q_rai for r in aut_rates], color = :brown)
+l3 = lines!(ax, τ, [r.d_ln_pp_d_ln_q_liq for r in acc_rates], color = :blue)
+l4 = lines!(ax, τ, [r.d_ln_pp_d_ln_q_rai for r in acc_rates], color = :green)
+
+Legend(
+    fig[1, 2],
+    [l1, l2, l3, l4],
+    [
+        "autoconversion, q_liq",
+        "autoconversion, q_rai",
+        "accretion, q_liq",
+        "accretion, q_rai",
+    ],
+)
+
+save("Glassmeier-Lohmann_Fig2.svg", fig)

--- a/src/CloudMicrophysics.jl
+++ b/src/CloudMicrophysics.jl
@@ -20,5 +20,6 @@ include("AerosolModel.jl")
 include("AerosolActivation.jl")
 include("Nucleation.jl")
 include("IceNucleation.jl")
+include("PrecipitationSusceptibility.jl")
 
 end # module

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -8,20 +8,15 @@ Double-moment bulk microphysics parametrizations including:
 """
 module Microphysics2M
 
-import ..Common
-const CO = Common
+import ..Common as CO
 
-import ..CommonTypes
-const CT = CommonTypes
+import ..CommonTypes as CT
 
-import SpecialFunctions
-const SF = SpecialFunctions
+import SpecialFunctions as SF
 
-import Thermodynamics
-const TD = Thermodynamics
+import Thermodynamics as TD
 
-import ..Parameters
-const CMP = Parameters
+import ..Parameters as CMP
 const APS = CMP.AbstractCloudMicrophysicsParameters
 
 export autoconversion

--- a/src/PrecipitationSusceptibility.jl
+++ b/src/PrecipitationSusceptibility.jl
@@ -1,0 +1,100 @@
+module PrecipitationSusceptibility
+
+import ..Microphysics2M as CM2
+
+import ..CommonTypes as CT
+
+import ..Parameters as CMP
+
+const APS = CMP.AbstractCloudMicrophysicsParameters
+
+using ForwardDiff
+
+export precipitation_susceptibility_autoconversion
+export precipitation_susceptibility_accretion
+
+"""
+A structure containing the logarithmic derivatives of the production of
+precipitation with respect to the specific humidities and number
+densities of liquid and rain water.
+"""
+Base.@kwdef struct precip_susceptibility_rates{FT <: Real}
+    d_ln_pp_d_ln_q_liq::FT
+    d_ln_pp_d_ln_q_rai::FT
+    d_ln_pp_d_ln_N_liq::FT
+    d_ln_pp_d_ln_N_rai::FT
+end
+
+"""
+    precipitation_susceptibility_autoconversion(param_set, scheme, q_liq, q_rai, ρ, N_liq)
+
+- `param_set` - abstract set with Earth parameters
+- `scheme` - type for 2-moment rain autoconversion parameterization
+- `q_liq` - cloud water specific humidity
+- `q_rai` - rain water specific humidity
+- `ρ` - air density
+- `N_liq` - cloud droplet number density
+
+Returns the precipitation susceptibility rates due to autoconversion as a `precip_susceptibility_rates`
+object, using automatic differentiation.
+Works for any 2-moment scheme, as long as autoconversion is defined for it.
+"""
+function precipitation_susceptibility_autoconversion(
+    param_set::APS,
+    scheme::ST,
+    q_liq::FT,
+    q_rai::FT,
+    ρ::FT,
+    N_liq::FT,
+) where {FT <: Real, ST <: CT.Abstract2MPrecipType}
+
+    grad = ForwardDiff.gradient(
+        x -> log(CM2.autoconversion(param_set, scheme, exp.(x)...).dq_rai_dt),
+        log.(abs.([q_liq, q_rai, ρ, N_liq])),
+    )
+    return precip_susceptibility_rates(
+        d_ln_pp_d_ln_q_liq = grad[1],
+        d_ln_pp_d_ln_q_rai = grad[2],
+        d_ln_pp_d_ln_N_liq = grad[4],
+        d_ln_pp_d_ln_N_rai = FT(0),
+    )
+
+end
+
+"""
+    precipitation_susceptibility_accretion(param_set, scheme, q_liq, q_rai, ρ, N_liq)
+
+- `param_set` - abstract set with Earth parameters
+- `scheme` - type for 2-moment rain autoconversion parameterization
+- `q_liq` - cloud water specific humidity
+- `q_rai` - rain water specific humidity
+- `ρ` - air density
+- `N_liq` - cloud droplet number density
+
+Returns the precipitation susceptibility rates due to accretion as a `precip_susceptibility_rates`
+object, using automatic differentiation.
+Works for any 2-moment scheme, as long as accretion is defined for it.
+"""
+function precipitation_susceptibility_accretion(
+    param_set::APS,
+    scheme::ST,
+    q_liq::FT,
+    q_rai::FT,
+    ρ::FT,
+    N_liq::FT,
+) where {FT <: Real, ST <: CT.Abstract2MPrecipType}
+
+    grad = ForwardDiff.gradient(
+        x -> log(CM2.accretion(param_set, scheme, exp.(x)...).dq_rai_dt),
+        log.(abs.([q_liq, q_rai, ρ, N_liq])),
+    )
+    return precip_susceptibility_rates(
+        d_ln_pp_d_ln_q_liq = grad[1],
+        d_ln_pp_d_ln_q_rai = grad[2],
+        d_ln_pp_d_ln_N_liq = grad[4],
+        d_ln_pp_d_ln_N_rai = FT(0),
+    )
+
+end
+
+end # module

--- a/test/precipitation_susceptibility_tests.jl
+++ b/test/precipitation_susceptibility_tests.jl
@@ -1,0 +1,94 @@
+import Test as TT
+
+import CloudMicrophysics as CM
+import CLIMAParameters as CP
+
+const CMP = CM.Parameters
+const CMT = CM.CommonTypes
+const CM2 = CM.Microphysics2M
+const CMPS = CM.PrecipitationSusceptibility
+
+include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
+
+const APS = CMP.AbstractCloudMicrophysicsParameters
+
+FT = Float64
+
+"""
+Logarithmic derivative of universal function for autoconversion as described
+    in Glassmeier & Lohmann, which is (1 + Phi(τ)/(1 - τ^2)) for Phi(τ)
+    from SB2006.
+"""
+function d_ln_phi_au_d_ln_τ(
+    param_set::APS,
+    scheme::CMT.SB2006Type,
+    τ::FT,
+) where {FT <: Real}
+    A::FT = CMP.A_phi_au_SB2006(param_set)
+    a::FT = CMP.a_phi_au_SB2006(param_set)
+    b::FT = CMP.b_phi_au_SB2006(param_set)
+    return -(
+        A *
+        τ^a *
+        (1 - τ^a)^(b - 1) *
+        (a * (τ - 1) * ((b + 1) * τ^a - 1) - 2 * τ * (τ^a - 1))
+    ) / (A * (τ - 1) * τ^a * (1 - τ^a)^b + (τ - 1)^3)
+end
+
+"""
+Logarithmic derivative of universal function for accretion as described
+    in Glassmeier & Lohmann
+"""
+function d_ln_phi_acc_d_ln_τ(
+    param_set::APS,
+    scheme::CMT.SB2006Type,
+    τ::FT,
+) where {FT <: Real}
+    τ0::FT = CMP.τ0_phi_ac_SB2006(param_set)
+    c::FT = CMP.c_phi_ac_SB2006(param_set)
+    return (c * τ0) / (τ + τ0)
+end
+
+
+toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
+prs = cloud_microphysics_parameters(toml_dict)
+
+TT.@testset "precipitation_susceptibility_SB2006" begin
+    scheme = CMT.SB2006Type()
+
+    q_liq = FT(0.5e-3)
+    N_liq = FT(1e8)
+    q_rai = FT(1e-5)
+    ρ = FT(1)
+
+    τ = FT(1) - q_liq / (q_liq + q_rai)
+
+    aut_rates = CMPS.precipitation_susceptibility_autoconversion(
+        prs,
+        scheme,
+        q_liq,
+        q_rai,
+        ρ,
+        N_liq,
+    )
+
+    acc_rates = CMPS.precipitation_susceptibility_accretion(
+        prs,
+        scheme,
+        q_liq,
+        q_rai,
+        ρ,
+        N_liq,
+    )
+
+    TT.@test aut_rates.d_ln_pp_d_ln_N_liq ≈ -2
+    TT.@test aut_rates.d_ln_pp_d_ln_q_liq ≈
+             4 - (1 - τ) * d_ln_phi_au_d_ln_τ(prs, scheme, τ)
+    TT.@test aut_rates.d_ln_pp_d_ln_q_rai ≈
+             (1 - τ) * d_ln_phi_au_d_ln_τ(prs, scheme, τ)
+
+    TT.@test acc_rates.d_ln_pp_d_ln_q_liq ≈
+             1 - (1 - τ) * d_ln_phi_acc_d_ln_τ(prs, scheme, τ)
+    TT.@test acc_rates.d_ln_pp_d_ln_q_rai ≈
+             1 + (1 - τ) * d_ln_phi_acc_d_ln_τ(prs, scheme, τ)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,3 @@
-
 include("performance_tests.jl")
 include("aerosol_activation_tests.jl")
 include("heterogeneous_ice_nucleation_tests.jl")
@@ -6,3 +5,4 @@ include("microphysics_tests.jl")
 include("gpu_tests.jl")
 include("common_functions_tests.jl")
 include("nucleation_unit_tests.jl")
+include("precipitation_susceptibility_tests.jl")


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This is an initial implementation of tests for precipitation susceptibility, as described in Glassmeier & Lohmann 2016.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- Analogous precipitation susceptibility rates need to be added for ice-phase processes.
- The struct with the precipitation susceptibility rates needs to be extended to include the ice-phase rates.


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- In a new file, `PrecipitationSusceptibility.jl`:
  - Added the struct `precip_susceptibility_rates`, which can store information on the logarithmic derivatives of precipitation production with respect to number density and specific humidity of cloud and rain droplets.
  - Added the functions `precipitation_susceptibility_autoconversion` and `precipitation_susceptibility_accretion` that compute the autoconversion and accretion susceptibility for any 2-moment scheme, using automatic differentiation (`ForwardDiff.jl`).
- In `test/precipitation_susceptibility_tests.jl`:
  - Added helper functions for computing derivatives of the universal functions from SB2006 / Glassmeier & Lohmann analytically.
  - Added tests to check if the autoconversion and accretion susceptibility from the automatic differentiation for SB2006 matches the expected autoconversion susceptibility described analytically in Glassmeier and Lohmann. All 5 tests are now passing.
- Created a documentation page for precipitation susceptibility.
  - Wrote plotting code for replicating Fig 2 from Glassmeier and Lohmann, added it to the documentation.
- Other miscellaneous changes:
  - Changed the label on the code samples in the README from `julia` to `bash` since VSCode was saying that it was not valid Julia syntax.
  - Changed the imports in `Microphysics2M` and the tests to use `as` instead of declaring `const`'s for the imported modules.
  - In `common_functions_tests.jl` changed `import Test` to `import Test as TT` because otherwise, this file was not able to run individually and only after other tests, since `TT` was not defined within the file.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
