### PR TITLE
add 2-moment GPU tests

### DIFF
--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -308,7 +308,7 @@ function rain_breakup(
 end
 
 """
-    rain_sef_collection_and_breakup(selfcollection, breakup, tv, q_rai, ρ, N_rai)
+    rain_self_collection_and_breakup(selfcollection, breakup, tv, q_rai, ρ, N_rai)
 
  - `selfcollection` - 2-moment liquid self-collection parameterization
  - `breakup` - breakup parameterization


### PR DESCRIPTION
Currently the rain_evaporation test breaks on the GPU. I'm suspecting the gamma function, but I don't have a proof:

```
Reason: unsupported dynamic function invocation (call to +)
--
  | Stacktrace:
  | [1] En_expand_origin_general
  | @ /central/scratch/esm/slurm-buildkite/cloudmicrophysics-ci/207/depot/gpu/packages/SpecialFunctions/QH8rV/src/expint.jl:322
  | [2] En_expand_origin
  | @ /central/scratch/esm/slurm-buildkite/cloudmicrophysics-ci/207/depot/gpu/packages/SpecialFunctions/QH8rV/src/expint.jl:375
  | [3] _expint
  | @ /central/scratch/esm/slurm-buildkite/cloudmicrophysics-ci/207/depot/gpu/packages/SpecialFunctions/QH8rV/src/expint.jl:431
  | [4] expint (repeats 2 times)
  | @ /central/scratch/esm/slurm-buildkite/cloudmicrophysics-ci/207/depot/gpu/packages/SpecialFunctions/QH8rV/src/expint.jl:516
  | [5] _gamma
  | @ /central/scratch/esm/slurm-buildkite/cloudmicrophysics-ci/207/depot/gpu/packages/SpecialFunctions/QH8rV/src/gamma_inc.jl:1137
  | [6] gamma
  | @ /central/scratch/esm/slurm-buildkite/cloudmicrophysics-ci/207/depot/gpu/packages/SpecialFunctions/QH8rV/src/gamma_inc.jl:1115
  | [7] rain_evaporation
  | @ /central/scratch/esm/slurm-buildkite/cloudmicrophysics-ci/207/cloudmicrophysics-ci/src/Microphysics2M.jl:442
```

I tested it locally on the CPU and it seems that the function is type stable (at least for me)

```
julia> using JET

julia> @test_opt CM2.rain_evaporation(evpSB2006, air_props, thermo_params, q, qr, ρ, Nr, T)
Test Passed
```