### PR TITLE
Add modal nucleation parameters to struct, update functions

### DIFF
--- a/docs/src/P3SchemePlots.jl
+++ b/docs/src/P3SchemePlots.jl
@@ -1,8 +1,8 @@
 import CairoMakie as Plt
 import CloudMicrophysics as CM
 import CLIMAParameters as CP
-const CMP = CM.Parameters
-const P3 = CM.P3Scheme
+import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.P3Scheme as P3
 const APS = CMP.AbstractCloudMicrophysicsParameters
 FT = Float64
 

--- a/docs/src/TerminalVelocityComparisons.jl
+++ b/docs/src/TerminalVelocityComparisons.jl
@@ -5,11 +5,11 @@ import CLIMAParameters as CP
 
 FT = Float64
 
-const CMT = CM.CommonTypes
-const CM1 = CM.Microphysics1M
-const CM2 = CM.Microphysics2M
-const CMP = CM.Parameters
-const CMO = CM.Common
+import CloudMicrophysics.CommonTypes as CMT
+import CloudMicrophysics.Microphysics1M as CM1
+import CloudMicrophysics.Microphysics2M as CM2
+import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.Common as CMO
 
 const rain = CMT.RainType()
 const liquid = CMT.LiquidType()

--- a/docs/src/nucleation_plotting/CLOUD_Nucleation_Plots.jl
+++ b/docs/src/nucleation_plotting/CLOUD_Nucleation_Plots.jl
@@ -1,39 +1,13 @@
 using Plots
-using CLIMAParameters
 
-include("../../src/Nucleation.jl")
-using .Nucleation
-
-# Testing for CLOUD-experiment based nucleation rates.
+import CLIMAParameters as CP
+import CloudMicrophysics as CM
+import CloudMicrophysics.Nucleation as Nucleation
+include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
 
 FT = Float64
