### PR TITLE
replacing Mohler AF with nucleation rate

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -87,6 +87,7 @@ AerosolActivation.total_M_activated
 ```@docs
 HetIceNucleation
 HetIceNucleation.dust_activated_number_fraction
+HetIceNucleation.MohlerDepositionRate
 HetIceNucleation.deposition_J
 HetIceNucleation.ABIFM_J
 ```

--- a/docs/src/IceNucleation.md
+++ b/docs/src/IceNucleation.md
@@ -22,28 +22,41 @@ The parameterization for deposition on dust particles is an implementation of
     freezing modes.
 
 ## Activated fraction for deposition freezing on dust
-The parameterization models the activated fraction
-  as an empirical function of ice saturation ratio,
-  see eq. (3) in [Mohler2006](@cite).
+There are 2 parameterizations from [Mohler2006](@cite) available: one
+  which calculates the activated fraction and one which calculates nucleation
+  rate. 
+The activated fraction parameterization follows eq. (3) in the paper.
 ```math
 \begin{equation}
 f_i(S_i) = exp[a(S_i - S_0)] - 1
 \end{equation}
 ```
-where:
+where 
   - ``f_i`` is the activated fraction
-      (the ratio of aerosol particles acting as ice nuclei to the total number of aerosol particles),
+     (the ratio of aerosol particles acting as ice nuclei to the total number of aerosol particles),
+  - ``a`` is a scaling parameter dependent on aerosol properties and temperature,
+  - ``S_i`` is the ice saturation ratio,
+  - ``S_0`` is an empirically derived threshold ice saturation ratio.
+The other parameterization models the nucleation rate of ice
+  as an empirical function of ice saturation ratio,
+  see eq. (5) in [Mohler2006](@cite).
+```math
+\begin{equation}
+\frac{dn_{ice}}{dt} = N_{aer} a \frac{dS_i}{dt}
+\end{equation}
+```
+where:
+  - ``N_{aer}`` is the number of available aerosol/ice nuclei,
+  - ``a`` is a scaling parameter dependent on aerosol properties and temperature,
   - ``S_i`` is the ice saturation ratio
-      (the ratio of water vapor partial pressure and the water vapor partial pressure at saturation over ice),
-  - ``S_0`` is the threshold ice saturation ratio,
-  - ``a`` is a scaling parameter dependent on aerosol properties and temperature.
+    (the ratio of water vapor partial pressure and the water vapor partial pressure at saturation over ice).
 
-Limited experimental values for the free parameters ``S_0`` and ``a`` can be found in [Mohler2006](@cite).
-Both parameters are dependent on aerosol properties and temperature.
+Limited experimental values for the free parameters ``a`` and ``S_0`` can be found in [Mohler2006](@cite). These
+  free parameters are strongly dependent on aerosol properties and temperature.
 
 !!! note
 
-    For a ``f_i`` values above 0.08 or ``S_i`` between 1.35 and 1.5,
+    For ``f_i`` values above 0.08 or ``S_i`` between 1.35 and 1.5,
     freezing occurs in a different ice nucleation mode
     (either a second deposition or other condensation type mode).
 
@@ -97,10 +110,10 @@ Once ``J_{ABIFM}`` is calculated, it can be used to determine the ice production
 per second via immersion freezing.
 ```math
 \begin{equation}
-  P_{ice} = J_{ABIFM}A(N_{tot} - N_{ice})
+  P_{ice} = J_{ABIFM}A(N_{aer} - N_{ice})
 \end{equation}
 ```
-where ``A`` is surface area of an individual ice nuclei, ``N_{tot}`` is total number
+where ``A`` is surface area of an individual ice nuclei, ``N_{aer}`` is total number
   of ice nuclei, and ``N_{ice}`` is number of ice crystals already in the system.
 
 ### ABIFM Example Figures

--- a/docs/src/IceNucleationParcel0D.md
+++ b/docs/src/IceNucleationParcel0D.md
@@ -121,7 +121,7 @@ where ``\xi = \frac{e_{sl}}{e_{si}}`` is the ratio of saturation vapor pressure 
 The crux of the problem is modeling the ``\frac{dq_l}{dt}`` and ``\frac{dq_i}{dt}``
   for different homogeneous and heterogeneous ice nucleation paths.
 
