### PR TITLE
Fix buildkite for new ClimaComms

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,6 +22,7 @@ steps:
       slurm_gpus: 1
       slurm_cpus_per_task: 8
     env:
+      CLIMACOMMS_DEVICE: "CUDA"
       JULIA_NUM_PRECOMPILE_TASKS: 8
 
   - wait
@@ -35,5 +36,7 @@ steps:
     key: "gpu_unittests"
     command:
       - "julia --project=test --color=yes test/gpu_tests.jl"
+    env:
+      CLIMACOMMS_DEVICE: "CUDA"
     agents:
       slurm_gpus: 1

--- a/test/gpu_tests.jl
+++ b/test/gpu_tests.jl
@@ -1,6 +1,7 @@
 using Test
 using KernelAbstractions
 using ClimaComms
+ClimaComms.@import_required_backends
 
 # Needed for parameters
 import CloudMicrophysics.Parameters as CMP


### PR DESCRIPTION
ClimaComms no longer automatically runs on the GPU if it finds one. See this [guide](https://github.com/CliMA/ClimaComms.jl/wiki/Transition-to-ClimaComms.jl-0.6) for details.