### PR TITLE
more cleanup

### DIFF
--- a/src/AerosolModel.jl
+++ b/src/AerosolModel.jl
@@ -43,7 +43,8 @@ struct Mode_B{NCOMP, T, FT}
     "tuple of aerosol densities for all components in this mode"
     aerosol_density::T
 end
-@inline Mode_B(
+
+function Mode_B(
     r_dry::FT,
     stdev::FT,
     N::FT,
@@ -54,21 +55,22 @@ end
     dissoc::T,
     aerosol_density::T,
     NCOMP::Int,
-) where {T, FT} = Mode_B{NCOMP, T, FT}(
-    r_dry,
-    stdev,
-    N,
-    mass_mix_ratio,
-    soluble_mass_frac,
-    osmotic_coeff,
-    molar_mass,
-    dissoc,
-    aerosol_density,
-)
+) where {T, FT}
+    return Mode_B{NCOMP, T, FT}(
+        r_dry,
+        stdev,
+        N,
+        mass_mix_ratio,
+        soluble_mass_frac,
+        osmotic_coeff,
+        molar_mass,
+        dissoc,
+        aerosol_density,
+    )
+end
 
 """ number of components in the mode """
 n_components(::Mode_B{NCOMP}) where {NCOMP} = NCOMP
-
 
 """
     Mode_κ
@@ -96,7 +98,8 @@ struct Mode_κ{NCOMP, T, FT}
     "tuple of kappa-kohler values for all components in this mode"
     kappa::T
 end
-@inline Mode_κ(
+
+function Mode_κ(
     r_dry::FT,
     stdev::FT,
     N::FT,
@@ -105,15 +108,17 @@ end
     molar_mass::T,
     kappa::T,
     NCOMP::Int,
-) where {T, FT} = Mode_κ{NCOMP, T, FT}(
-    r_dry,
-    stdev,
-    N,
-    vol_mix_ratio,
-    mass_mix_ratio,
-    molar_mass,
-    kappa,
-)
+) where {T, FT}
+    return Mode_κ{NCOMP, T, FT}(
+        r_dry,
+        stdev,
+        N,
+        vol_mix_ratio,
+        mass_mix_ratio,
+        molar_mass,
+        kappa,
+    )
+end
 
 """ number of components in the mode """
 n_components(::Mode_κ{NCOMP}) where {NCOMP} = NCOMP
@@ -134,10 +139,9 @@ struct AerosolDistribution{T} <: CMP.AerosolDistributionType
     "tuple with all aerosol size distribution modes"
     Modes::T
 
-    function AerosolDistribution(Modes::NTuple{N, T}) where {N, T}
-        return new{typeof(Modes)}(Modes)
-    end
-
+end
+function AerosolDistribution(Modes::NTuple{N, T}) where {N, T}
+    return AerosolDistribution{typeof(Modes)}(Modes)
 end
 Base.broadcastable(x::AerosolDistribution) = tuple(x)
 n_modes(::AerosolDistribution{NTuple{N, T}}) where {N, T} = N

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -31,15 +31,15 @@ export autoconversion,
 A structure containing the rates of change of the specific humidities and number
 densities of liquid and rain water.
 """
-Base.@kwdef struct LiqRaiRates{FT}
+@kwdef struct LiqRaiRates{FT}
     "Rate of change of the liquid water specific humidity"
-    dq_liq_dt::FT
+    dq_liq_dt::FT = FT(0)
     "Rate of change of the liquid water number density"
-    dN_liq_dt::FT
+    dN_liq_dt::FT = FT(0)
     "Rate of change of the rain water specific humidity"
-    dq_rai_dt::FT
+    dq_rai_dt::FT = FT(0)
     "Rate of change of the rain water number density"
-    dN_rai_dt::FT
+    dN_rai_dt::FT = FT(0)
 end
 
 # Double-moment bulk microphysics autoconversion, accretion, self-collection, breakup,
