### PR TITLE
Clean up parameter changes

### DIFF
--- a/src/parameters/IceNucleation.jl
+++ b/src/parameters/IceNucleation.jl
@@ -78,14 +78,15 @@ struct IceNucleationParameters{FT, DEP, HOM} <: ParametersType{FT}
     homogeneous::HOM
 end
 
-function IceNucleationParameters(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
+IceNucleationParameters(::Type{FT}) where {FT <: AbstractFloat} =
+    IceNucleationParameters(CP.create_toml_dict(FT))
+
+function IceNucleationParameters(toml_dict::CP.AbstractTOMLDict)
     deposition = Mohler2006(toml_dict)
     homogeneous = Koop2000(toml_dict)
     DEP = typeof(deposition)
     HOM = typeof(homogeneous)
+    FT = CP.float_type(toml_dict)
     return IceNucleationParameters{FT, DEP, HOM}(deposition, homogeneous)
 end
 

--- a/src/parameters/Microphysics2M.jl
+++ b/src/parameters/Microphysics2M.jl
@@ -77,12 +77,13 @@ struct KK2000{FT, AV, AR} <: Precipitation2MType{FT}
     accr::AR
 end
 
-function KK2000(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
+KK2000(::Type{FT}) where {FT <: AbstractFloat} = KK2000(CP.create_toml_dict(FT))
+
+
+function KK2000(toml_dict::CP.AbstractTOMLDict)
     acnv = AcnvKK2000(toml_dict)
     accr = AccrKK2000(toml_dict)
+    FT = CP.float_type(toml_dict)
     return KK2000{FT, typeof(acnv), typeof(accr)}(acnv, accr)
 end
 

--- a/src/parameters/TerminalVelocity.jl
+++ b/src/parameters/TerminalVelocity.jl
@@ -91,12 +91,13 @@ struct Blk1MVelType{FT, R, S} <: TerminalVelocityType{FT}
     snow::S
 end
 
-function Blk1MVelType(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
+Blk1MVelType(::Type{FT}) where {FT <: AbstractFloat} =
+    Blk1MVelType(CP.create_toml_dict(FT))
+
+function Blk1MVelType(toml_dict::CP.AbstractTOMLDict)
     rain = Blk1MVelTypeRain(toml_dict)
     snow = Blk1MVelTypeSnow(toml_dict)
+    FT = CP.float_type(toml_dict)
     return Blk1MVelType{FT, typeof(rain), typeof(snow)}(rain, snow)
 end
 
@@ -230,11 +231,12 @@ struct Chen2022VelType{FT, R, SI} <: TerminalVelocityType{FT}
     snow_ice::SI
 end
 
-function Chen2022VelType(
-    ::Type{FT},
-    toml_dict::CP.AbstractTOMLDict = CP.create_toml_dict(FT),
-) where {FT}
+Chen2022VelType(::Type{FT}) where {FT <: AbstractFloat} =
+    Chen2022VelType(CP.create_toml_dict(FT))
+
+function Chen2022VelType(toml_dict::CP.AbstractTOMLDict)
     rain = Chen2022VelTypeRain(toml_dict)
     snow_ice = Chen2022VelTypeSnowIce(toml_dict)
+    FT = CP.float_type(toml_dict)
     return Chen2022VelType{FT, typeof(rain), typeof(snow_ice)}(rain, snow_ice)
 end


### PR DESCRIPTION
I missed changing a few constructors in #315. 

This PR changes the following structs to have separate FT and toml dict based constructors:
- IceNucleationParameters
- KK2000
- Blk1MVelType
- Chen2022VelType

This is not strictly needed since no functionality is changed but I want to standardize the parameter constructors across repos.