### PR TITLE
box tracks droplet radius instead of area

### DIFF
--- a/box/Alpert_Knopf_2016_forward.jl
+++ b/box/Alpert_Knopf_2016_forward.jl
@@ -20,7 +20,8 @@ end
 include(joinpath(pkgdir(CM), "box", "box.jl"))
 
 # initial conditions following KA16 figure 4 (Cr1 case)
-A_droplet = FT(1e-5) * 1e-4 # INP surface area, m^2
+A_aero = FT(1e-5) * 1e-4 # INP surface area, m^2
+r_aero = sqrt(A_droplet / 4 / FT(π))
 σg = 10
 N₀ = 1000
 N_ice = 0
@@ -43,14 +44,15 @@ Aj_sorted = zeros(N₀)
 Aj_sorted = sort(Aj_unsorted, rev = true)
 
 # initial condition for the ODE problem
-IC = [T_initial, A_sum, FT(N₀), FT(N_ice)]
+IC_const = [T_initial, r_l, FT(N₀), FT(N_ice)]
+IC_var = [T_initial, A_sum, FT(N₀), FT(N_ice)]
 # additional model parameters
-p_def = (; tps, A_droplet, aerosol, cooling_rate, N₀)
+p_def = (; tps, A_aero, aerosol, cooling_rate, N₀)
 
 # run the box model without and with distribution sampling
-sol_cst = run_box(IC, t_0, t_end, (p_def..., const_dt = dt, flag = false))
+sol_cst = run_box(IC_const, t_0, t_end, (p_def..., const_dt = dt, flag = false))
 sol_var = run_box(
-    IC,
+    IC_var,
     t_0,
     t_end,
     (p_def..., const_dt = dt, flag = true, Aj_sorted = Aj_sorted),

--- a/box/box.jl
+++ b/box/box.jl
@@ -11,12 +11,13 @@ import CloudMicrophysics.HetIceNucleation as CMI_het
 function box_model(dY, Y, p, t)
 
     # Get simulation parameters
-    (; tps, A_droplet, aerosol, cooling_rate) = p
+    (; tps, aerosol, cooling_rate) = p
     # Numerical precision used in the simulation
     FT = eltype(Y)
 
     # Our state vector
     T = Y[1]          # temperature
+    r_aero = Y[2]     # INP radius
     N_liq = Y[3]      # number concentration of existing water droplets
     N_ice = Y[4]      # number concentration of activated ice crystals
 
@@ -28,7 +29,7 @@ function box_model(dY, Y, p, t)
     dN_ice_dt = FT(0)
     dN_liq_dt = FT(0)
     if N_liq > 0
-        dN_ice_dt = J_immer * N_liq * A_droplet
+        dN_ice_dt = J_immer * N_liq * 4 * FT(π) * r_aero^2
         dN_liq_dt = -dN_ice_dt
     end
 
@@ -45,7 +46,7 @@ end
 function box_model_with_probability(dY, Y, p, t)
 
     # Get simulation parameters
-    (; tps, const_dt, A_droplet, aerosol, cooling_rate, Aj_sorted, N₀) = p
+    (; tps, const_dt, A_aero, aerosol, cooling_rate, Aj_sorted, N₀) = p
     # Numerical precision used in the simulation
     FT = eltype(Y)
 
@@ -88,7 +89,7 @@ function box_model_with_probability(dY, Y, p, t)
     # Set tendencies
     dY[1] = dT_dt          # temperature
     dY[2] = dAj_dt         # total Aj
-    dY[3] = dN_liq_dt      # mumber concentration of droplets
+    dY[3] = dN_liq_dt      # number concentration of droplets
     dY[4] = dN_ice_dt      # number concentration of ice activated particles
 
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Generalize box model with individual droplet radius in state vector instead of total surface area

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