@@ -95,12 +95,7 @@ function autoconversion(
 ) where {FT}
 
     if q_liq < eps(FT)
-        return LiqRaiRates(
-            dq_liq_dt = FT(0),
-            dN_liq_dt = FT(0),
-            dq_rai_dt = FT(0),
-            dN_rai_dt = FT(0),
-        )
+        return LiqRaiRates{FT}()
     end
 
     (; kcc, νc, x_star, ρ0, A, a, b) = acnv
@@ -144,12 +139,7 @@ collisions between raindrops and cloud droplets (accretion) for `scheme == SB200
 function accretion((; accr)::CMP.SB2006{FT}, q_liq, q_rai, ρ, N_liq) where {FT}
 
     if q_liq < eps(FT) || q_rai < eps(FT)
-        return LiqRaiRates(
-            dq_liq_dt = zero(q_liq),
-            dN_liq_dt = zero(N_liq),
-            dq_rai_dt = zero(q_rai),
-            dN_rai_dt = zero(N_liq),
-        )
+        return LiqRaiRates{FT}()
     end
 
     (; kcr, τ0, ρ0, c) = accr

--- a/src/PrecipitationSusceptibility.jl
+++ b/src/PrecipitationSusceptibility.jl
@@ -13,11 +13,11 @@ A structure containing the logarithmic derivatives of the production of
 precipitation with respect to the specific humidities and number
 densities of liquid and rain water.
 """
-Base.@kwdef struct precip_susceptibility_rates{FT}
-    d_ln_pp_d_ln_q_liq::FT
-    d_ln_pp_d_ln_q_rai::FT
-    d_ln_pp_d_ln_N_liq::FT
-    d_ln_pp_d_ln_N_rai::FT
+@kwdef struct precip_susceptibility_rates{FT}
+    d_ln_pp_d_ln_q_liq::FT = FT(0)
+    d_ln_pp_d_ln_q_rai::FT = FT(0)
+    d_ln_pp_d_ln_N_liq::FT = FT(0)
+    d_ln_pp_d_ln_N_rai::FT = FT(0)
 end
 
 """

--- a/src/parameters/AerosolModalNucleation.jl
+++ b/src/parameters/AerosolModalNucleation.jl
@@ -10,7 +10,7 @@ DOI:10.1126/science.aaf2649
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-Base.@kwdef struct H2S04NucleationParameters{FT} <: ParametersType{FT}
+struct H2S04NucleationParameters{FT} <: ParametersType{FT}
     p_b_n::FT
     p_b_i::FT
     u_b_n::FT
@@ -33,6 +33,35 @@ Base.@kwdef struct H2S04NucleationParameters{FT} <: ParametersType{FT}
     a_i::FT
 end
 
+function H2S04NucleationParameters(
+    ::Type{FT},
+    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
+) where {FT}
+    (; data) = toml_dict
+    return H2S04NucleationParameters(
+        FT(data["mam3_nucleation_p_b_n_neutral"]["value"]),
+        FT(data["mam3_nucleation_p_b_i_ion_induced"]["value"]),
+        FT(data["mam3_nucleation_u_b_n_neutral"]["value"]),
+        FT(data["mam3_nucleation_u_b_i_ion_induced"]["value"]),
+        FT(data["mam3_nucleation_v_b_n_neutral"]["value"]),
+        FT(data["mam3_nucleation_v_b_i_ion_induced"]["value"]),
+        FT(data["mam3_nucleation_w_b_n_neutral"]["value"]),
+        FT(data["mam3_nucleation_w_b_i_ion_induced"]["value"]),
+        FT(data["mam3_nucleation_p_t_n_neutral"]["value"]),
+        FT(data["mam3_nucleation_p_t_i_ion_induced"]["value"]),
+        FT(data["mam3_nucleation_u_t_n_neutral"]["value"]),
+        FT(data["mam3_nucleation_u_t_i_ion_induced"]["value"]),
+        FT(data["mam3_nucleation_v_t_n_neutral"]["value"]),
+        FT(data["mam3_nucleation_v_t_i_ion_induced"]["value"]),
+        FT(data["mam3_nucleation_w_t_n_neutral"]["value"]),
+        FT(data["mam3_nucleation_w_t_i_ion_induced"]["value"]),
+        FT(data["mam3_nucleation_p_A_n_neutral"]["value"]),
+        FT(data["mam3_nucleation_p_A_i_ion_induced"]["value"]),
+        FT(data["mam3_nucleation_a_n_neutral"]["value"]),
+        FT(data["mam3_nucleation_a_i_ion_induced"]["value"]),
+    )
+end
+
 """
 OrganicNucleationParameters{FT}
 
@@ -42,7 +71,7 @@ DOI: 10.1038/nature17953
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-Base.@kwdef struct OrganicNucleationParameters{FT} <: ParametersType{FT}
+struct OrganicNucleationParameters{FT} <: ParametersType{FT}
     a_1::FT
     a_2::FT
     a_3::FT
@@ -56,6 +85,26 @@ Base.@kwdef struct OrganicNucleationParameters{FT} <: ParametersType{FT}
     exp_MTOH::FT
 end
 
+function OrganicNucleationParameters(
+    ::Type{FT},
+    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
+) where {FT}
+    (; data) = toml_dict
+    return OrganicNucleationParameters(
+        FT(data["mam3_nucleation_a_1_neutral"]["value"]),
+        FT(data["mam3_nucleation_a_2_neutral"]["value"]),
+        FT(data["mam3_nucleation_a_3_ion_induced"]["value"]),
+        FT(data["mam3_nucleation_a_4_ion_induced"]["value"]),
+        FT(data["mam3_nucleation_a_5"]["value"]),
+        FT(data["mam3_nucleation_Y_MTO3_percent"]["value"]),
+        FT(data["mam3_nucleation_Y_MTOH_percent"]["value"]),
+        FT(data["mam3_nucleation_k_MTO3_organic_factor"]["value"]),
+        FT(data["mam3_nucleation_k_MTOH_organic_factor"]["value"]),
+        FT(data["mam3_nucleation_exp_MTO3_organic_factor"]["value"]),
+        FT(data["mam3_nucleation_exp_MTOH_organic_factor"]["value"]),
+    )
+end
+
 """
 MixedNucleationParameters{FT}
 
@@ -65,23 +114,22 @@ DOI:10.1126/science.1243527
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-Base.@kwdef struct MixedNucleationParameters{FT} <: ParametersType{FT}
+struct MixedNucleationParameters{FT} <: ParametersType{FT}
     k_H2SO4org::FT
     k_MTOH::FT
     exp_MTOH::FT
 end
 
-for var in [
-    :H2S04NucleationParameters,
-    :OrganicNucleationParameters,
-    :MixedNucleationParameters,
-]
-    @eval function $var(
-        ::Type{FT},
-        toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-    ) where {FT}
-        aliases = string.(fieldnames($var))
-        pairs = CP.get_parameter_values!(toml_dict, aliases)
-        return $var{FT}(; pairs...)
-    end
+function MixedNucleationParameters(
+    ::Type{FT},
+    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
+) where {FT}
+    (; data) = toml_dict
+    return MixedNucleationParameters(
+        FT(
+            data["mam3_nucleation_k_H2SO4_mixed_organic_sulfuric_acid_factor"]["value"],
+        ),
+        FT(data["mam3_nucleation_k_MTOH_organic_factor"]["value"]),
+        FT(data["mam3_nucleation_exp_MTOH_organic_factor"]["value"]),
+    )
 end


### PR DESCRIPTION
This PR:
- removes `kwdef` from modal aerosol nucleation parameters
- removes inline from aerosol model
- replaces inner constructor with outer constructor for aerosol model