-## Condensation
+## Condensation growth
 
 The diffusional growth of individual cloud droplet is described by
 ([see discussion](https://clima.github.io/CloudMicrophysics.jl/dev/Microphysics1M/#Snow-autoconversion)),
@@ -165,7 +165,7 @@ For a gamma distribution of droplets ``n(r) = A \; r \; exp(-\lambda r)``,
 ``\bar{r} = \frac{2}{\lambda}``
 where ``\lambda = \left(\frac{32 \pi N_{tot} \rho_l}{q_l \rho_a}\right)^{1/3}``.
 
-## Deposition nucleation on dust particles
+## Deposition growth
 
 Similarly, for a case of a spherical ice particle growing through water vapor deposition
 ```math
@@ -196,15 +196,12 @@ It follows that
 where:
 - ``N_{act}`` is the number of activated ice particles.
 
-``N_{act}`` can be computed for example from
-  [activated fraction](https://clima.github.io/CloudMicrophysics.jl/dev/IceNucleation/#Activated-fraction-for-deposition-freezing-on-dust) ``f_i``
-```math
-\begin{equation}
-  N_{act} = N_{aer} f_i
-\end{equation}
-```
-where:
-- ``N_{aer}`` is the number of available dust aerosol particles.
+## Deposition Nucleation on dust particles
+There are multiple ways of running deposition nucleation in the parcel.
+  `"MohlerAF_Deposition"` will trigger an activated fraction approach from [Mohler2006](@cite).
+  `"MohlerRate_Deposition"` will trigger a nucleation rate approach from [Mohler2006](@cite).
+The deposition nucleation methods are parameterized as described in
+  [Ice Nucleation](https://clima.github.io/CloudMicrophysics.jl/dev/IceNucleation/).
 
 ## Immersion Freezing
 Following the water activity based immersion freezing model (ABIFM), the ABIFM derived
@@ -241,13 +238,20 @@ Here we show various example simulation results from the adiabatic parcel
   and homogeneous freezing with deposition growth.
 
 We start with deposition freezing on dust.
-The model is run three times for 30 minutes simulation time,
-  (shown by three different colors on the plot).
+The model is run three times using the `"MohlerAF_Deposition"` approach 
+  for 30 minutes simulation time, (shown by three different colors on the plot).
 Between each run the water vapor specific humidity is changed,
   while keeping all other state variables the same as at the last time step
   of the previous run.
 The prescribed vertical velocity is equal to 3.5 cm/s.
 Supersaturation is plotted for both liquid (solid lines) and ice (dashed lines).
+The pale blue line uses the `"MohlerRate_Deposition"`approach. 
+  We only run it for the first GCM timestep because the rate approach requires
+  the change in ice saturation over time. With the discontinuous jump in saturation,
+  the parameterization is unable to determine a proper nucleation rate. When we force
+  the initial ice crystal number concentration for this simulation to match
+  that in the `"MohlerAF_Deposition"` approach, we obtain the same results as
+  in the `"MohlerAF_Deposition"` approach for the first GCM timestep.
 
 ```@example
 include("../../parcel/Tully_et_al_2023.jl")

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -88,6 +88,7 @@ function benchmark_test(FT)
     T_air_2 = FT(250)
     T_air_cold = FT(230)
     S_ice = FT(1.2)
+    dSi_dt = FT(0.05)
 
     w_air = FT(0.5)
     p_air = FT(1e5)
@@ -136,6 +137,11 @@ function benchmark_test(FT)
         CMI_het.dust_activated_number_fraction,
         (desert_dust, ip.deposition, S_ice, T_air_2),
         50,
+    )
+    bench_press(
+        CMI_het.MohlerDepositionRate,
+        (desert_dust, ip.deposition, S_ice, T_air_2, dSi_dt, N_aer),
+        80,
     )
     bench_press(CMI_het.deposition_J, (kaolinite, Delta_a_w), 230)
     bench_press(CMI_het.ABIFM_J, (desert_dust, Delta_a_w), 230)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- replacing the AF parameterization from Mohler with the nucleation rate parameterization from the same paper. This requires one less empirical parameter and would be more numerically stable in the parcel model.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- clean up? delete AF function or replace with a function that calculates the rate. also delete unnecessary parameters (see CLIMAParameters.jl)
- if replacing AF function with new function for rate, revise unit/gpu/performance tests, api, etc.
- fix Tully; the jump between GCM time steps should cause a jump in ice formation

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->