### PR TITLE
Update VariableTimescale autoconversion rate to the new parameters

### DIFF
--- a/docs/src/Microphysics2M.md
+++ b/docs/src/Microphysics2M.md
@@ -650,13 +650,13 @@ const KK2000 = CMT.KK2000Type()
 const B1994  = CMT.B1994Type()
 const TC1980 = CMT.TC1980Type()
 const LD2004 = CMT.LD2004Type()
-const VarTimeScaleAcnv = CMT.VarTimeScaleAcnvType()
 const SB2006 = CMT.SB2006Type()
 const acnv_SB2006 = CMT.AutoconversionSB2006(FT)
 const acnv_KK2000 = CMT.AutoconversionKK2000(FT)
 const acnv_B1994 = CMT.AutoconversionB1994(FT)
 const acnv_TC1980 = CMT.AutoconversionTC1980(FT)
 const acnv_LD2004 = CMT.AutoconversionLD2004(FT)
+const acnv_TSc = CMT.AutoconversionVarTimescale(FT)
 const rain_acnv_1m = CMT.Autoconversion1M(FT, rain)
 const accretion_KK2000 = CMT.AccretionKK2000(FT)
 const accretion_B1994 = CMT.AccretionB1994(FT)
@@ -679,7 +679,7 @@ q_liq_KK2000 = [CM2.conv_q_liq_to_q_rai(acnv_KK2000, q_liq, ρ_air, N_d = 1e8) f
 q_liq_B1994 = [CM2.conv_q_liq_to_q_rai(acnv_B1994, q_liq, ρ_air, N_d = 1e8) for q_liq in q_liq_range]
 q_liq_TC1980 = [CM2.conv_q_liq_to_q_rai(acnv_TC1980, q_liq, ρ_air, N_d = 1e8) for q_liq in q_liq_range]
 q_liq_LD2004 = [CM2.conv_q_liq_to_q_rai(acnv_LD2004, q_liq, ρ_air, N_d = 1e8) for q_liq in q_liq_range]
-q_liq_VarTimeScaleAcnv = [CM2.conv_q_liq_to_q_rai(param_set, VarTimeScaleAcnv, q_liq, ρ_air, N_d = 1e8) for q_liq in q_liq_range]
+q_liq_VarTimeScaleAcnv = [CM2.conv_q_liq_to_q_rai(acnv_TSc, q_liq, ρ_air, N_d = 1e8) for q_liq in q_liq_range]
 q_liq_SB2006 = [CM2.autoconversion(acnv_SB2006, q_liq, q_rai, ρ_air, 1e8).dq_rai_dt for q_liq in q_liq_range]
 q_liq_K1969 = [CM1.conv_q_liq_to_q_rai(rain_acnv_1m, q_liq) for q_liq in q_liq_range]
 
@@ -687,7 +687,7 @@ N_d_KK2000 = [CM2.conv_q_liq_to_q_rai(acnv_KK2000, 5e-4, ρ_air, N_d = N_d) for 
 N_d_B1994 = [CM2.conv_q_liq_to_q_rai(acnv_B1994, 5e-4, ρ_air, N_d = N_d) for N_d in N_d_range]
 N_d_TC1980 = [CM2.conv_q_liq_to_q_rai(acnv_TC1980, 5e-4, ρ_air, N_d = N_d) for N_d in N_d_range]
 N_d_LD2004 = [CM2.conv_q_liq_to_q_rai(acnv_LD2004, 5e-4, ρ_air, N_d = N_d) for N_d in N_d_range]
-N_d_VarTimeScaleAcnv = [CM2.conv_q_liq_to_q_rai(param_set, VarTimeScaleAcnv, 5e-4, ρ_air, N_d = N_d) for N_d in N_d_range]
+N_d_VarTimeScaleAcnv = [CM2.conv_q_liq_to_q_rai(acnv_TSc, 5e-4, ρ_air, N_d = N_d) for N_d in N_d_range]
 N_d_SB2006 = [CM2.autoconversion(acnv_SB2006, q_liq, q_rai, ρ_air, N_d).dq_rai_dt for N_d in N_d_range]
 
 accKK2000_q_liq = [CM2.accretion(accretion_KK2000, q_liq, q_rai, ρ_air) for q_liq in q_liq_range]

--- a/src/CommonTypes.jl
+++ b/src/CommonTypes.jl
@@ -441,6 +441,21 @@ function AutoconversionB1994(
     )
 end
 
+struct AutoconversionVarTimescale{FT}
+    τ::FT
+    α::FT
+end
+
+function AutoconversionVarTimescale(
+    ::Type{FT};
+    toml_dict = CP.create_toml_dict(FT),
+) where {FT}
+    (; data) = toml_dict
+    τ = FT(data["rain_autoconversion_timescale"]["value"])
+    α = FT(data["Variable_time_scale_autoconversion_coeff_alpha"]["value"])
+    return AutoconversionVarTimescale(τ, α)
+end
+
 struct AccretionTC1980{FT}
     A::FT
 end

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -563,19 +563,12 @@ function conv_q_liq_to_q_rai(
     end
 end
 function conv_q_liq_to_q_rai(
-    param_set::APS,
-    scheme::CT.VarTimeScaleAcnvType,
+    (; τ, α)::CT.AutoconversionVarTimescale{FT},
     q_liq::FT,
     ρ::FT;
     N_d::FT = FT(1e8),
 ) where {FT <: Real}
-
-    q_liq = max(0, q_liq)
-
-    _τ_acnv_0::FT = CMP.τ_acnv_rai(param_set)
-    _α_acnv::FT = CMP.α_var_time_scale_acnv(param_set)
-
-    return max(0, q_liq) / (_τ_acnv_0 * (N_d / 1e8)^_α_acnv)
+    return max(0, q_liq) / (τ * (N_d / 1e8)^α)
 end
 
 """

--- a/test/gpu_tests.jl
+++ b/test/gpu_tests.jl
@@ -218,7 +218,7 @@ end
 
     @inbounds begin
         output[1, i] =
-            CM2.conv_q_liq_to_q_rai(prs, acnvVarT, ql[i], ρ[i], N_d = Nd[i])
+            CM2.conv_q_liq_to_q_rai(acnvVarT, ql[i], ρ[i], N_d = Nd[i])
         output[2, i] =
             CM2.conv_q_liq_to_q_rai(acnvLD2004, ql[i], ρ[i], N_d = Nd[i])
         output[3, i] =
@@ -701,7 +701,7 @@ function test_gpu(FT)
     acnvB1994 = CMT.AutoconversionB1994(FT)
     acnvTC1980 = CMT.AutoconversionTC1980(FT)
     acnvLD2004 = CMT.AutoconversionLD2004(FT)
-    acnvVarT = CMT.VarTimeScaleAcnvType()
+    acnvVarT = CMT.AutoconversionVarTimescale(FT)
     accKK2000 = CMT.AccretionKK2000(FT)
     accB1994 = CMT.AccretionB1994(FT)
     accTC1980 = CMT.AccretionTC1980(FT)

--- a/test/microphysics_tests.jl
+++ b/test/microphysics_tests.jl
@@ -20,7 +20,6 @@ const KK2000 = CMT.KK2000Type()
 const B1994 = CMT.B1994Type()
 const TC1980 = CMT.TC1980Type()
 const LD2004 = CMT.LD2004Type()
-const VarTimeScaleAcnv = CMT.VarTimeScaleAcnvType()
 const SB2006Vel = CMT.SB2006VelType()
 
 @info "Microphysics Tests"
@@ -48,6 +47,7 @@ function test_microphysics(FT)
     acnv_B1994 = CMT.AutoconversionB1994(FT)
     acnv_TC1980 = CMT.AutoconversionTC1980(FT)
     acnv_LD2004 = CMT.AutoconversionLD2004(FT)
+    acnv_VarTSc = CMT.AutoconversionVarTimescale(FT)
     evap_SB2006 = CMT.EvaporationSB2006(FT)
     breakup_SB2006 = CMT.BreakupSB2006(FT)
     selfcollection_SB2006 = CMT.SelfCollectionSB2006(FT)
@@ -568,12 +568,13 @@ function test_microphysics(FT)
         TT.@test CM2.accretion(accretion_KK2000, q_liq, q_rai, ρ) != NaN
         TT.@test CM2.accretion(accretion_B1994, q_liq, q_rai, ρ) != NaN
         TT.@test CM2.accretion(accretion_TC1980, q_liq, q_rai) != NaN
-        TT.@test CM2.conv_q_liq_to_q_rai(prs, VarTimeScaleAcnv, q_liq, ρ) != NaN
+        TT.@test CM2.conv_q_liq_to_q_rai(acnv_VarTSc, q_liq, ρ) != NaN
 
         # output should be zero if either q_liq or q_rai are zero
         q_liq = FT(0)
         q_rai = FT(1e-6)
 
+        TT.@test CM2.conv_q_liq_to_q_rai(acnv_VarTSc, q_liq, ρ) == FT(0)
         TT.@test CM2.conv_q_liq_to_q_rai(acnv_KK2000, q_liq, ρ) == FT(0)
         TT.@test CM2.conv_q_liq_to_q_rai(acnv_B1994, q_liq, ρ) == FT(0)
         TT.@test CM2.conv_q_liq_to_q_rai(acnv_TC1980, q_liq, ρ) == FT(0)
@@ -581,8 +582,6 @@ function test_microphysics(FT)
         TT.@test CM2.accretion(accretion_KK2000, q_liq, q_rai, ρ) == FT(0)
         TT.@test CM2.accretion(accretion_B1994, q_liq, q_rai, ρ) == FT(0)
         TT.@test CM2.accretion(accretion_TC1980, q_liq, q_rai) == FT(0)
-        TT.@test CM2.conv_q_liq_to_q_rai(prs, VarTimeScaleAcnv, q_liq, ρ) ==
-                 FT(0)
 
         q_liq = FT(0.5e-3)
         q_rai = FT(0)
@@ -590,19 +589,8 @@ function test_microphysics(FT)
         TT.@test CM2.accretion(accretion_B1994, q_liq, q_rai, ρ) == FT(0)
         TT.@test CM2.accretion(accretion_TC1980, q_liq, q_rai) == FT(0)
 
-        TT.@test CM2.conv_q_liq_to_q_rai(
-            prs,
-            VarTimeScaleAcnv,
-            q_liq,
-            ρ,
-            N_d = FT(1e8),
-        ) > CM2.conv_q_liq_to_q_rai(
-            prs,
-            VarTimeScaleAcnv,
-            q_liq,
-            ρ,
-            N_d = FT(1e9),
-        )
+        TT.@test CM2.conv_q_liq_to_q_rai(acnv_VarTSc, q_liq, ρ, N_d = FT(1e8)) >
+                 CM2.conv_q_liq_to_q_rai(acnv_VarTSc, q_liq, ρ, N_d = FT(1e9))
 
         # far from threshold points, autoconversion with and without smooth transition should
         # be approximately equal


### PR DESCRIPTION
@nefrathenrici - Could you help me figure out why the aqua test is failing?

```
  Expression: length(ambs) ≤ 0
   Evaluated: 1 ≤ 0
```