### PR TITLE
Refactor parameters to use ClimaParameters API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,10 +12,10 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
-CLIMAParameters = "0.8"
+CLIMAParameters = "0.8.6"
 DocStringExtensions = "0.8, 0.9"
 ForwardDiff = "0.10"
 RootSolvers = "0.3, 0.4"
 SpecialFunctions = "1, 2"
-Thermodynamics = "0.9, 0.10, 0.11"
+Thermodynamics = "0.11"
 julia = "1.6"

--- a/docs/src/guides/Parameters.jl
+++ b/docs/src/guides/Parameters.jl
@@ -39,7 +39,7 @@ open(override_file, "w") do io
 end
 toml_dict = CP.create_toml_dict(FT; override_file)
 isfile(override_file) && rm(override_file; force = true)
-const overwrite = CMP.Rain(FT, toml_dict)
+const overwrite = CMP.Rain(toml_dict)
 
 nothing #hide
 
@@ -51,7 +51,7 @@ override_file = Dict(
         Dict("value" => 13, "type" => "float"),
 )
 toml_dict2 = CP.create_toml_dict(FT; override_file)
-const overwrite2 = CMP.Rain(FT, toml_dict2)
+const overwrite2 = CMP.Rain(toml_dict2)
 
 nothing #hide
 

--- a/docs/src/plots/Thersholds_transitions.jl
+++ b/docs/src/plots/Thersholds_transitions.jl
@@ -27,10 +27,10 @@ for i in 1:3
     toml_dict = CP.create_toml_dict(FT; override_file)
     isfile(override_file) && rm(override_file; force = true)
 
-    push!(rain, CMP.Rain(FT, toml_dict))
-    push!(B1994, CMP.B1994(FT, toml_dict))
-    push!(TC1980, CMP.TC1980(FT, toml_dict))
-    push!(LD2004, CMP.LD2004(FT, toml_dict))
+    push!(rain, CMP.Rain(toml_dict))
+    push!(B1994, CMP.B1994(toml_dict))
+    push!(TC1980, CMP.TC1980(toml_dict))
+    push!(LD2004, CMP.LD2004(toml_dict))
 end
 
 # example values

--- a/src/parameters/AerosolATD.jl
+++ b/src/parameters/AerosolATD.jl
@@ -9,7 +9,7 @@ Mohler et al, 2006. DOI: 10.5194/acp-6-3007-2006
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct ArizonaTestDust{FT} <: AerosolType{FT}
+Base.@kwdef struct ArizonaTestDust{FT} <: AerosolType{FT}
     "S₀ for T > T_thr [-]"
     S₀_warm::FT
     "S₀ for T < T_thr [-]"
@@ -20,15 +20,17 @@ struct ArizonaTestDust{FT} <: AerosolType{FT}
     a_cold::FT
 end
 
