### PR TITLE
Update to Julia 1.10

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,14 +1,15 @@
 agents:
   queue: central
   slurm_mem: 8G
-  modules: julia/1.9.3 cuda/11.8 ucx/1.14.1_cuda-11.8 openmpi/4.1.5_cuda-11.8 hdf5/1.12.2-ompi415 nsight-systems/2023.2.1
+  modules: julia/1.10.0 cuda/12.2 ucx/1.14.1_cuda-12.2 openmpi/4.1.5_cuda-12.2 nsight-systems/2023.3.1
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"
   OPENBLAS_NUM_THREADS: 1
   JULIA_NVTX_CALLBACKS: gc
   OMPI_MCA_opal_warn_on_missing_libcuda: 0
-  JULIA_CPU_TARGET: 'broadwell;skylake'
+  MPITRAMPOLINE_LIB: '/groups/esm/software/MPIwrapper/ompi4.1.5_cuda-12.2/lib64/libmpiwrapper.so'
+  MPITRAMPOLINE_MPIEXEC: '/groups/esm/software/MPIwrapper/ompi4.1.5_cuda-12.2/bin/mpiwrapperexec'
 
 steps:
   - label: "initialize"

--- a/.github/workflows/CodeCov.yml
+++ b/.github/workflows/CodeCov.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Julia
       uses: julia-actions/setup-julia@latest
       with:
-        version: 1.9
+        version: '1.10'
 
     - name: Test with coverage
       env:

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: julia-actions/setup-julia@latest
       if: steps.filter.outputs.julia_file_change == 'true'
       with:
-        version: 1.9
+        version: '1.10'
 
     - name: Apply JuliaFormatter
       if: steps.filter.outputs.julia_file_change == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9.2'
+          - '1.10'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.9
+          version: '1.10'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.15.1"
+version = "0.15.2"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -9,3 +9,6 @@ KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
+
+[compat]
+KernelAbstractions = "0.9"

--- a/test/gpu_tests.jl
+++ b/test/gpu_tests.jl
@@ -25,7 +25,6 @@ ClimaComms.device() isa ClimaComms.CUDADevice || error("No GPU found")
 
 # Set up GPU
 using CUDA
-using CUDA.CUDAKernels
 const backend = CUDABackend()
 CUDA.allowscalar(false)
 const ArrayType = CuArray


### PR DESCRIPTION
- Update buildkite and GH actions to 1.10
- Set KernelAbstractions compat
- Bump patch version

The required CI actions should be set to 1.10, I don't have permissions to do this.