### PR TITLE
Bump version for a new release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.18.0"
+version = "0.19.0"
 
 [deps]
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"


### PR DESCRIPTION
I don't think. it's a breaking release. But there was a lot of development from the last one. So just to be on the safe side I'm bumping it to `0.19`