-function ArizonaTestDust(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return ArizonaTestDust(
-        FT(data["Mohler2006_S0_warm_ArizonaTestDust"]["value"]),
-        FT(data["Mohler2006_S0_cold_ArizonaTestDust"]["value"]),
-        FT(data["Mohler2006_a_warm_ArizonaTestDust"]["value"]),
-        FT(data["Mohler2006_a_cold_ArizonaTestDust"]["value"]),
+ArizonaTestDust(::Type{FT}) where {FT <: AbstractFloat} =
+    ArizonaTestDust(CP.create_toml_dict(FT))
+
+function ArizonaTestDust(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :Mohler2006_S0_warm_ArizonaTestDust => :S₀_warm,
+        :Mohler2006_S0_cold_ArizonaTestDust => :S₀_cold,
+        :Mohler2006_a_warm_ArizonaTestDust => :a_warm,
+        :Mohler2006_a_cold_ArizonaTestDust => :a_cold,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return ArizonaTestDust{FT}(; parameters...)
 end

--- a/src/parameters/AerosolActivation.jl
+++ b/src/parameters/AerosolActivation.jl
@@ -9,7 +9,7 @@ DOI: 10.1029/1999JD901161
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct AerosolActivationParameters{FT} <: ParametersType{FT}
+Base.@kwdef struct AerosolActivationParameters{FT} <: ParametersType{FT}
     "molar mass of water [kg/mol]"
     M_w::FT
     "gas constant [J/mol/K]"
@@ -22,16 +22,18 @@ struct AerosolActivationParameters{FT} <: ParametersType{FT}
     g::FT
 end
 
-function AerosolActivationParameters(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return AerosolActivationParameters(
-        FT(data["molar_mass_water"]["value"]),
-        FT(data["gas_constant"]["value"]),
-        FT(data["density_liquid_water"]["value"]),
-        FT(data["surface_tension_water"]["value"]),
-        FT(data["gravitational_acceleration"]["value"]),
+AerosolActivationParameters(::Type{FT}) where {FT <: AbstractFloat} =
+    AerosolActivationParameters(CP.create_toml_dict(FT))
+
+function AerosolActivationParameters(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :molar_mass_water => :M_w,
+        :gas_constant => :R,
+        :density_liquid_water => :ρ_w,
+        :surface_tension_water => :σ,
+        :gravitational_acceleration => :g,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return AerosolActivationParameters{FT}(; parameters...)
 end

--- a/src/parameters/AerosolDesertDust.jl
+++ b/src/parameters/AerosolDesertDust.jl
@@ -10,7 +10,7 @@ and from Mohler et al, 2006 DOI: 10.5194/acp-6-3007-2006
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct DesertDust{FT} <: AerosolType{FT}
+Base.@kwdef struct DesertDust{FT} <: AerosolType{FT}
     "S₀ for T > T_thr [-]"
     S₀_warm::FT
     "S₀ for T < T_thr [-]"
@@ -25,17 +25,19 @@ struct DesertDust{FT} <: AerosolType{FT}
     ABIFM_c::FT
 end
 
-function DesertDust(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return DesertDust(
-        FT(data["Mohler2006_S0_warm_DesertDust"]["value"]),
-        FT(data["Mohler2006_S0_cold_DesertDust"]["value"]),
-        FT(data["Mohler2006_a_warm_DesertDust"]["value"]),
-        FT(data["Mohler2006_a_cold_DesertDust"]["value"]),
-        FT(data["AlpertKnopf2016_J_ABIFM_m_DesertDust"]["value"]),
-        FT(data["AlpertKnopf2016_J_ABIFM_c_DesertDust"]["value"]),
+DesertDust(::Type{FT}) where {FT <: AbstractFloat} =
+    DesertDust(CP.create_toml_dict(FT))
+
+function DesertDust(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :Mohler2006_S0_warm_DesertDust => :S₀_warm,
+        :Mohler2006_S0_cold_DesertDust => :S₀_cold,
+        :Mohler2006_a_warm_DesertDust => :a_warm,
+        :Mohler2006_a_cold_DesertDust => :a_cold,
+        :AlpertKnopf2016_J_ABIFM_m_DesertDust => :ABIFM_m,
+        :AlpertKnopf2016_J_ABIFM_c_DesertDust => :ABIFM_c,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return DesertDust{FT}(; parameters...)
 end

--- a/src/parameters/AerosolFeldspar.jl
+++ b/src/parameters/AerosolFeldspar.jl
@@ -9,20 +9,22 @@ DOI: 10.1039/D1EA00077B
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct Feldspar{FT} <: AerosolType{FT}
+Base.@kwdef struct Feldspar{FT} <: AerosolType{FT}
     "m coefficient for deposition nucleation J [-]"
     deposition_m::FT
     "c coefficient for deposition nucleation J [-]"
     deposition_c::FT
 end
 
-function Feldspar(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return Feldspar(
-        FT(data["Alpert2022_J_deposition_m_Feldspar"]["value"]),
-        FT(data["Alpert2022_J_deposition_c_Feldspar"]["value"]),
+Feldspar(::Type{FT}) where {FT <: AbstractFloat} =
+    Feldspar(CP.create_toml_dict(FT))
+
+function Feldspar(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :Alpert2022_J_deposition_m_Feldspar => :deposition_m,
+        :Alpert2022_J_deposition_c_Feldspar => :deposition_c,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return Feldspar{FT}(; parameters...)
 end

--- a/src/parameters/AerosolFerrihydrite.jl
+++ b/src/parameters/AerosolFerrihydrite.jl
@@ -9,20 +9,22 @@ DOI: 10.1039/D1EA00077B
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct Ferrihydrite{FT} <: AerosolType{FT}
+Base.@kwdef struct Ferrihydrite{FT} <: AerosolType{FT}
     "m coefficient for deposition nucleation J [-]"
     deposition_m::FT
     "c coefficient for deposition nucleation J [-]"
     deposition_c::FT
 end
 
-function Ferrihydrite(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return Ferrihydrite(
-        FT(data["Alpert2022_J_deposition_m_Ferrihydrite"]["value"]),
-        FT(data["Alpert2022_J_deposition_c_Ferrihydrite"]["value"]),
+Ferrihydrite(::Type{FT}) where {FT <: AbstractFloat} =
+    Ferrihydrite(CP.create_toml_dict(FT))
+
+function Ferrihydrite(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :Alpert2022_J_deposition_m_Ferrihydrite => :deposition_m,
+        :Alpert2022_J_deposition_c_Ferrihydrite => :deposition_c,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return Ferrihydrite{FT}(; parameters...)
 end

--- a/src/parameters/AerosolIllite.jl
+++ b/src/parameters/AerosolIllite.jl
@@ -9,20 +9,21 @@ DOI: 10.1039/C3FD00035D
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct Illite{FT} <: AerosolType{FT}
+Base.@kwdef struct Illite{FT} <: AerosolType{FT}
     "m coefficient for immersion freezing J [-]"
     ABIFM_m::FT
     "c coefficient for immersion freezing J [-]"
     ABIFM_c::FT
 end
 
-function Illite(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return Illite(
-        FT(data["KnopfAlpert2013_J_ABIFM_m_Illite"]["value"]),
-        FT(data["KnopfAlpert2013_J_ABIFM_c_Illite"]["value"]),
+Illite(::Type{FT}) where {FT <: AbstractFloat} = Illite(CP.create_toml_dict(FT))
+
+function Illite(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :KnopfAlpert2013_J_ABIFM_m_Illite => :ABIFM_m,
+        :KnopfAlpert2013_J_ABIFM_c_Illite => :ABIFM_c,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return Illite{FT}(; parameters...)
 end

--- a/src/parameters/AerosolKaolinite.jl
+++ b/src/parameters/AerosolKaolinite.jl
@@ -10,7 +10,7 @@ DOI: 10.1002/2016JD025817
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct Kaolinite{FT} <: AerosolType{FT}
+Base.@kwdef struct Kaolinite{FT} <: AerosolType{FT}
     "m coefficient for deposition nucleation J [-]"
     deposition_m::FT
     "c coefficient for deposition nucleation J [-]"
@@ -21,15 +21,17 @@ struct Kaolinite{FT} <: AerosolType{FT}
     ABIFM_c::FT
 end
 
-function Kaolinite(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return Kaolinite(
-        FT(data["China2017_J_deposition_m_Kaolinite"]["value"]),
-        FT(data["China2017_J_deposition_c_Kaolinite"]["value"]),
-        FT(data["KnopfAlpert2013_J_ABIFM_m_Kaolinite"]["value"]),
-        FT(data["KnopfAlpert2013_J_ABIFM_c_Kaolinite"]["value"]),
+Kaolinite(::Type{FT}) where {FT <: AbstractFloat} =
+    Kaolinite(CP.create_toml_dict(FT))
+
+function Kaolinite(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :China2017_J_deposition_m_Kaolinite => :deposition_m,
+        :China2017_J_deposition_c_Kaolinite => :deposition_c,
+        :KnopfAlpert2013_J_ABIFM_m_Kaolinite => :ABIFM_m,
+        :KnopfAlpert2013_J_ABIFM_c_Kaolinite => :ABIFM_c,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return Kaolinite{FT}(; parameters...)
 end

--- a/src/parameters/AerosolModalNucleation.jl
+++ b/src/parameters/AerosolModalNucleation.jl
@@ -10,7 +10,7 @@ DOI:10.1126/science.aaf2649
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct H2S04NucleationParameters{FT} <: ParametersType{FT}
+Base.@kwdef struct H2S04NucleationParameters{FT} <: ParametersType{FT}
     p_b_n::FT
     p_b_i::FT
     u_b_n::FT
@@ -33,34 +33,37 @@ struct H2S04NucleationParameters{FT} <: ParametersType{FT}
     a_i::FT
 end
 
-function H2S04NucleationParameters(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return H2S04NucleationParameters(
-        FT(data["mam3_nucleation_p_b_n_neutral"]["value"]),
-        FT(data["mam3_nucleation_p_b_i_ion_induced"]["value"]),
-        FT(data["mam3_nucleation_u_b_n_neutral"]["value"]),
-        FT(data["mam3_nucleation_u_b_i_ion_induced"]["value"]),
-        FT(data["mam3_nucleation_v_b_n_neutral"]["value"]),
-        FT(data["mam3_nucleation_v_b_i_ion_induced"]["value"]),
-        FT(data["mam3_nucleation_w_b_n_neutral"]["value"]),
-        FT(data["mam3_nucleation_w_b_i_ion_induced"]["value"]),
-        FT(data["mam3_nucleation_p_t_n_neutral"]["value"]),
-        FT(data["mam3_nucleation_p_t_i_ion_induced"]["value"]),
-        FT(data["mam3_nucleation_u_t_n_neutral"]["value"]),
-        FT(data["mam3_nucleation_u_t_i_ion_induced"]["value"]),
-        FT(data["mam3_nucleation_v_t_n_neutral"]["value"]),
-        FT(data["mam3_nucleation_v_t_i_ion_induced"]["value"]),
-        FT(data["mam3_nucleation_w_t_n_neutral"]["value"]),
-        FT(data["mam3_nucleation_w_t_i_ion_induced"]["value"]),
-        FT(data["mam3_nucleation_p_A_n_neutral"]["value"]),
-        FT(data["mam3_nucleation_p_A_i_ion_induced"]["value"]),
-        FT(data["mam3_nucleation_a_n_neutral"]["value"]),
-        FT(data["mam3_nucleation_a_i_ion_induced"]["value"]),
+H2S04NucleationParameters(::Type{FT}) where {FT <: AbstractFloat} =
+    H2S04NucleationParameters(CP.create_toml_dict(FT))
+
+function H2S04NucleationParameters(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :mam3_nucleation_p_b_n_neutral => :p_b_n,
+        :mam3_nucleation_p_b_i_ion_induced => :p_b_i,
+        :mam3_nucleation_u_b_n_neutral => :u_b_n,
+        :mam3_nucleation_u_b_i_ion_induced => :u_b_i,
+        :mam3_nucleation_v_b_n_neutral => :v_b_n,
+        :mam3_nucleation_v_b_i_ion_induced => :v_b_i,
+        :mam3_nucleation_w_b_n_neutral => :w_b_n,
+        :mam3_nucleation_w_b_i_ion_induced => :w_b_i,
+        :mam3_nucleation_p_t_n_neutral => :p_t_n,
+        :mam3_nucleation_p_t_i_ion_induced => :p_t_i,
+        :mam3_nucleation_u_t_n_neutral => :u_t_n,
+        :mam3_nucleation_u_t_i_ion_induced => :u_t_i,
+        :mam3_nucleation_v_t_n_neutral => :v_t_n,
+        :mam3_nucleation_v_t_i_ion_induced => :v_t_i,
+        :mam3_nucleation_w_t_n_neutral => :w_t_n,
+        :mam3_nucleation_w_t_i_ion_induced => :w_t_i,
+        :mam3_nucleation_p_A_n_neutral => :p_A_n,
+        :mam3_nucleation_p_A_i_ion_induced => :p_A_i,
+        :mam3_nucleation_a_n_neutral => :a_n,
+        :mam3_nucleation_a_i_ion_induced => :a_i,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return H2S04NucleationParameters{FT}(; parameters...)
 end
+
 
 """
 OrganicNucleationParameters{FT}
@@ -71,7 +74,7 @@ DOI: 10.1038/nature17953
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct OrganicNucleationParameters{FT} <: ParametersType{FT}
+Base.@kwdef struct OrganicNucleationParameters{FT} <: ParametersType{FT}
     a_1::FT
     a_2::FT
     a_3::FT
@@ -85,24 +88,26 @@ struct OrganicNucleationParameters{FT} <: ParametersType{FT}
     exp_MTOH::FT
 end
 
-function OrganicNucleationParameters(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return OrganicNucleationParameters(
-        FT(data["mam3_nucleation_a_1_neutral"]["value"]),
-        FT(data["mam3_nucleation_a_2_neutral"]["value"]),
-        FT(data["mam3_nucleation_a_3_ion_induced"]["value"]),
-        FT(data["mam3_nucleation_a_4_ion_induced"]["value"]),
-        FT(data["mam3_nucleation_a_5"]["value"]),
-        FT(data["mam3_nucleation_Y_MTO3_percent"]["value"]),
-        FT(data["mam3_nucleation_Y_MTOH_percent"]["value"]),
-        FT(data["mam3_nucleation_k_MTO3_organic_factor"]["value"]),
-        FT(data["mam3_nucleation_k_MTOH_organic_factor"]["value"]),
-        FT(data["mam3_nucleation_exp_MTO3_organic_factor"]["value"]),
-        FT(data["mam3_nucleation_exp_MTOH_organic_factor"]["value"]),
+OrganicNucleationParameters(::Type{FT}) where {FT <: AbstractFloat} =
+    OrganicNucleationParameters(CP.create_toml_dict(FT))
+
+function OrganicNucleationParameters(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :mam3_nucleation_a_1_neutral => :a_1,
+        :mam3_nucleation_a_2_neutral => :a_2,
+        :mam3_nucleation_a_3_ion_induced => :a_3,
+        :mam3_nucleation_a_4_ion_induced => :a_4,
+        :mam3_nucleation_a_5 => :a_5,
+        :mam3_nucleation_Y_MTO3_percent => :Y_MTO3,
+        :mam3_nucleation_Y_MTOH_percent => :Y_MTOH,
+        :mam3_nucleation_k_MTO3_organic_factor => :k_MTO3,
+        :mam3_nucleation_k_MTOH_organic_factor => :k_MTOH,
+        :mam3_nucleation_exp_MTO3_organic_factor => :exp_MTO3,
+        :mam3_nucleation_exp_MTOH_organic_factor => :exp_MTOH,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return OrganicNucleationParameters{FT}(; parameters...)
 end
 
 """
@@ -114,22 +119,23 @@ DOI:10.1126/science.1243527
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct MixedNucleationParameters{FT} <: ParametersType{FT}
+Base.@kwdef struct MixedNucleationParameters{FT} <: ParametersType{FT}
     k_H2SO4org::FT
     k_MTOH::FT
     exp_MTOH::FT
 end
 
-function MixedNucleationParameters(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return MixedNucleationParameters(
-        FT(
-            data["mam3_nucleation_k_H2SO4_mixed_organic_sulfuric_acid_factor"]["value"],
-        ),
-        FT(data["mam3_nucleation_k_MTOH_organic_factor"]["value"]),
-        FT(data["mam3_nucleation_exp_MTOH_organic_factor"]["value"]),
+MixedNucleationParameters(::Type{FT}) where {FT <: AbstractFloat} =
+    MixedNucleationParameters(CP.create_toml_dict(FT))
+
+function MixedNucleationParameters(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :mam3_nucleation_k_H2SO4_mixed_organic_sulfuric_acid_factor =>
+            :k_H2SO4org,
+        :mam3_nucleation_k_MTOH_organic_factor => :k_MTOH,
+        :mam3_nucleation_exp_MTOH_organic_factor => :exp_MTOH,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return MixedNucleationParameters{FT}(; parameters...)
 end

--- a/src/parameters/AerosolSeasalt.jl
+++ b/src/parameters/AerosolSeasalt.jl
@@ -8,7 +8,7 @@ Parameters for seasalt
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct Seasalt{FT} <: AerosolType{FT}
+Base.@kwdef struct Seasalt{FT} <: AerosolType{FT}
     "molar mass [kg/mol]"
     M::FT
     "density [kg/m3]"
@@ -23,17 +23,19 @@ struct Seasalt{FT} <: AerosolType{FT}
     κ::FT
 end
 
-function Seasalt(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return Seasalt(
-        FT(data["seasalt_aerosol_molar_mass"]["value"]),
-        FT(data["seasalt_aerosol_density"]["value"]),
-        FT(data["seasalt_aerosol_osmotic_coefficient"]["value"]),
-        FT(data["seasalt_aerosol_ion_number"]["value"]),
-        FT(data["seasalt_aerosol_water_soluble_mass_fraction"]["value"]),
-        FT(data["seasalt_aerosol_kappa"]["value"]),
+Seasalt(::Type{FT}) where {FT <: AbstractFloat} =
+    Seasalt(CP.create_toml_dict(FT))
+
+function Seasalt(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :seasalt_aerosol_molar_mass => :M,
+        :seasalt_aerosol_density => :ρ,
+        :seasalt_aerosol_osmotic_coefficient => :ϕ,
+        :seasalt_aerosol_ion_number => :ν,
+        :seasalt_aerosol_water_soluble_mass_fraction => :ϵ,
+        :seasalt_aerosol_kappa => :κ,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return Seasalt{FT}(; parameters...)
 end

--- a/src/parameters/AerosolSulfate.jl
+++ b/src/parameters/AerosolSulfate.jl
@@ -8,7 +8,7 @@ Parameters for sulfate aerosol
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct Sulfate{FT} <: AerosolType{FT}
+Base.@kwdef struct Sulfate{FT} <: AerosolType{FT}
     "molar mass [kg/mol]"
     M::FT
     "density [kg/m3]"
@@ -23,17 +23,19 @@ struct Sulfate{FT} <: AerosolType{FT}
     κ::FT
 end
 
-function Sulfate(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return Sulfate(
-        FT(data["sulfate_aerosol_molar_mass"]["value"]),
-        FT(data["sulfate_aerosol_density"]["value"]),
-        FT(data["sulfate_aerosol_osmotic_coefficient"]["value"]),
-        FT(data["sulfate_aerosol_ion_number"]["value"]),
-        FT(data["sulfate_aerosol_water_soluble_mass_fraction"]["value"]),
-        FT(data["sulfate_aerosol_kappa"]["value"]),
+Sulfate(::Type{FT}) where {FT <: AbstractFloat} =
+    Sulfate(CP.create_toml_dict(FT))
+
+function Sulfate(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :sulfate_aerosol_molar_mass => :M,
+        :sulfate_aerosol_density => :ρ,
+        :sulfate_aerosol_osmotic_coefficient => :ϕ,
+        :sulfate_aerosol_ion_number => :ν,
+        :sulfate_aerosol_water_soluble_mass_fraction => :ϵ,
+        :sulfate_aerosol_kappa => :κ,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return Sulfate{FT}(; parameters...)
 end

--- a/src/parameters/Aerosol_H2SO4_Solution.jl
+++ b/src/parameters/Aerosol_H2SO4_Solution.jl
@@ -9,7 +9,7 @@ from Luo et al 1995. DOI: 10.1029/94GL02988
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct H2SO4SolutionParameters{FT} <: ParametersType{FT}
+Base.@kwdef struct H2SO4SolutionParameters{FT}
     "max temperature for which the parameterization is valid [K]"
     T_max::FT
     "min temperature for which the parameterization is valid [K]"
@@ -32,21 +32,23 @@ struct H2SO4SolutionParameters{FT} <: ParametersType{FT}
     c7::FT
 end
 
-function H2SO4SolutionParameters(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return H2SO4SolutionParameters(
-        FT(data["p_over_sulphuric_acid_solution_T_max"]["value"]),
-        FT(data["p_over_sulphuric_acid_solution_T_min"]["value"]),
-        FT(data["p_over_sulphuric_acid_solution_w_2"]["value"]),
-        FT(data["p_over_sulphuric_acid_solution_c1"]["value"]),
-        FT(data["p_over_sulphuric_acid_solution_c2"]["value"]),
-        FT(data["p_over_sulphuric_acid_solution_c3"]["value"]),
-        FT(data["p_over_sulphuric_acid_solution_c4"]["value"]),
-        FT(data["p_over_sulphuric_acid_solution_c5"]["value"]),
-        FT(data["p_over_sulphuric_acid_solution_c6"]["value"]),
-        FT(data["p_over_sulphuric_acid_solution_c7"]["value"]),
+H2SO4SolutionParameters(::Type{FT}) where {FT <: AbstractFloat} =
+    H2SO4SolutionParameters(CP.create_toml_dict(FT))
+
+function H2SO4SolutionParameters(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :p_over_sulphuric_acid_solution_T_max => :T_max,
+        :p_over_sulphuric_acid_solution_T_min => :T_min,
+        :p_over_sulphuric_acid_solution_w_2 => :w_2,
+        :p_over_sulphuric_acid_solution_c1 => :c1,
+        :p_over_sulphuric_acid_solution_c2 => :c2,
+        :p_over_sulphuric_acid_solution_c3 => :c3,
+        :p_over_sulphuric_acid_solution_c4 => :c4,
+        :p_over_sulphuric_acid_solution_c5 => :c5,
+        :p_over_sulphuric_acid_solution_c6 => :c6,
+        :p_over_sulphuric_acid_solution_c7 => :c7,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return H2SO4SolutionParameters{FT}(; parameters...)
 end

--- a/src/parameters/AirProperties.jl
+++ b/src/parameters/AirProperties.jl
@@ -8,7 +8,7 @@ Parameters with air properties.
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct AirProperties{FT} <: ParametersType{FT}
+Base.@kwdef struct AirProperties{FT} <: ParametersType{FT}
     "thermal conductivity of air [w/m/K]"
     K_therm::FT
     "diffusivity of water vapor [m2/s]"
@@ -17,14 +17,16 @@ struct AirProperties{FT} <: ParametersType{FT}
     ν_air::FT
 end
 
-function AirProperties(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return AirProperties(
-        FT(data["thermal_conductivity_of_air"]["value"]),
-        FT(data["diffusivity_of_water_vapor"]["value"]),
-        FT(data["kinematic_viscosity_of_air"]["value"]),
+AirProperties(::Type{FT}) where {FT <: AbstractFloat} =
+    AirProperties(CP.create_toml_dict(FT))
+
+function AirProperties(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :thermal_conductivity_of_air => :K_therm,
+        :diffusivity_of_water_vapor => :D_vapor,
+        :kinematic_viscosity_of_air => :ν_air,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return AirProperties{FT}(; parameters...)
 end

--- a/src/parameters/Microphysics0M.jl
+++ b/src/parameters/Microphysics0M.jl
@@ -8,7 +8,7 @@ Parameters for zero-moment bulk microphysics scheme
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct Parameters0M{FT} <: ParametersType{FT}
+Base.@kwdef struct Parameters0M{FT} <: ParametersType{FT}
     "precipitation timescale [s]"
     τ_precip::FT
     "specific humidity precipitation threshold [-]"
@@ -17,14 +17,16 @@ struct Parameters0M{FT} <: ParametersType{FT}
     S_0::FT
 end
 
-function Parameters0M(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return Parameters0M(
-        FT(data["precipitation_timescale"]["value"]),
-        FT(data["specific_humidity_precipitation_threshold"]["value"]),
-        FT(data["supersaturation_precipitation_threshold"]["value"]),
+Parameters0M(::Type{FT}) where {FT <: AbstractFloat} =
+    Parameters0M(CP.create_toml_dict(FT))
+
+function Parameters0M(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :precipitation_timescale => :τ_precip,
+        :specific_humidity_precipitation_threshold => :qc_0,
+        :supersaturation_precipitation_threshold => :S_0,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return Parameters0M{FT}(; parameters...)
 end

--- a/src/parameters/Microphysics2M.jl
+++ b/src/parameters/Microphysics2M.jl
@@ -8,7 +8,7 @@ Khairoutdinov and Kogan (2000) autoconversion parameters
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct AcnvKK2000{FT} <: ParametersType{FT}
+Base.@kwdef struct AcnvKK2000{FT} <: ParametersType{FT}
     "Autoconversion coefficient A"
     A::FT
     "Autoconversion coefficient a"
@@ -19,6 +19,18 @@ struct AcnvKK2000{FT} <: ParametersType{FT}
     c::FT
 end
 
+function AcnvKK2000(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :KK2000_auctoconversion_coeff_A => :A,
+        :KK2000_auctoconversion_coeff_a => :a,
+        :KK2000_auctoconversion_coeff_b => :b,
+        :KK2000_auctoconversion_coeff_c => :c,
+    )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return AcnvKK2000{FT}(; parameters...)
+end
+
 """
     AccrKK2000
 
@@ -27,13 +39,24 @@ Khairoutdinov and Kogan (2000) accretion parameters
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct AccrKK2000{FT} <: ParametersType{FT}
+Base.@kwdef struct AccrKK2000{FT} <: ParametersType{FT}
     "Accretion coefficient A"
     A::FT
     "Accretion coefficient a"
     a::FT
     "Accretion coefficient b"
     b::FT
+end
+
+function AccrKK2000(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :KK2000_accretion_coeff_A => :A,
+        :KK2000_accretion_coeff_a => :a,
+        :KK2000_accretion_coeff_b => :b,
+    )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return AccrKK2000{FT}(; parameters...)
 end
 
 """
@@ -58,18 +81,8 @@ function KK2000(
     ::Type{FT},
     toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
 ) where {FT}
-    (; data) = toml_dict
-    acnv = AcnvKK2000(
-        FT(data["KK2000_auctoconversion_coeff_A"]["value"]),
-        FT(data["KK2000_auctoconversion_coeff_a"]["value"]),
-        FT(data["KK2000_auctoconversion_coeff_b"]["value"]),
-        FT(data["KK2000_auctoconversion_coeff_c"]["value"]),
-    )
-    accr = AccrKK2000(
-        FT(data["KK2000_accretion_coeff_A"]["value"]),
-        FT(data["KK2000_accretion_coeff_a"]["value"]),
-        FT(data["KK2000_accretion_coeff_b"]["value"]),
-    )
+    acnv = AcnvKK2000(toml_dict)
+    accr = AccrKK2000(toml_dict)
     return KK2000{FT, typeof(acnv), typeof(accr)}(acnv, accr)
 end
 
@@ -81,7 +94,7 @@ Beheng (1994) autoconversion parameters
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct AcnvB1994{FT} <: ParametersType{FT}
+Base.@kwdef struct AcnvB1994{FT} <: ParametersType{FT}
     "Autoconversion coeff C"
     C::FT
     "Autoconversion coeff a"
@@ -100,6 +113,22 @@ struct AcnvB1994{FT} <: ParametersType{FT}
     k::FT
 end
 
+function AcnvB1994(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :B1994_auctoconversion_coeff_C => :C,
+        :B1994_auctoconversion_coeff_a => :a,
+        :B1994_auctoconversion_coeff_b => :b,
+        :B1994_auctoconversion_coeff_c => :c,
+        :B1994_auctoconversion_coeff_N_0 => :N_0,
+        :B1994_auctoconversion_coeff_d_low => :d_low,
+        :B1994_auctoconversion_coeff_d_high => :d_high,
+        :threshold_smooth_transition_steepness => :k,
+    )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return AcnvB1994{FT}(; parameters...)
+end
+
 """
     AccrB1994
 
@@ -111,6 +140,16 @@ $(DocStringExtensions.FIELDS)
 struct AccrB1994{FT} <: ParametersType{FT}
     "Accretion coefficient A"
     A::FT
+end
+
+function AccrB1994(toml_dict::CP.AbstractTOMLDict)
+    (; B1994_accretion_coeff_A) = CP.get_parameter_values(
+        toml_dict,
+        "B1994_accretion_coeff_A",
+        "CloudMicrophysics",
+    )
+    FT = CP.float_type(toml_dict)
+    return AccrB1994{FT}(B1994_accretion_coeff_A)
 end
 
 """
@@ -129,24 +168,12 @@ struct B1994{FT, AV, AR} <: Precipitation2MType{FT}
     accr::AR
 end
 
-function B1994(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
+B1994(::Type{FT}) where {FT <: AbstractFloat} = B1994(CP.create_toml_dict(FT))
 
-    acnv = AcnvB1994(
-        FT(data["B1994_auctoconversion_coeff_C"]["value"]),
-        FT(data["B1994_auctoconversion_coeff_a"]["value"]),
-        FT(data["B1994_auctoconversion_coeff_b"]["value"]),
-        FT(data["B1994_auctoconversion_coeff_c"]["value"]),
-        FT(data["B1994_auctoconversion_coeff_N_0"]["value"]),
-        FT(data["B1994_auctoconversion_coeff_d_low"]["value"]), # typo aucto => auto
-        FT(data["B1994_auctoconversion_coeff_d_high"]["value"]), # type aucto => auto
-        FT(data["threshold_smooth_transition_steepness"]["value"]),
-    )
-    accr = AccrB1994(FT(data["B1994_accretion_coeff_A"]["value"]))
-
+function B1994(toml_dict::CP.AbstractTOMLDict)
+    acnv = AcnvB1994(toml_dict)
+    accr = AccrB1994(toml_dict)
+    FT = CP.float_type(toml_dict)
     return B1994{FT, typeof(acnv), typeof(accr)}(acnv, accr)
 end
 
@@ -158,7 +185,7 @@ Tripoli and Cotton (1980) autoconversion parameters
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct AcnvTC1980{FT} <: ParametersType{FT}
+Base.@kwdef struct AcnvTC1980{FT} <: ParametersType{FT}
     "Autoconversion coefficient a"
     a::FT
     "Autoconversion coefficient b"
@@ -175,6 +202,23 @@ struct AcnvTC1980{FT} <: ParametersType{FT}
     k::FT
 end
 
+function AcnvTC1980(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :TC1980_autoconversion_coeff_a => :a,
+        :TC1980_autoconversion_coeff_b => :b,
+        :TC1980_autoconversion_coeff_D => :D,
+        :TC1980_autoconversion_coeff_r_0 => :r_0,
+        :TC1980_autoconversion_coeff_me_liq => :me_liq,
+        :threshold_smooth_transition_steepness => :k,
+        :density_liquid_water => :m0_liq_coeff,
+    )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    m0_liq_coeff = 4 / 3 * π * parameters.m0_liq_coeff
+
+    FT = CP.float_type(td)
+    return AcnvTC1980{FT}(; parameters..., m0_liq_coeff)
+end
+
 """
     AccrTC1980
 
@@ -186,6 +230,16 @@ $(DocStringExtensions.FIELDS)
 struct AccrTC1980{FT} <: ParametersType{FT}
     "Accretion coefficient A"
     A::FT
+end
+
+function AccrTC1980(toml_dict::CP.AbstractTOMLDict)
+    (; TC1980_accretion_coeff_A) = CP.get_parameter_values(
+        toml_dict,
+        "TC1980_accretion_coeff_A",
+        "CloudMicrophysics",
+    )
+    FT = CP.float_type(toml_dict)
+    return AccrTC1980{FT}(TC1980_accretion_coeff_A)
 end
 
 """
@@ -206,23 +260,12 @@ struct TC1980{FT, AV, AR} <: Precipitation2MType{FT}
     accr::AR
 end
 
-function TC1980(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    ρ_cloud_liq = FT(data["density_liquid_water"]["value"])
-    acnv = AcnvTC1980(
-        FT(data["TC1980_autoconversion_coeff_a"]["value"]),
-        FT(data["TC1980_autoconversion_coeff_b"]["value"]),
-        FT(data["TC1980_autoconversion_coeff_D"]["value"]),
-        FT(data["TC1980_autoconversion_coeff_r_0"]["value"]),
-        FT(data["TC1980_autoconversion_coeff_me_liq"]["value"]),
-        FT(4 / 3) * π * ρ_cloud_liq,
-        FT(data["threshold_smooth_transition_steepness"]["value"]),
-    )
-    accr = AccrTC1980(FT(data["TC1980_accretion_coeff_A"]["value"]))
+TC1980(::Type{FT}) where {FT <: AbstractFloat} = TC1980(CP.create_toml_dict(FT))
 
+function TC1980(toml_dict::CP.AbstractTOMLDict)
+    acnv = AcnvTC1980(toml_dict)
+    accr = AccrTC1980(toml_dict)
+    FT = CP.float_type(toml_dict)
     return TC1980{FT, typeof(acnv), typeof(accr)}(acnv, accr)
 end
 
@@ -237,7 +280,7 @@ DOI: 10.1175/1520-0469(2004)061<1539:POTAPI>2.0.CO;2
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct LD2004{FT} <: Precipitation2MType{FT}
+Base.@kwdef struct LD2004{FT} <: Precipitation2MType{FT}
     "Autoconversion coefficient R_6C_0"
     R_6C_0::FT
     "Autoconversion coefficient E_0"
@@ -248,17 +291,18 @@ struct LD2004{FT} <: Precipitation2MType{FT}
     k::FT
 end
 
-function LD2004(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return LD2004(
-        FT(data["LD2004_R_6C_coeff"]["value"]),
-        FT(data["LD2004_E_0_coeff"]["value"]),
-        FT(data["density_liquid_water"]["value"]),
-        FT(data["threshold_smooth_transition_steepness"]["value"]),
+LD2004(::Type{FT}) where {FT <: AbstractFloat} = LD2004(CP.create_toml_dict(FT))
+
+function LD2004(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :LD2004_R_6C_coeff => :R_6C_0,
+        :LD2004_E_0_coeff => :E_0,
+        :density_liquid_water => :ρ_w,
+        :threshold_smooth_transition_steepness => :k,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return LD2004{FT}(; parameters...)
 end
 
 """
@@ -270,22 +314,24 @@ The type for 2-moment precipitation formation based on the
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct VarTimescaleAcnv{FT} <: Precipitation2MType{FT}
+Base.@kwdef struct VarTimescaleAcnv{FT} <: Precipitation2MType{FT}
     "Timescale [s]"
     τ::FT
     "Powerlaw coefficient [-]"
     α::FT
 end
 
-function VarTimescaleAcnv(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return VarTimescaleAcnv(
-        FT(data["rain_autoconversion_timescale"]["value"]),
-        FT(data["Variable_time_scale_autoconversion_coeff_alpha"]["value"]),
+VarTimescaleAcnv(::Type{FT}) where {FT <: AbstractFloat} =
+    VarTimescaleAcnv(CP.create_toml_dict(FT))
+
+function VarTimescaleAcnv(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :rain_autoconversion_timescale => :τ,
+        :Variable_time_scale_autoconversion_coeff_alpha => :α,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return VarTimescaleAcnv{FT}(; parameters...)
 end
 
 """
@@ -296,7 +342,7 @@ Rain size distribution parameters from SB2006
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct ParticlePDF_SB2006{FT} <: ParametersType{FT}
+Base.@kwdef struct ParticlePDF_SB2006{FT} <: ParametersType{FT}
     "Raindrop minimal mass"
     xr_min::FT
     "Raindrop maximum mass"
@@ -315,6 +361,22 @@ struct ParticlePDF_SB2006{FT} <: ParametersType{FT}
     ρ0::FT
 end
 
+function ParticlePDF_SB2006(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :SB2006_raindrops_min_mass => :xr_min,
+        :SB2006_raindrops_max_mass => :xr_max,
+        :SB2006_raindrops_size_distribution_coeff_N0_min => :N0_min,
+        :SB2006_raindrops_size_distribution_coeff_N0_max => :N0_max,
+        :SB2006_raindrops_size_distribution_coeff_lambda_min => :λ_min,
+        :SB2006_raindrops_size_distribution_coeff_lambda_max => :λ_max,
+        :density_liquid_water => :ρw,
+        :SB2006_reference_air_density => :ρ0,
+    )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return ParticlePDF_SB2006{FT}(; parameters...)
+end
+
 """
     AcnvSB2006
 
@@ -323,7 +385,7 @@ Autoconversion parameters from SB2006
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct AcnvSB2006{FT} <: ParametersType{FT}
+Base.@kwdef struct AcnvSB2006{FT} <: ParametersType{FT}
     "Collection kernel coefficient"
     kcc::FT
     "Cloud gamma distribution coefficient"
@@ -340,6 +402,22 @@ struct AcnvSB2006{FT} <: ParametersType{FT}
     b::FT
 end
 
+function AcnvSB2006(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :SB2006_collection_kernel_coeff_kcc => :kcc,
+        :SB2006_cloud_gamma_distribution_parameter => :νc,
+        :SB2006_raindrops_min_mass => :x_star,
+        :SB2006_reference_air_density => :ρ0,
+        :SB2006_autoconversion_correcting_function_coeff_A => :A,
+        :SB2006_autoconversion_correcting_function_coeff_a => :a,
+        :SB2006_autoconversion_correcting_function_coeff_b => :b,
+    )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return AcnvSB2006{FT}(; parameters...)
+end
+
+
 """
     AccrSB2006
 
@@ -348,7 +426,7 @@ Accretion parameters from SB2006
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct AccrSB2006{FT} <: ParametersType{FT}
+Base.@kwdef struct AccrSB2006{FT} <: ParametersType{FT}
     "Collection kernel coefficient Kcr"
     kcr::FT
     "Accretion correcting function coefficient τ_0"
@@ -359,6 +437,18 @@ struct AccrSB2006{FT} <: ParametersType{FT}
     c::FT
 end
 
+function AccrSB2006(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :SB2006_collection_kernel_coeff_kcr => :kcr,
+        :SB2006_accretion_correcting_function_coeff_tau0 => :τ0,
+        :SB2006_reference_air_density => :ρ0,
+        :SB2006_accretion_correcting_function_coeff_c => :c,
+    )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return AccrSB2006{FT}(; parameters...)
+end
+
 """
     SelfColSB2006
 
@@ -367,13 +457,24 @@ Rain selfcollection parameters from SB2006
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct SelfColSB2006{FT} <: ParametersType{FT}
+Base.@kwdef struct SelfColSB2006{FT} <: ParametersType{FT}
     "Collection kernel coefficient krr"
     krr::FT
     "Collection kernel coefficient kappa rr"
     κrr::FT
     "Raindrop self collection coefficient d"
     d::FT
+end
+
+function SelfColSB2006(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :SB2006_collection_kernel_coeff_krr => :krr,
+        :SB2006_collection_kernel_coeff_kapparr => :κrr,
+        Symbol("SB2006_raindrops_self-collection_coeff_d") => :d,
+    )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return SelfColSB2006{FT}(; parameters...)
 end
 
 """
@@ -384,7 +485,7 @@ Rain breakup parameters from SB2006
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct BreakupSB2006{FT} <: ParametersType{FT}
+Base.@kwdef struct BreakupSB2006{FT} <: ParametersType{FT}
     "Raindrop equilibrium mean diamater"
     Deq::FT
     "Raindrop breakup mean diamater threshold"
@@ -395,6 +496,18 @@ struct BreakupSB2006{FT} <: ParametersType{FT}
     κbr::FT
 end
 
+function BreakupSB2006(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :SB2006_raindrops_equlibrium_mean_diameter => :Deq,
+        :SB2006_raindrops_breakup_mean_diameter_threshold => :Dr_th,
+        :SB2006_raindrops_breakup_coeff_kbr => :kbr,
+        :SB2006_raindrops_breakup_coeff_kappabr => :κbr,
+    )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return BreakupSB2006{FT}(; parameters...)
+end
+
 """
     EvaporationSB2006
 
@@ -403,7 +516,7 @@ Rain evaporation parameters from SB2006
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct EvaporationSB2006{FT} <: ParametersType{FT}
+Base.@kwdef struct EvaporationSB2006{FT} <: ParametersType{FT}
     "Ventillation coefficient a"
     av::FT
     "Ventillation coefficient b"
@@ -414,6 +527,19 @@ struct EvaporationSB2006{FT} <: ParametersType{FT}
     β::FT
     "Reference air density [kg/m3]"
     ρ0::FT
+end
+
+function EvaporationSB2006(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :SB2006_ventilation_factor_coeff_av => :av,
+        :SB2006_ventilation_factor_coeff_bv => :bv,
+        :SB2006_rain_evaportation_coeff_alpha => :α,
+        :SB2006_rain_evaportation_coeff_beta => :β,
+        :SB2006_reference_air_density => :ρ0,
+    )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return EvaporationSB2006{FT}(; parameters...)
 end
 
 """
@@ -442,73 +568,21 @@ struct SB2006{FT, PD, AV, AR, SC, BR, EV} <: Precipitation2MType{FT}
     evap::EV
 end
 
-function SB2006(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
+SB2006(::Type{FT}) where {FT <: AbstractFloat} = SB2006(CP.create_toml_dict(FT))
 
-    pdf = ParticlePDF_SB2006(
-        FT(data["SB2006_raindrops_min_mass"]["value"]),
-        FT(data["SB2006_raindrops_max_mass"]["value"]),
-        FT(data["SB2006_raindrops_size_distribution_coeff_N0_min"]["value"]),
-        FT(data["SB2006_raindrops_size_distribution_coeff_N0_max"]["value"]),
-        FT(
-            data["SB2006_raindrops_size_distribution_coeff_lambda_min"]["value"],
-        ),
-        FT(
-            data["SB2006_raindrops_size_distribution_coeff_lambda_max"]["value"],
-        ),
-        FT(data["density_liquid_water"]["value"]),
-        FT(data["SB2006_reference_air_density"]["value"]),
-    )
-    acnv = AcnvSB2006(
-        FT(data["SB2006_collection_kernel_coeff_kcc"]["value"]),
-        FT(data["SB2006_cloud_gamma_distribution_parameter"]["value"]),
-        FT(data["SB2006_raindrops_min_mass"]["value"]),
-        FT(data["SB2006_reference_air_density"]["value"]),
-        FT(data["SB2006_autoconversion_correcting_function_coeff_A"]["value"]),
-        FT(data["SB2006_autoconversion_correcting_function_coeff_a"]["value"]),
-        FT(data["SB2006_autoconversion_correcting_function_coeff_b"]["value"]),
-    )
-    accr = AccrSB2006(
-        FT(data["SB2006_collection_kernel_coeff_kcr"]["value"]),
-        FT(data["SB2006_accretion_correcting_function_coeff_tau0"]["value"]),
-        FT(data["SB2006_reference_air_density"]["value"]),
-        FT(data["SB2006_accretion_correcting_function_coeff_c"]["value"]),
-    )
-    self = SelfColSB2006(
-        FT(data["SB2006_collection_kernel_coeff_krr"]["value"]),
-        FT(data["SB2006_collection_kernel_coeff_kapparr"]["value"]),
-        FT(data["SB2006_raindrops_self-collection_coeff_d"]["value"]),
-    )
-    brek = BreakupSB2006(
-        FT(data["SB2006_raindrops_equlibrium_mean_diameter"]["value"]),
-        FT(data["SB2006_raindrops_breakup_mean_diameter_threshold"]["value"]),
-        FT(data["SB2006_raindrops_breakup_coeff_kbr"]["value"]),
-        FT(data["SB2006_raindrops_breakup_coeff_kappabr"]["value"]),
-    )
-    evap = EvaporationSB2006(
-        FT(data["SB2006_ventilation_factor_coeff_av"]["value"]),
-        FT(data["SB2006_ventilation_factor_coeff_bv"]["value"]),
-        FT(data["SB2006_rain_evaportation_coeff_alpha"]["value"]),
-        FT(data["SB2006_rain_evaportation_coeff_beta"]["value"]),
-        FT(data["SB2006_reference_air_density"]["value"]),
-    )
-    return SB2006{
-        FT,
-        typeof(pdf),
-        typeof(acnv),
-        typeof(accr),
-        typeof(self),
-        typeof(brek),
-        typeof(evap),
-    }(
-        pdf,
-        acnv,
-        accr,
-        self,
-        brek,
-        evap,
-    )
+function SB2006(toml_dict::CP.AbstractTOMLDict)
+    pdf = ParticlePDF_SB2006(toml_dict)
+    acnv = AcnvSB2006(toml_dict)
+    accr = AccrSB2006(toml_dict)
+    self = SelfColSB2006(toml_dict)
+    brek = BreakupSB2006(toml_dict)
+    evap = EvaporationSB2006(toml_dict)
+    FT = CP.float_type(toml_dict)
+    PD = typeof(pdf)
+    AN = typeof(acnv)
+    AR = typeof(accr)
+    SE = typeof(self)
+    BR = typeof(brek)
+    EV = typeof(evap)
+    return SB2006{FT, PD, AN, AR, SE, BR, EV}(pdf, acnv, accr, self, brek, evap)
 end

--- a/src/parameters/MicrophysicsP3.jl
+++ b/src/parameters/MicrophysicsP3.jl
@@ -9,7 +9,7 @@ Morrison and Milbrandt 2015 doi: 10.1175/JAS-D-14-0065.1
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct ParametersP3{FT} <: ParametersType{FT}
+Base.@kwdef struct ParametersP3{FT} <: ParametersType{FT}
     "Coefficient in mass(size) relation [g/μm^β_va]"
     α_va::FT
     "Coefficient in mass(size) relation [-]"
@@ -32,21 +32,23 @@ struct ParametersP3{FT} <: ParametersType{FT}
     μ_max::FT
 end
 
-function ParametersP3(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return ParametersP3(
-        FT(data["BF1995_mass_coeff_alpha"]["value"]),
-        FT(data["BF1995_mass_exponent_beta"]["value"]),
-        FT(data["density_ice_water"]["value"]),
-        FT(data["density_liquid_water"]["value"]),
-        FT(data["M1996_area_coeff_gamma"]["value"]),
-        FT(data["M1996_area_exponent_sigma"]["value"]),
-        FT(data["Heymsfield_mu_coeff1"]["value"]),
-        FT(data["Heymsfield_mu_coeff2"]["value"]),
-        FT(data["Heymsfield_mu_coeff3"]["value"]),
-        FT(data["Heymsfield_mu_cutoff"]["value"]),
+ParametersP3(::Type{FT}) where {FT <: AbstractFloat} =
+    ParametersP3(CP.create_toml_dict(FT))
+
+function ParametersP3(td::CP.AbstractTOMLDict)
+    name_map = (;
+        :BF1995_mass_coeff_alpha => :α_va,
+        :BF1995_mass_exponent_beta => :β_va,
+        :density_ice_water => :ρ_i,
+        :density_liquid_water => :ρ_l,
+        :M1996_area_coeff_gamma => :γ,
+        :M1996_area_exponent_sigma => :σ,
+        :Heymsfield_mu_coeff1 => :a,
+        :Heymsfield_mu_coeff2 => :b,
+        :Heymsfield_mu_coeff3 => :c,
+        :Heymsfield_mu_cutoff => :μ_max,
     )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return ParametersP3{FT}(; parameters...)
 end

--- a/src/parameters/WaterProperties.jl
+++ b/src/parameters/WaterProperties.jl
@@ -8,20 +8,19 @@ Parameters with water properties.
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct WaterProperties{FT} <: ParametersType{FT}
+Base.@kwdef struct WaterProperties{FT} <: ParametersType{FT}
     "density of liquid water [kg/m3]"
     ρw::FT
     "density of ice [kg/m3]"
     ρi::FT
 end
 
-function WaterProperties(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
-    (; data) = toml_dict
-    return WaterProperties(
-        FT(data["density_liquid_water"]["value"]),
-        FT(data["density_ice_water"]["value"]),
-    )
+WaterProperties(::Type{FT}) where {FT <: AbstractFloat} =
+    WaterProperties(CP.create_toml_dict(FT))
+
+function WaterProperties(td::CP.AbstractTOMLDict)
+    name_map = (; :density_liquid_water => :ρw, :density_ice_water => :ρi)
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    FT = CP.float_type(td)
+    return WaterProperties{FT}(; parameters...)
 end


### PR DESCRIPTION
This PR changes all existing parameter constructors to use `get_parameter_values` instead of accessing the toml dict directly. This requires a lot of lines changed, but most of it is boilerplate.

### Example for Kaolinite
Original:
```julia
function Kaolinite(
    ::Type{FT},
    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
) where {FT}
    (; data) = toml_dict
    return Kaolinite(
        FT(data["China2017_J_deposition_m_Kaolinite"]["value"]),
        FT(data["China2017_J_deposition_c_Kaolinite"]["value"]),
        FT(data["KnopfAlpert2013_J_ABIFM_m_Kaolinite"]["value"]),
        FT(data["KnopfAlpert2013_J_ABIFM_c_Kaolinite"]["value"]),
    )
end
```
New constructor:
```julia
Kaolinite(::Type{FT}) where {FT <: AbstractFloat} =
    Kaolinite(CP.create_toml_dict(FT))

function Kaolinite(td::CP.AbstractTOMLDict)
    name_map = (;
        :China2017_J_deposition_m_Kaolinite => :deposition_m,
        :China2017_J_deposition_c_Kaolinite => :deposition_c,
        :KnopfAlpert2013_J_ABIFM_m_Kaolinite => :ABIFM_m,
        :KnopfAlpert2013_J_ABIFM_c_Kaolinite => :ABIFM_c,
    )
    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
    FT = CP.float_type(td)
    return Kaolinite{FT}(; parameters...)
end
```

### Key Changes
Constructors with the form: `ParamStruct(FT, toml_dict = CP.create_toml_dict(FT))` have been changed to 
`ParamStruct(FT) = ParamStruct(CP.create_toml_dict(FT))` and `ParamStruct(toml_dict)`. 
This preserves the behavior of `ParamStruct(FT)`, but is technically an interface change since a call like `ParamStruct(FT, toml_dict)` is no longer possible.

Add a kwarg constructor for most parameter structs - this is needed for nicer integration with climaparameters.

The biggest changes are in the 1 moment Rain, Snow, and CloudIce constructors:
- Add a few new TOML-based constructors for small structs (AcnvB1994, AccrKK2000, AccrB1994, etc)
- Dispatch `ParticleMass` and `ParticleArea` constructors for Rain, Snow, and CloudIce