### PR TITLE
add auto-conversion rate with time scale depending on number density

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.13.2"
+version = "0.13.3"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
@@ -13,7 +13,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
-CLIMAParameters = "0.7.14"
+CLIMAParameters = "0.7.15"
 DocStringExtensions = "0.8, 0.9"
 ForwardDiff = "0.10"
 KernelAbstractions = "0.8, 0.9"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -10,4 +10,4 @@ Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
-CLIMAParameters = "0.7.12"
+CLIMAParameters = "0.7.15"

--- a/docs/src/Microphysics2M.md
+++ b/docs/src/Microphysics2M.md
@@ -750,8 +750,8 @@ ax4.ylabel = "accretion rate [1/s]"
 
 Legend(
     fig[1, 3],
-    [l1, l2, l3, l4, l26, l5, l6, l7, l8, l9],
-    ["KK2000", "B1994", "TC1980", "LD2004", "SB2006", "K1969", "Wood_KK2000", "Wood_B1994", "Wood_TC1980", "Wood_LD2004"]
+    [l1, l2, l3, l4, l26, l5, l6, l7, l8, l9, l29],
+    ["KK2000", "B1994", "TC1980", "LD2004", "SB2006", "K1969", "Wood_KK2000", "Wood_B1994", "Wood_TC1980", "Wood_LD2004", "SA2023"]
 )
 save("Autoconversion_accretion.svg", fig)
 ```

--- a/docs/src/Microphysics2M.md
+++ b/docs/src/Microphysics2M.md
@@ -542,6 +542,26 @@ Then the ``R_6`` and ``R_{6C}`` are defined as
 |``R_{C0}``  | ``7.5 ``                  |
 |``E_0``     | ``1.08 \times 10^{10}``   |
 
+#### Auto-conversion with time scale depending on number density
+
+```math
+\begin{equation}
+  \left. \frac{d \, q_{rai}}{dt} \right|_{acnv} =
+    \frac{q_{liq}}{\tau_{acnv,\, 0} \left(\frac{N_d}{100\, cm^{-3}}\right)^{\alpha_{acnv}}}
+\end{equation}
+```
+where:
+  - ``q_{liq}`` is the cloud liquid water specific humidity,
+  - ``N_d`` is the cloud droplet number concentration,
+  - ``\tau_{acnv,\, 0}`` is the auto-conversion time scale at ``N_d = 100 cm^{-3}``.
+
+The default free parameter values are:
+
+|   symbol             | default value             |
+|----------------------|---------------------------|
+|``\tau_{acnv,\, 0}``  | ``1000\ s``               |
+|``\alpha_{acnv}``     | ``1``                     |
+
 ### Accretion
 
 #### Khairoutdinov and Kogan (2000)
@@ -630,6 +650,7 @@ const KK2000 = CMT.KK2000Type()
 const B1994  = CMT.B1994Type()
 const TC1980 = CMT.TC1980Type()
 const LD2004 = CMT.LD2004Type()
+const VarTimeScaleAcnv = CMT.VarTimeScaleAcnvType()
 const SB2006 = CMT.SB2006Type()
 
 include(joinpath(pkgdir(CloudMicrophysics), "docs", "src", "Wooddata.jl"))
@@ -646,6 +667,7 @@ q_liq_KK2000 = [CM2.conv_q_liq_to_q_rai(param_set, KK2000, q_liq, ρ_air, N_d = 
 q_liq_B1994 = [CM2.conv_q_liq_to_q_rai(param_set, B1994, q_liq, ρ_air, N_d = 1e8) for q_liq in q_liq_range]
 q_liq_TC1980 = [CM2.conv_q_liq_to_q_rai(param_set, TC1980, q_liq, ρ_air, N_d = 1e8) for q_liq in q_liq_range]
 q_liq_LD2004 = [CM2.conv_q_liq_to_q_rai(param_set, LD2004, q_liq, ρ_air, N_d = 1e8) for q_liq in q_liq_range]
+q_liq_VarTimeScaleAcnv = [CM2.conv_q_liq_to_q_rai(param_set, VarTimeScaleAcnv, q_liq, ρ_air, N_d = 1e8) for q_liq in q_liq_range]
 q_liq_SB2006 = [CM2.autoconversion(param_set, SB2006, q_liq, q_rai, ρ_air, 1e8).dq_rai_dt for q_liq in q_liq_range]
 q_liq_K1969 = [CM1.conv_q_liq_to_q_rai(param_set, q_liq) for q_liq in q_liq_range]
 
@@ -653,6 +675,7 @@ N_d_KK2000 = [CM2.conv_q_liq_to_q_rai(param_set, KK2000, 5e-4, ρ_air, N_d = N_d
 N_d_B1994 = [CM2.conv_q_liq_to_q_rai(param_set, B1994, 5e-4, ρ_air, N_d = N_d) for N_d in N_d_range]
 N_d_TC1980 = [CM2.conv_q_liq_to_q_rai(param_set, TC1980, 5e-4, ρ_air, N_d = N_d) for N_d in N_d_range]
 N_d_LD2004 = [CM2.conv_q_liq_to_q_rai(param_set, LD2004, 5e-4, ρ_air, N_d = N_d) for N_d in N_d_range]
+N_d_VarTimeScaleAcnv = [CM2.conv_q_liq_to_q_rai(param_set, VarTimeScaleAcnv, 5e-4, ρ_air, N_d = N_d) for N_d in N_d_range]
 N_d_SB2006 = [CM2.autoconversion(param_set, SB2006, q_liq, q_rai, ρ_air, N_d).dq_rai_dt for N_d in N_d_range]
 
 accKK2000_q_liq = [CM2.accretion(param_set, KK2000, q_liq, q_rai, ρ_air) for q_liq in q_liq_range]
@@ -712,6 +735,9 @@ l26 = lines!(ax1, q_liq_range * 1e3, q_liq_SB2006,    color = :cyan)
 l27 = lines!(ax2, N_d_range * 1e-6, N_d_SB2006,    color = :cyan)
 l28 = lines!(ax3, q_liq_range * 1e3, accSB2006_q_liq,    color = :cyan)
 l28 = lines!(ax4, q_rai_range * 1e3, accSB2006_q_rai,    color = :cyan)
+
+l29 = lines!(ax1, q_liq_range * 1e3, q_liq_VarTimeScaleAcnv,    color = :orange)
+l30 = lines!(ax2, N_d_range * 1e-6, N_d_VarTimeScaleAcnv,    color = :orange)
 
 ax1.xlabel = "q_liq [g/kg]"
 ax1.ylabel = "autoconversion rate [1/s]"

--- a/src/CommonTypes.jl
+++ b/src/CommonTypes.jl
@@ -125,6 +125,14 @@ struct LD2004Type <: Abstract2MPrecipType end
 Base.broadcastable(x::LD2004Type) = tuple(x)
 
 """
+    VarTimeScaleAcnvType
+
+The type for 2-moment precipitation formation based on the 1-moment parameterization
+"""
+struct VarTimeScaleAcnvType <: Abstract2MPrecipType end
+Base.broadcastable(x::VarTimeScaleAcnvType) = tuple(x)
+
+"""
     SB2006Type
 
 The type for 2-moment precipitation formation by Seifert and Beheng (2006)

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -649,6 +649,21 @@ function conv_q_liq_to_q_rai(
         return E * (q_liq * ρ)^3 / N_d / ρ * _output
     end
 end
+function conv_q_liq_to_q_rai(
+    param_set::APS,
+    scheme::CT.VarTimeScaleAcnvType,
+    q_liq::FT,
+    ρ::FT;
+    N_d::FT = FT(1e8),
+) where {FT <: Real}
+
+    q_liq = max(0, q_liq)
+
+    _τ_acnv_0::FT = CMP.τ_acnv_rai(param_set)
+    _α_acnv::FT = CMP.α_var_time_scale_acnv(param_set)
+
+    return max(0, q_liq) / (_τ_acnv_0 * (N_d / 1e8)^_α_acnv)
+end
 
 """
     accretion(param_set, scheme, q_liq, q_rai, ρ)

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -102,6 +102,7 @@ Base.@kwdef struct CloudMicrophysicsParameters{FT, TP, MNP} <:
     b_acc_KK2000::FT
     R_6C_coeff_LD2004::FT
     E_0_LD2004::FT
+    α_var_time_scale_acnv::FT
     k_thrshld_stpnss::FT
     kcc_SB2006::FT
     kcr_SB2006::FT

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -11,4 +11,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
-CLIMAParameters = "0.7.12"
+CLIMAParameters = "0.7.15"

--- a/test/common_types_tests.jl
+++ b/test/common_types_tests.jl
@@ -17,6 +17,7 @@ function test_common_types_broadcasts()
         CMT.B1994Type,
         CMT.TC1980Type,
         CMT.LD2004Type,
+        CMT.VarTimeScaleAcnvType,
         CMT.SB2006Type,
         CMT.AbstractTerminalVelocityType,
         CMT.Blk1MVelType,

--- a/test/microphysics_tests.jl
+++ b/test/microphysics_tests.jl
@@ -23,6 +23,7 @@ const KK2000 = CMT.KK2000Type()
 const B1994 = CMT.B1994Type()
 const TC1980 = CMT.TC1980Type()
 const LD2004 = CMT.LD2004Type()
+const VarTimeScaleAcnv = CMT.VarTimeScaleAcnvType()
 const Blk1MVel = CMT.Blk1MVelType()
 const SB2006Vel = CMT.SB2006VelType()
 const Ch2022 = CMT.Chen2022Type()
@@ -480,6 +481,7 @@ function test_microphysics(FT)
         # no reference data available - checking if callable and not NaN
         q_liq = FT(0.5e-3)
         q_rai = FT(1e-6)
+        TT.@test CM2.conv_q_liq_to_q_rai(prs, VarTimeScaleAcnv, q_liq, ρ) != NaN
         TT.@test CM2.accretion(prs, KK2000, q_liq, q_rai, ρ) != NaN
         TT.@test CM2.accretion(prs, B1994, q_liq, q_rai, ρ) != NaN
         TT.@test CM2.accretion(prs, TC1980, q_liq, q_rai) != NaN
@@ -492,6 +494,8 @@ function test_microphysics(FT)
         TT.@test CM2.conv_q_liq_to_q_rai(prs, B1994, q_liq, ρ) == FT(0)
         TT.@test CM2.conv_q_liq_to_q_rai(prs, TC1980, q_liq, ρ) == FT(0)
         TT.@test CM2.conv_q_liq_to_q_rai(prs, LD2004, q_liq, ρ) == FT(0)
+        TT.@test CM2.conv_q_liq_to_q_rai(prs, VarTimeScaleAcnv, q_liq, ρ) ==
+                 FT(0)
         TT.@test CM2.accretion(prs, KK2000, q_liq, q_rai, ρ) == FT(0)
         TT.@test CM2.accretion(prs, B1994, q_liq, q_rai, ρ) == FT(0)
         TT.@test CM2.accretion(prs, TC1980, q_liq, q_rai) == FT(0)

--- a/test/microphysics_tests.jl
+++ b/test/microphysics_tests.jl
@@ -505,6 +505,20 @@ function test_microphysics(FT)
         TT.@test CM2.accretion(prs, B1994, q_liq, q_rai, ρ) == FT(0)
         TT.@test CM2.accretion(prs, TC1980, q_liq, q_rai) == FT(0)
 
+        TT.@test CM2.conv_q_liq_to_q_rai(
+            prs,
+            VarTimeScaleAcnv,
+            q_liq,
+            ρ,
+            N_d = FT(1e8),
+        ) > CM2.conv_q_liq_to_q_rai(
+            prs,
+            VarTimeScaleAcnv,
+            q_liq,
+            ρ,
+            N_d = FT(1e9),
+        )
+
         # far from threshold points, autoconversion with and without smooth transition should
         # be approximately equal
         q_liq = FT(0.5e-3)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
add auto-conversion rate with time scale depending on number density

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.
- I have read and checked the items on the review checklist.