-toml_dict = CLIMAParameters.create_toml_dict(FT)
-param_names = [
-    "u_b_n",
-    "v_b_n",
-    "w_b_n",
-    "u_b_i",
-    "v_b_i",
-    "w_b_i",
-    "u_t_n",
-    "v_t_n",
-    "w_t_n",
-    "u_t_i",
-    "v_t_i",
-    "w_t_i",
-    "p_t_n",
-    "p_A_n",
-    "a_n",
-    "p_t_i",
-    "p_A_i",
-    "a_i",
-    "p_b_n",
-    "p_b_i",
-    "p_t_n",
-    "p_t_i",
-]
-params = CLIMAParameters.get_parameter_values!(toml_dict, param_names)
-params = (; params...)
+toml_dict = CP.create_toml_dict(FT)
+params = cloud_microphysics_parameters(toml_dict)
 
 function plot_pure_h2so4_nucleation_rate(
     h2so4_concentrations,

--- a/docs/src/nucleation_plotting/Kirkby_organic_nucleation_plots.jl
+++ b/docs/src/nucleation_plotting/Kirkby_organic_nucleation_plots.jl
@@ -1,21 +1,18 @@
 using Plots
+
 import CLIMAParameters as CP
-
-include("../../src/Nucleation.jl")
-using .Nucleation
-
-# Testing for CLOUD-experiment based nucleation rates.
+import CloudMicrophysics as CM
+import CloudMicrophysics.Nucleation as Nucleation
+include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
 
 FT = Float64
 toml_dict = CP.create_toml_dict(FT)
-param_names = ("a_1", "a_2", "a_3", "a_4", "a_5")
-params = CP.get_parameter_values!(toml_dict, param_names)
-params = (; params...)
+params = cloud_microphysics_parameters(toml_dict)
 
 HOM_concentrations = 10 .^ (6:0.125:8.7)
 
 rates = map(HOM_concentrations) do HOM_conc
-    sum(Nucleation.organic_nucleation_rate(0, HOM_conc, params)) * 1e-6
+    sum(Nucleation.organic_nucleation_rate_hom_prescribed(0, HOM_conc, params)) * 1e-6
 end
 
 Plots.plot()

--- a/docs/src/nucleation_plotting/Riccobono_mixed_nucleation_plots.jl
+++ b/docs/src/nucleation_plotting/Riccobono_mixed_nucleation_plots.jl
@@ -1,23 +1,23 @@
 using Plots
-using CLIMAParameters
 
-include("../../src/Nucleation.jl")
-using .Nucleation
-
-# Testing for CLOUD-experiment based nucleation rates.
+import CLIMAParameters as CP
+import CloudMicrophysics as CM
+import CloudMicrophysics.Nucleation as Nucleation
+include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
 
 FT = Float64
-
-toml_dict = CLIMAParameters.create_toml_dict(FT)
-param_names = ["k_H2SO4org", "a_1"]
-params = CLIMAParameters.get_parameter_values!(toml_dict, param_names)
-params = (; params...)
+toml_dict = CP.create_toml_dict(FT)
+params = cloud_microphysics_parameters(toml_dict)
 
 # Units: 1/m³
 bioOxOrg_concentrations = 10 .^ (5.8:0.125:8.5)
 
 nucleation_rates = map(bioOxOrg_concentrations) do bioOxOrg_conc
-    Nucleation.organic_and_h2so4_nucleation_rate(2.6e6, bioOxOrg_conc, params) * 1e6
+    Nucleation.organic_and_h2so4_nucleation_rate_bioOxOrg_prescribed(
+        2.6e6,
+        bioOxOrg_conc,
+        params,
+    ) * 1e6
 end
 
 Plots.plot(xaxis = :log, yaxis = :log, lw = 3)

--- a/docs/src/nucleation_plotting/compare_vehkamaki_CLOUD_nucleation.jl
+++ b/docs/src/nucleation_plotting/compare_vehkamaki_CLOUD_nucleation.jl
@@ -1,8 +1,13 @@
 using Plots
-using CLIMAParameters
 
-include("../../src/Nucleation.jl")
-using .Nucleation
+import CLIMAParameters as CP
+import CloudMicrophysics as CM
+import CloudMicrophysics.Nucleation as Nucleation
+include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
+
+FT = Float64
+toml_dict = CP.create_toml_dict(FT)
+params = cloud_microphysics_parameters(toml_dict)
 
 """
     vehkamaki_nucleation_timestep(rh, temp, so4)
@@ -93,34 +98,6 @@ function vehkamaki_nucleation_timestep(rh, temp, so4)
     return J
 end
 
-FT = Float64
-toml_dict = create_toml_dict(FT)
-param_names = [
-    "u_b_n",
-    "v_b_n",
-    "w_b_n",
-    "u_b_i",
-    "v_b_i",
-    "w_b_i",
-    "u_t_n",
-    "v_t_n",
-    "w_t_n",
-    "u_t_i",
-    "v_t_i",
-    "w_t_i",
-    "p_t_n",
-    "p_A_n",
-    "a_n",
-    "p_t_i",
-    "p_A_i",
-    "a_i",
-    "p_b_n",
-    "p_b_i",
-    "p_t_n",
-    "p_t_i",
-]
-params = CLIMAParameters.get_parameter_values!(toml_dict, param_names)
-params = (; params...)
 
 function plot_vehk_cloud_comparison(humidities, temp, h2so4_concentrations)
     Plots.plot()

--- a/docs/src/nucleation_plotting/lehtinen_apparent_nucleation_rate.jl
+++ b/docs/src/nucleation_plotting/lehtinen_apparent_nucleation_rate.jl
@@ -1,37 +1,6 @@
-import CLIMAParameters as CP
 using Plots
 
-include("../../src/Nucleation.jl")
-using .Nucleation
-
-FT = Float64
-toml_dict = CP.create_toml_dict(FT)
-param_names = [
-    "u_b_n",
-    "v_b_n",
-    "w_b_n",
-    "u_b_i",
-    "v_b_i",
-    "w_b_i",
-    "u_t_n",
-    "v_t_n",
-    "w_t_n",
-    "u_t_i",
-    "v_t_i",
-    "w_t_i",
-    "p_t_n",
-    "p_A_n",
-    "a_n",
-    "p_t_i",
-    "p_A_i",
-    "a_i",
-    "p_b_n",
-    "p_b_i",
-    "p_t_n",
-    "p_t_i",
-]
-params = CP.get_parameter_values!(toml_dict, param_names)
-params = (; params...)
+import CloudMicrophysics.Nucleation as Nucleation
 
 output_diams = 1.7:0.125:10
 coag_sinks = 0.5:0.125:10

--- a/parcel/parcel.jl
+++ b/parcel/parcel.jl
@@ -1,10 +1,10 @@
 import Thermodynamics as TD
 import CloudMicrophysics as CM
 
-const CMT = CM.CommonTypes
-const CMO = CM.Common
-const CMI = CM.HetIceNucleation
-const CMP = CM.Parameters
+import CloudMicrophysics.CommonTypes as CMT
+import CloudMicrophysics.Common as CMO
+import CloudMicrophysics.HetIceNucleation as CMI
+import CloudMicrophysics.Parameters as CMP
 
 include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
 

--- a/src/IceNucleation.jl
+++ b/src/IceNucleation.jl
@@ -53,7 +53,7 @@ function dust_activated_number_fraction(
     T_thr::FT = CMP.T_thr_Mohler2006(prs)
 
     if Si > Si_max
-        @warn "Supersaturation exceedes the allowed value."
+        @warn "Supersaturation exceeds the allowed value."
         @warn "No dust particles will be activated"
         return FT(0)
     else

--- a/test/aerosol_activation_tests.jl
+++ b/test/aerosol_activation_tests.jl
@@ -4,9 +4,9 @@ import CloudMicrophysics as CM
 import CLIMAParameters as CP
 import Thermodynamics as TD
 
-const AM = CM.AerosolModel
-const AA = CM.AerosolActivation
-const CMP = CM.Parameters
+import CloudMicrophysics.AerosolModel as AM
+import CloudMicrophysics.AerosolActivation as AA
+import CloudMicrophysics.Parameters as CMP
 
 include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
 

--- a/test/common_functions_tests.jl
+++ b/test/common_functions_tests.jl
@@ -1,7 +1,7 @@
 import Test as TT
 
 import CloudMicrophysics
-const CO = CloudMicrophysics.Common
+import CloudMicrophysics.Common as CO
 
 import Thermodynamics as TD
 import CLIMAParameters as CP

--- a/test/create_parameters.jl
+++ b/test/create_parameters.jl
@@ -1,4 +1,5 @@
 import CloudMicrophysics as CM
+import CloudMicrophysics.Parameters as CMP
 import CLIMAParameters as CP
 import Thermodynamics as TD
 
@@ -21,50 +22,17 @@ function cloud_microphysics_parameters(toml_dict)
     thermo_params = TD.Parameters.ThermodynamicsParameters{FT}(; pairs...)
     TP = typeof(thermo_params)
 
-    aliases = string.(fieldnames(CM.Parameters.CloudMicrophysicsParameters))
-    aliases = setdiff(aliases, ["thermo_params"])
+    aliases = string.(fieldnames(CMP.ModalNucleationParameters))
     pairs = CP.get_parameter_values!(toml_dict, aliases, "CloudMicrophysics")
-    return CM.Parameters.CloudMicrophysicsParameters{FT, TP}(;
+    modal_nucleation_params = CMP.ModalNucleationParameters{FT}(; pairs...)
+    MNP = typeof(modal_nucleation_params)
+
+    aliases = string.(fieldnames(CMP.CloudMicrophysicsParameters))
+    pairs = CP.get_parameter_values!(toml_dict, aliases, "CloudMicrophysics")
+
+    return CMP.CloudMicrophysicsParameters{FT, TP, MNP}(;
         pairs...,
         thermo_params,
+        modal_nucleation_params,
     )
-end
-
-function nucleation_parameters(toml_dict)
-    nucleation_param_names = (
-        "u_b_n",
-        "v_b_n",
-        "w_b_n",
-        "u_b_i",
-        "v_b_i",
-        "w_b_i",
-        "u_t_n",
-        "v_t_n",
-        "w_t_n",
-        "u_t_i",
-        "v_t_i",
-        "w_t_i",
-        "p_t_n",
-        "p_A_n",
-        "a_n",
-        "p_t_i",
-        "p_A_i",
-        "a_i",
-        "p_b_n",
-        "p_b_i",
-        "a_1",
-        "a_2",
-        "a_3",
-        "a_4",
-        "a_5",
-        "k_H2SO4org",
-        "Y_MTO3",
-        "Y_MTOH",
-        "k_MTO3",
-        "k_MTOH",
-        "exp_MTO3",
-        "exp_MTOH",
-    )
-    params = CP.get_parameter_values!(toml_dict, nucleation_param_names)
-    return (; params...)
 end

--- a/test/heterogeneous_ice_nucleation_tests.jl
+++ b/test/heterogeneous_ice_nucleation_tests.jl
@@ -4,9 +4,9 @@ import Thermodynamics as TD
 import CloudMicrophysics as CM
 import CLIMAParameters as CP
 
-const CMT = CM.CommonTypes
-const CO = CM.Common
-const CMI_het = CM.HetIceNucleation
+import CloudMicrophysics.CommonTypes as CMT
+import CloudMicrophysics.Common as CO
+import CloudMicrophysics.HetIceNucleation as CMI_het
 const ArizonaTestDust = CMT.ArizonaTestDustType()
 const DesertDust = CMT.DesertDustType()
 

--- a/test/homogeneous_ice_nucleation_tests.jl
+++ b/test/homogeneous_ice_nucleation_tests.jl
@@ -4,8 +4,8 @@ import Thermodynamics as TD
 import CloudMicrophysics as CM
 import CLIMAParameters as CP
 
-const CO = CM.Common
-const CMH = CM.HomIceNucleation
+import CloudMicrophysics.Common as CO
+import CloudMicrophysics.HomIceNucleation as CMH
 
 include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
 

--- a/test/microphysics_tests.jl
+++ b/test/microphysics_tests.jl
@@ -4,13 +4,13 @@ import Thermodynamics as TD
 import CloudMicrophysics as CM
 import CLIMAParameters as CP
 
-const CMP = CM.Parameters
-const CMC = CM.Common
-const CMT = CM.CommonTypes
-const CMNe = CM.MicrophysicsNonEq
-const CM0 = CM.Microphysics0M
-const CM1 = CM.Microphysics1M
-const CM2 = CM.Microphysics2M
+import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.Common as CMC
+import CloudMicrophysics.CommonTypes as CMT
+import CloudMicrophysics.MicrophysicsNonEq as CMNe
+import CloudMicrophysics.Microphysics0M as CM0
+import CloudMicrophysics.Microphysics1M as CM1
+import CloudMicrophysics.Microphysics2M as CM2
 
 include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
 

--- a/test/nucleation_unit_tests.jl
+++ b/test/nucleation_unit_tests.jl
@@ -7,7 +7,7 @@ include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
 
 FT = Float64
 toml_dict = CP.create_toml_dict(FT)
-params = nucleation_parameters(toml_dict)
+params = cloud_microphysics_parameters(toml_dict)
 
 @testset "Pure H2SO4 Nucleation Smoke Test" begin
     nh3_conc = 0.0
@@ -44,7 +44,7 @@ end
     negative_ion_conc = 0.0
     test_organic(hom_c) =
         sum(
-            CM.Nucleation.organic_nucleation_rate(
+            CM.Nucleation.organic_nucleation_rate_hom_prescribed(
                 negative_ion_conc,
                 hom_c,
                 params,
@@ -68,7 +68,7 @@ end
 @testset "Mixed Organic and H2SO4 Nucleation Smoke Test" begin
     h2so4_conc = 2.6e6
     test_mixed_nucleation(bioOxOrg) =
-        CM.Nucleation.organic_and_h2so4_nucleation_rate(
+        CM.Nucleation.organic_and_h2so4_nucleation_rate_bioOxOrg_prescribed(
             h2so4_conc,
             bioOxOrg,
             params,

--- a/test/p3_tests.jl
+++ b/test/p3_tests.jl
@@ -1,8 +1,7 @@
 import Test as TT
 import CloudMicrophysics as CM
-
-const P3 = CM.P3Scheme
-const CMP = CM.Parameters
+import CloudMicrophysics.P3Scheme as P3
+import CloudMicrophysics.Parameters as CMP
 
 @info "P3 Scheme Tests"
 

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -5,18 +5,18 @@ import CloudMicrophysics as CM
 import Thermodynamics as TD
 import CLIMAParameters as CP
 
-const CMT = CM.CommonTypes
-const CO = CM.Common
-const AM = CM.AerosolModel
-const AA = CM.AerosolActivation
-const CMI_het = CM.HetIceNucleation
-const CMI_hom = CM.HomIceNucleation
-const CMN = CM.MicrophysicsNonEq
-const CM0 = CM.Microphysics0M
-const CM1 = CM.Microphysics1M
-const CM2 = CM.Microphysics2M
-const HN = CM.Nucleation
-const P3 = CM.P3Scheme
+import CloudMicrophysics.CommonTypes as CMT
+import CloudMicrophysics.Common as CO
+import CloudMicrophysics.AerosolModel as AM
+import CloudMicrophysics.AerosolActivation as AA
+import CloudMicrophysics.HetIceNucleation as CMI_het
+import CloudMicrophysics.HomIceNucleation as CMI_hom
+import CloudMicrophysics.MicrophysicsNonEq as CMN
+import CloudMicrophysics.Microphysics0M as CM0
+import CloudMicrophysics.Microphysics1M as CM1
+import CloudMicrophysics.Microphysics2M as CM2
+import CloudMicrophysics.Nucleation as HN
+import CloudMicrophysics.P3Scheme as P3
 
 include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
 
@@ -47,7 +47,6 @@ function benchmark_test(FT)
 
     toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
     prs = cloud_microphysics_parameters(toml_dict)
-    nucleation_params = nucleation_parameters(toml_dict)
     liquid = CMT.LiquidType()
     rain = CMT.RainType()
     sb2006 = CMT.SB2006Type()
@@ -158,19 +157,15 @@ function benchmark_test(FT)
         1700,
     )
     # Homogeneous Nucleation
-    bench_press(
-        HN.h2so4_nucleation_rate,
-        (1e12, 1.0, 1.0, 208, nucleation_params),
-        470,
-    )
+    bench_press(HN.h2so4_nucleation_rate, (1e12, 1.0, 1.0, 208, prs), 470)
     bench_press(
         HN.organic_nucleation_rate,
-        (0.0, 1e3, 1e3, 1e3, 300, 1, nucleation_params),
+        (0.0, 1e3, 1e3, 1e3, 300, 1, prs),
         550,
     )
     bench_press(
         HN.organic_and_h2so4_nucleation_rate,
-        (2.6e6, 1.0, 1.0, 300, 1, nucleation_params),
+        (2.6e6, 1.0, 1.0, 300, 1, prs),
         120,
     )
 end

--- a/test/precipitation_susceptibility_tests.jl
+++ b/test/precipitation_susceptibility_tests.jl
@@ -2,11 +2,10 @@ import Test as TT
 
 import CloudMicrophysics as CM
 import CLIMAParameters as CP
-
-const CMP = CM.Parameters
-const CMT = CM.CommonTypes
-const CM2 = CM.Microphysics2M
-const CMPS = CM.PrecipitationSusceptibility
+import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.CommonTypes as CMT
+import CloudMicrophysics.Microphysics2M as CM2
+import CloudMicrophysics.PrecipitationSusceptibility as CMPS
 
 include(joinpath(pkgdir(CM), "test", "create_parameters.jl"))
 


### PR DESCRIPTION
## Content
- Updates CloudMicrophysicsParameters to include a ModalNucleationParameters struct, update machinery to generate functions for parameters
- Updates nucleation functions to match the struct. Changes a few function names where values are explicitly given (mostly for testing)
- Update unit and GPU perf tests
- Update docs
- Update from `const CMP = CM.Parameters` to using `import CloudMicrophysics.Parameters as CMP` for all submodules

closes #192 
