### PR TITLE
Bring the docs up to speed

### DIFF
--- a/parcel/Immersion_Freezing.jl
+++ b/parcel/Immersion_Freezing.jl
@@ -6,7 +6,7 @@ import CLIMAParameters as CP
 
 # definition of the ODE problem for parcel model
 include(joinpath(pkgdir(CM), "parcel", "parcel.jl"))
-FT = Float64
+FT = Float32
 # get free parameters
 tps = TD.Parameters.ThermodynamicsParameters(FT)
 aps = CMP.AirProperties(FT)
@@ -26,7 +26,7 @@ r₀ = FT(1e-6)
 p₀ = FT(800 * 1e2)
 T₀ = FT(251)
 qᵥ = FT(8.1e-4)
-qₗ = Nₗ * 4 / 3 * FT(π) * r₀^3 * ρₗ / 1.2 # 1.2 should be ρₐ
+qₗ = Nₗ * 4 / 3 * FT(π) * r₀^3 * ρₗ / FT(1.2) # 1.2 should be ρₐ
 qᵢ = FT(0)
 x_sulph = FT(0.01)
 

--- a/parcel/Jensen_et_al_2022.jl
+++ b/parcel/Jensen_et_al_2022.jl
@@ -9,7 +9,7 @@ import CloudMicrophysics.Parameters as CMP
 # definition of the ODE problem for parcel model
 include(joinpath(pkgdir(CM), "parcel", "parcel.jl"))
 
-FT = Float64
+FT = Float32
 
 # Get free parameters
 tps = TD.Parameters.ThermodynamicsParameters(FT)
@@ -42,7 +42,7 @@ x_sulph = FT(0)
 # saturation and partial pressure
 eₛ = TD.saturation_vapor_pressure(tps, T₀, TD.Liquid())
 qᵥ = ϵₘ / (ϵₘ - 1 + 1 / cᵥ₀)
-qₗ = Nₗ * 4 / 3 * FT(π) * r₀^3 * ρₗ / 1.2
+qₗ = Nₗ * 4 / 3 * FT(π) * r₀^3 * ρₗ / FT(1.2)
 qᵢ = FT(0)
 q = TD.PhasePartition(qᵥ + qₗ + qᵢ, qₗ, qᵢ)
 R_a = TD.gas_constant_air(tps, q)

--- a/parcel/Liquid_only.jl
+++ b/parcel/Liquid_only.jl
@@ -7,7 +7,7 @@ import CLIMAParameters as CP
 # definition of the ODE problem for parcel model
 include(joinpath(pkgdir(CM), "parcel", "parcel.jl"))
 
-FT = Float64
+FT = Float32
 
 # Get free parameters
 tps = TD.Parameters.ThermodynamicsParameters(FT)

--- a/parcel/Tully_et_al_2023.jl
+++ b/parcel/Tully_et_al_2023.jl
@@ -203,4 +203,4 @@ function Tully_et_al_2023(FT)
     end
     MK.save("cirrus_box.svg", fig)
 end
-Tully_et_al_2023(Float64)
+Tully_et_al_2023(Float32)

--- a/parcel/parcel.jl
+++ b/parcel/parcel.jl
@@ -36,7 +36,7 @@ function parcel_model(dY, Y, p, t)
     N_aer = Y[7]      # number concentration of interstitial aerosol
     N_liq = Y[8]      # number concentration of existing water droplets
     N_ice = Y[9]      # number concentration of activated ice crystals
-    x_sulph = Y[10]   # percent mass sulphuric acid    
+    x_sulph = Y[10]   # percent mass sulphuric acid
 
     # Constants
     R_v = TD.Parameters.R_v(tps)
@@ -350,8 +350,8 @@ function run_parcel(IC, t_0, t_end, p)
         problem,
         timestepper,
         dt = const_dt,
-        reltol = 10 * eps(FT),
-        abstol = 10 * eps(FT),
+        reltol = 100 * eps(FT),
+        abstol = 100 * eps(FT),
     )
     return sol
 end


### PR DESCRIPTION
This PR brings the docs compile time back to reasonable. `112.712372 seconds (1.54 G allocations: 72.581 GiB, 5.14% gc time, 36.17% compilation time: 8% of which was recompilation)` on my laptop.  The reason for the slowdown was setting a very demanding tolerances for the ODE solver in our parcel model (especially if running with `Float64` precision). I think by default we should run everything in `Float32`

Btw, when I was running individual simulations I noticed some of them were throwing warnings like:

`WARNING: Multiple deposition nucleation parameterizations chosen to run in one simulation. Parcel will only run MohlerAF_Deposition for now.`

Is that expected behavior @amylu00 ?