### PR TITLE
Aerosol constructor changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,16 @@ CloudMicrophysics.jl Release Notes
 main
 ------
 <!--- # Add changes since the most recent release here --->
+
+
+v0.20.0
+------
+
+- API change:
+  - return a named tuple in 2-moment microphysics rain evaporation
+  - changed aerosol size distribution constructor
+  - [#392](https://github.com/CliMA/CloudMicrophysics.jl/pull/392)
+
 - Added AIDA homogeneous ice nucleation data as artifacts ([#388](https://github.com/CliMA/CloudMicrophysics.jl/pull/388))
 
 - Generalize calibration functions in ice_nucleation_2024 ([#380](https://github.com/CliMA/CloudMicrophysics.jl/pull/380))

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.19.0"
+version = "0.20.0"
 
 [deps]
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"

--- a/docs/src/plots/ARGplots.jl
+++ b/docs/src/plots/ARGplots.jl
@@ -69,7 +69,6 @@ function make_ARG_figX(X)
         if X in (1, 4)
             vol_mixing_ratios_1 = (1.0,)
             mass_mixing_ratios_1 = (1.0,)
-            n_components_1 = 1
             if v_B
                 paper_mode_1 = AM.Mode_B(
                     r_dry_1,
@@ -81,7 +80,6 @@ function make_ARG_figX(X)
                     (sulfate.M,),
                     (sulfate.ν,),
                     (sulfate.ρ,),
-                    n_components_1,
                 )
             else
                 paper_mode_1 = AM.Mode_κ(
@@ -92,7 +90,6 @@ function make_ARG_figX(X)
                     mass_mixing_ratios_1,
                     (sulfate.M,),
                     (sulfate.κ,),
-                    n_components_1,
                 )
             end
         end
@@ -100,7 +97,6 @@ function make_ARG_figX(X)
         if X in (2, 3, 5)
             vol_mixing_ratios_1 = (1.0, 0.0)
             mass_mixing_ratios_1 = (1.0, 0.0)
-            n_components_1 = 2
             if v_B
                 paper_mode_1 = AM.Mode_B(
                     r_dry_1,
@@ -112,7 +108,6 @@ function make_ARG_figX(X)
                     (sulfate.M, M_insol),
                     (sulfate.ν, ν_insol),
                     (sulfate.ρ, ρ_insol),
-                    n_components_1,
                 )
             else
                 paper_mode_1 = AM.Mode_κ(
@@ -123,7 +118,6 @@ function make_ARG_figX(X)
                     mass_mixing_ratios_1,
                     (sulfate.M, M_insol),
                     (sulfate.κ, κ_insol),
-                    n_components_1,
                 )
             end
         end
@@ -139,7 +133,6 @@ function make_ARG_figX(X)
             w = 0.5                                         # vertical velocity, m/s
             r_dry_2 = 0.05 * 1e-6                           # um
             N_2 = range(100, stop = 5000, length = len) * 1e6   # 1/m3
-            n_components_2 = 1                              # 1 mode
             mass_mixing_ratios_2 = (1.0,)                   # all sulfate
             vol_mixing_ratios_2 = (1.0,)                    # all sulfate
 
@@ -155,7 +148,6 @@ function make_ARG_figX(X)
                         (sulfate.M,),
                         (sulfate.ν,),
                         (sulfate.ρ,),
-                        n_components_2,
                     )
                 else
                     paper_mode_2 = AM.Mode_κ(
@@ -166,7 +158,6 @@ function make_ARG_figX(X)
                         mass_mixing_ratios_2,
                         (sulfate.M,),
                         (sulfate.κ,),
-                        n_components_2,
                     )
                 end
                 AD = AM.AerosolDistribution((paper_mode_1, paper_mode_2))
@@ -195,7 +186,6 @@ function make_ARG_figX(X)
             w = 0.5                                         # vertical velocity, m/s
             r_dry_2 = 0.05 * 1e-6                           # um
             N_2 = range(100, stop = 5000, length = len) * 1e6   # 1/m3
-            n_components_2 = 2                              # 2 modes
             mass_mixing_ratios_2 = (0.1, 0.9)                # 10% sulfate, 90% insoluble
             vol_mixing_ratios_2 = mass2vol(mass_mixing_ratios_2)
 
@@ -211,7 +201,6 @@ function make_ARG_figX(X)
                         (sulfate.M, M_insol),
                         (sulfate.ν, ν_insol),
                         (sulfate.ρ, ρ_insol),
-                        n_components_2,
                     )
                 else
                     paper_mode_2 = AM.Mode_κ(
@@ -222,7 +211,6 @@ function make_ARG_figX(X)
                         mass_mixing_ratios_2,
                         (sulfate.M, M_insol),
                         (sulfate.κ, κ_insol),
-                        n_components_2,
                     )
                 end
                 AD = AM.AerosolDistribution((paper_mode_1, paper_mode_2))
@@ -251,7 +239,6 @@ function make_ARG_figX(X)
             w = 0.5                                     # vertical velocity, m/s
             r_dry_2 = 0.05 * 1e-6                       # um
             N_2 = 100 * 1e6                             # 1/m3
-            n_components_2 = 2                          # 2 modes
             # ranging from 10% to 100% sulfate, 90% to 0% insoluble
             xvar = range(0.1, stop = 1, length = len)
             mass_mixing_ratios_2 = [(i, 1 - i) for i in xvar]
@@ -269,7 +256,6 @@ function make_ARG_figX(X)
                         (sulfate.M, M_insol),
                         (sulfate.ν, ν_insol),
                         (sulfate.ρ, ρ_insol),
-                        n_components_2,
                     )
                 else
                     paper_mode_2 = AM.Mode_κ(
@@ -280,7 +266,6 @@ function make_ARG_figX(X)
                         mmr2i,
                         (sulfate.M, M_insol),
                         (sulfate.κ, κ_insol),
-                        n_components_2,
                     )
                 end
                 AD = AM.AerosolDistribution((paper_mode_1, paper_mode_2))
@@ -308,7 +293,6 @@ function make_ARG_figX(X)
             w = 0.5                                     # vertical velocity, m/s
             r_dry_2 = range(0.01, stop = 0.5, length = len) * 1e-6 # um
             N_2 = 100 * 1e6                             # 1/m3
-            n_components_2 = 1                          # 1 mode
             mass_mixing_ratios_2 = (1.0,)               # all sulfate
             vol_mixing_ratios_2 = mass2vol(mass_mixing_ratios_2)
 
@@ -324,7 +308,6 @@ function make_ARG_figX(X)
                         (sulfate.M,),
                         (sulfate.ν,),
                         (sulfate.ρ,),
-                        n_components_2,
                     )
                 else
                     paper_mode_2 = AM.Mode_κ(
@@ -335,7 +318,6 @@ function make_ARG_figX(X)
                         mass_mixing_ratios_2,
                         (sulfate.M,),
                         (sulfate.κ,),
-                        n_components_2,
                     )
                 end
                 AD = AM.AerosolDistribution((paper_mode_1, paper_mode_2))
@@ -364,7 +346,6 @@ function make_ARG_figX(X)
             w = range(0.01, stop = 5, length = len)     # vertical velocity, m/s
             r_dry_2 = 0.05 * 1e-6                       # um
             N_2 = 100 * 1e6                             # 1/m3
-            n_components_2 = 2                          # 2 modes
             mass_mixing_ratios_2 = (0.1, 0.9)           # 10% sulfate, 90% insoluble
             vol_mixing_ratios_2 = mass2vol(mass_mixing_ratios_2)
 
@@ -379,7 +360,6 @@ function make_ARG_figX(X)
                     (sulfate.M, M_insol),
                     (sulfate.ν, ν_insol),
                     (sulfate.ρ, ρ_insol),
-                    n_components_2,
                 )
             else
                 paper_mode_2 = AM.Mode_κ(
@@ -390,7 +370,6 @@ function make_ARG_figX(X)
                     mass_mixing_ratios_2,
                     (sulfate.M, M_insol),
                     (sulfate.κ, κ_insol),
-                    n_components_2,
                 )
             end
             AD = AM.AerosolDistribution((paper_mode_1, paper_mode_2))

--- a/docs/src/plots/ARGplots_fig1.jl
+++ b/docs/src/plots/ARGplots_fig1.jl
@@ -37,7 +37,6 @@ N_1 = 100.0 * 1e6   # 1/m3
 # Sulfate - universal parameters
 sulfate = CMP.Sulfate(FT)
 
-n_components_1 = 1
 mass_fractions_1 = (1.0,)
 paper_mode_1_B = AM.Mode_B(
     r_dry,
@@ -49,7 +48,6 @@ paper_mode_1_B = AM.Mode_B(
     (sulfate.M,),
     (sulfate.ν,),
     (sulfate.ρ,),
-    n_components_1,
 )
 
 N_2_range = range(0, stop = 5000 * 1e6, length = 100)
@@ -57,7 +55,6 @@ N_act_frac_B = Vector{Float64}(undef, 100)
 
 it = 1
 for N_2 in N_2_range
-    n_components_2 = 1
     mass_fractions_2 = (1.0,)
     paper_mode_2_B = AM.Mode_B(
         r_dry,
@@ -69,7 +66,6 @@ for N_2 in N_2_range
         (sulfate.M,),
         (sulfate.ν,),
         (sulfate.ρ,),
-        n_components_2,
     )
     AD_B = AM.AerosolDistribution((paper_mode_1_B, paper_mode_2_B))
     N_act_frac_B[it] =

--- a/docs/src/plots/RainEvapoartionSB2006.jl
+++ b/docs/src/plots/RainEvapoartionSB2006.jl
@@ -51,7 +51,7 @@ function rain_evaporation_CPU(SB2006, aps, tps, q, q_rai, ρ, N_rai, T)
         evap_rate_1 = min(FT(0), FT(2) * FT(π) * G * S * N_rai * Dr * Fv1 / ρ)
     end
 
-    return (evap_rate_0, evap_rate_1)
+    return (; evap_rate_0, evap_rate_1)
 end
 
 qᵥ = FT(1e-2)
@@ -66,21 +66,21 @@ Nᵣ_range = range(1e6, stop = 1e9, length = 1000)
 T_range = range(273.15, stop = 273.15 + 50, length = 1000)
 
 #! format: off
-evap_qᵣ_0 = [rain_evaporation_CPU(SB2006, aps, tps, q, _qᵣ, ρ, Nᵣ, T)[1] for _qᵣ in qᵣ_range]
-evap_Nᵣ_0 = [rain_evaporation_CPU(SB2006, aps, tps, q, qᵣ, ρ, _Nᵣ, T)[1] for _Nᵣ in Nᵣ_range]
-evap_T_0 = [rain_evaporation_CPU(SB2006, aps, tps, q, qᵣ, ρ, Nᵣ, _T)[1] for _T in T_range]
+evap_qᵣ_0 = [rain_evaporation_CPU(SB2006, aps, tps, q, _qᵣ, ρ, Nᵣ, T).evap_rate_0 for _qᵣ in qᵣ_range]
+evap_Nᵣ_0 = [rain_evaporation_CPU(SB2006, aps, tps, q, qᵣ, ρ, _Nᵣ, T).evap_rate_0 for _Nᵣ in Nᵣ_range]
+evap_T_0 = [rain_evaporation_CPU(SB2006, aps, tps, q, qᵣ, ρ, Nᵣ, _T).evap_rate_0 for _T in T_range]
 
-evap_qᵣ_0n = [CM2.rain_evaporation(SB2006, aps, tps, q, _qᵣ, ρ, Nᵣ, T)[1] for _qᵣ in qᵣ_range]
-evap_Nᵣ_0n = [CM2.rain_evaporation(SB2006, aps, tps, q, qᵣ, ρ, _Nᵣ, T)[1] for _Nᵣ in Nᵣ_range]
-evap_T_0n = [CM2.rain_evaporation(SB2006, aps, tps, q, qᵣ, ρ, Nᵣ, _T)[1] for _T in T_range]
+evap_qᵣ_0n = [CM2.rain_evaporation(SB2006, aps, tps, q, _qᵣ, ρ, Nᵣ, T).evap_rate_0 for _qᵣ in qᵣ_range]
+evap_Nᵣ_0n = [CM2.rain_evaporation(SB2006, aps, tps, q, qᵣ, ρ, _Nᵣ, T).evap_rate_0 for _Nᵣ in Nᵣ_range]
+evap_T_0n = [CM2.rain_evaporation(SB2006, aps, tps, q, qᵣ, ρ, Nᵣ, _T).evap_rate_0 for _T in T_range]
 
-evap_qᵣ_3 = [rain_evaporation_CPU(SB2006, aps, tps, q, _qᵣ, ρ, Nᵣ, T)[2] for _qᵣ in qᵣ_range]
-evap_Nᵣ_3 = [rain_evaporation_CPU(SB2006, aps, tps, q, qᵣ, ρ, _Nᵣ, T)[2] for _Nᵣ in Nᵣ_range]
-evap_T_3 = [rain_evaporation_CPU(SB2006, aps, tps, q, qᵣ, ρ, Nᵣ, _T)[2] for _T in T_range]
+evap_qᵣ_3 = [rain_evaporation_CPU(SB2006, aps, tps, q, _qᵣ, ρ, Nᵣ, T).evap_rate_1 for _qᵣ in qᵣ_range]
+evap_Nᵣ_3 = [rain_evaporation_CPU(SB2006, aps, tps, q, qᵣ, ρ, _Nᵣ, T).evap_rate_1 for _Nᵣ in Nᵣ_range]
+evap_T_3 = [rain_evaporation_CPU(SB2006, aps, tps, q, qᵣ, ρ, Nᵣ, _T).evap_rate_1 for _T in T_range]
 
-evap_qᵣ_3n = [CM2.rain_evaporation(SB2006, aps, tps, q, _qᵣ, ρ, Nᵣ, T)[2] for _qᵣ in qᵣ_range]
-evap_Nᵣ_3n = [CM2.rain_evaporation(SB2006, aps, tps, q, qᵣ, ρ, _Nᵣ, T)[2] for _Nᵣ in Nᵣ_range]
-evap_T_3n = [CM2.rain_evaporation(SB2006, aps, tps, q, qᵣ, ρ, Nᵣ, _T)[2] for _T in T_range]
+evap_qᵣ_3n = [CM2.rain_evaporation(SB2006, aps, tps, q, _qᵣ, ρ, Nᵣ, T).evap_rate_1 for _qᵣ in qᵣ_range]
+evap_Nᵣ_3n = [CM2.rain_evaporation(SB2006, aps, tps, q, qᵣ, ρ, _Nᵣ, T).evap_rate_1 for _Nᵣ in Nᵣ_range]
+evap_T_3n = [CM2.rain_evaporation(SB2006, aps, tps, q, qᵣ, ρ, Nᵣ, _T).evap_rate_1 for _T in T_range]
 
 fig = MK.Figure(resolution = (800, 600))
 

--- a/ext/Common.jl
+++ b/ext/Common.jl
@@ -35,7 +35,6 @@ function read_aerosol_dataset(
     df = filter(row -> row.S_max > 0 && row.S_max < 0.2, initial_data)
     selected_columns_X = []
     num_modes = get_num_modes(df)
-    @info(num_modes)
     for i in 1:num_modes
         append!(
             selected_columns_X,
@@ -97,7 +96,7 @@ function get_ARG_act_frac(
         push!(mode_kappas, data_row[Symbol("mode_$(i)_kappa")])
     end
     ad = AM.AerosolDistribution(
-        Tuple(
+        (
             AM.Mode_κ(
                 mode_means[i],
                 mode_stdevs[i],
@@ -106,9 +105,8 @@ function get_ARG_act_frac(
                 FT(1),
                 FT(0),
                 FT(mode_kappas[i]),
-                1,
             ) for i in 1:num_modes
-        ),
+        )...,
     )
     pv0 = TD.saturation_vapor_pressure(tps, FT(T), TD.Liquid())
     vapor_mix_ratio = pv0 / TD.Parameters.molmass_ratio(tps) / (p - pv0)

--- a/src/AerosolActivation.jl
+++ b/src/AerosolActivation.jl
@@ -59,7 +59,7 @@ function mean_hygroscopicity_parameter(
 ) where {N, T <: AM.Mode_B}
     return ntuple(Val(AM.n_modes(ad))) do i
         FT = eltype(ap)
-        mode_i = ad.Modes[i]
+        mode_i = ad.modes[i]
 
         nom = FT(0)
         @inbounds for j in 1:(AM.n_components(mode_i))
@@ -85,7 +85,7 @@ function mean_hygroscopicity_parameter(
 
     return ntuple(Val(AM.n_modes(ad))) do i
         FT = eltype(ap)
-        mode_i = ad.Modes[i]
+        mode_i = ad.modes[i]
 
         result = FT(0)
         @inbounds for j in 1:(AM.n_components(mode_i))
@@ -114,7 +114,7 @@ function critical_supersaturation(
     hygro = mean_hygroscopicity_parameter(ap, ad)
 
     return ntuple(Val(AM.n_modes(ad))) do i
-        2 / sqrt(hygro[i]) * (A / 3 / ad.Modes[i].r_dry)^FT(3 / 2)
+        2 / sqrt(hygro[i]) * (A / 3 / ad.modes[i].r_dry)^FT(3 / 2)
     end
 end
 
@@ -163,7 +163,7 @@ function max_supersaturation(
     tmp::FT = FT(0)
     @inbounds for i in 1:AM.n_modes(ad)
 
-        mode_i = ad.Modes[i]
+        mode_i = ad.modes[i]
 
         f::FT = ap.f1 * exp(ap.f2 * (log(mode_i.stdev))^2)
         g::FT = ap.g1 + ap.g2 * log(mode_i.stdev)
@@ -207,7 +207,7 @@ function N_activated_per_mode(
 
     return ntuple(Val(AM.n_modes(ad))) do i
 
-        mode_i = ad.Modes[i]
+        mode_i = ad.modes[i]
         u_i::FT = 2 * log(sm[i] / smax) / 3 / sqrt(2) / log(mode_i.stdev)
 
         mode_i.N * (1 / 2) * (1 - SF.erf(u_i))
@@ -244,7 +244,7 @@ function M_activated_per_mode(
 
     return ntuple(Val(AM.n_modes(ad))) do i
 
-        mode_i = ad.Modes[i]
+        mode_i = ad.modes[i]
 
         avg_molar_mass_i = FT(0)
         @inbounds for j in 1:(AM.n_components(mode_i))

--- a/src/AerosolModel.jl
+++ b/src/AerosolModel.jl
@@ -23,7 +23,7 @@ and follow a lognormal size distribution.
 The chemical composition of aerosol particles in this mode
 is described using the parameters from Abdul-Razzak and Ghan 2000.
 """
-struct Mode_B{NCOMP, T, FT}
+struct Mode_B{T, FT}
     "geometric mean dry radius"
     r_dry::FT
     "geometric standard deviation"
@@ -54,9 +54,8 @@ function Mode_B(
     molar_mass::T,
     dissoc::T,
     aerosol_density::T,
-    NCOMP::Int,
 ) where {T, FT}
-    return Mode_B{NCOMP, T, FT}(
+    return Mode_B{T, FT}(
         r_dry,
         stdev,
         N,
@@ -70,7 +69,8 @@ function Mode_B(
 end
 
 """ number of components in the mode """
-n_components(::Mode_B{NCOMP}) where {NCOMP} = NCOMP
+n_components(::Mode_B{T}) where {T <: Tuple} = fieldcount(T)
+n_components(::Mode_B{T}) where {T <: Real} = 1
 
 """
     Mode_κ
@@ -82,7 +82,7 @@ and follow a lognormal size distribution.
 The chemical composition of aerosol particles in this mode
 is described using the parameters from Petters and Kreidenweis 2007.
 """
-struct Mode_κ{NCOMP, T, FT}
+struct Mode_κ{T, FT}
     "geometric mean dry radius"
     r_dry::FT
     "geometric standard deviation"
@@ -107,9 +107,8 @@ function Mode_κ(
     mass_mix_ratio::T,
     molar_mass::T,
     kappa::T,
-    NCOMP::Int,
 ) where {T, FT}
-    return Mode_κ{NCOMP, T, FT}(
+    return Mode_κ{T, FT}(
         r_dry,
         stdev,
         N,
@@ -121,7 +120,8 @@ function Mode_κ(
 end
 
 """ number of components in the mode """
-n_components(::Mode_κ{NCOMP}) where {NCOMP} = NCOMP
+n_components(::Mode_κ{T}) where {T <: Tuple} = fieldcount(T)
+n_components(::Mode_κ{T}) where {T <: Real} = 1
 
 """
     AerosolDistribution
@@ -132,18 +132,18 @@ or of type Mode_κ (Petters and Kreidenweis 2007).
 
 # Constructors
 
-    AerosolDistribution(Modes::T)
+    AerosolDistribution(modes::T)
 """
 struct AerosolDistribution{T} <: CMP.AerosolDistributionType
 
     "tuple with all aerosol size distribution modes"
-    Modes::T
+    modes::T
 
 end
-function AerosolDistribution(Modes::NTuple{N, T}) where {N, T}
-    return AerosolDistribution{typeof(Modes)}(Modes)
-end
+AerosolDistribution(modes::Union{Mode_κ, Mode_B}...) =
+    AerosolDistribution{typeof(modes)}(modes)
+
 Base.broadcastable(x::AerosolDistribution) = tuple(x)
-n_modes(::AerosolDistribution{NTuple{N, T}}) where {N, T} = N
+n_modes(d::AerosolDistribution) = length(d.modes)
 
 end

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -396,7 +396,7 @@ end
  - `N_rai` - raindrops number density
  - `T` - air temperature
 
-Returns a tupple containing the tendency of raindrops number density and rain water
+Returns a named tuple containing the tendency of raindrops number density and rain water
 specific humidity due to rain rain_evaporation, assuming a power law velocity relation for
 fall velocity of individual drops and an exponential size distribution, for `scheme == SB2006Type`
 """
@@ -444,23 +444,23 @@ function rain_evaporation(
         evap_rate_1 = min(FT(0), FT(2) * FT(π) * G * S * N_rai * Dr * Fv1 / ρ)
     end
 
-    return (evap_rate_0, evap_rate_1)
+    return (; evap_rate_0, evap_rate_1)
 end
 
-""" 
+"""
     radar_reflectivity(struct, q_liq, q_rai, N_liq, N_rai, ρ_air, ρ_w, τ_q, τ_N)
 
     - `struct` - type for 2-moment rain autoconversion parameterization
-    - `q_liq` - cloud water specific humidity 
+    - `q_liq` - cloud water specific humidity
     - `q_rai` - rain water specific humidity
-    - `N_liq` - cloud droplet number density 
-    - `N_rai` - rain droplet number density 
+    - `N_liq` - cloud droplet number density
+    - `N_rai` - rain droplet number density
     - `ρ_air` - air density
     - `ρ_w` - water density
     - `τ_q` - threshold for minimum specific humidity value
     - `τ_N` - threshold for minimum number density value
 
-Returns logarithmic radar reflectivity from the assumed cloud and rain particle 
+Returns logarithmic radar reflectivity from the assumed cloud and rain particle
 size distribuions normalized by the reflectivty of 1 millimiter drop in a volume of
 one meter cube
 """
@@ -515,20 +515,20 @@ function radar_reflectivity(
            FT(10) * (log10((Zc + Zr) / Z₀) + log10(FT(1e-9)))
 end
 
-""" 
+"""
     effective_radius(struct, q_liq, q_rai, N_liq, N_rai, ρ_air, ρ_w, τ_q, τ_N)
 
     - `struct` - type for 2-moment rain autoconversion parameterization
-    - `q_liq` - cloud water specific humidity 
+    - `q_liq` - cloud water specific humidity
     - `q_rai` - rain water specific humidity
-    - `N_liq` - cloud droplet number density 
-    - `N_rai` - rain droplet number density 
+    - `N_liq` - cloud droplet number density
+    - `N_rai` - rain droplet number density
     - `ρ_air` - air density
     - `ρ_w` - water density
     - `τ_q` - threshold for minimum specific humidity value
     - `τ_N` - threshold for minimum number density value
 
-Returns effective radius using the 2-moment scheme 
+Returns effective radius using the 2-moment scheme
 cloud and rain particle size distributions
 """
 function effective_radius(
@@ -586,13 +586,13 @@ function effective_radius(
            FT(1e-3)
 end
 
-""" 
+"""
     effective_radius_Liu_Hallet_97(q_liq, q_rai, N_liq, N_rai, ρ_air, ρ_w)
 
-    - `q_liq` - cloud water specific humidity 
+    - `q_liq` - cloud water specific humidity
     - `q_rai` - rain water specific humidity
-    - `N_liq` - cloud droplet number density 
-    - `N_rai` - rain droplet number density 
+    - `N_liq` - cloud droplet number density
+    - `N_rai` - rain droplet number density
     - `ρ_air` - air density
     - `ρ_w` - water density
 

--- a/test/aerosol_activation_calibration.jl
+++ b/test/aerosol_activation_calibration.jl
@@ -142,9 +142,9 @@ function test_emulator(FT; rtols = [1e-4, 1e-3, 0.26], N_samples_calib = 2)
     r2 = FT(1.5 * 1e-6)   # m
     σ2 = FT(2.1)          # -
     N2 = FT(1e6)          # 1/m3
-    acc = AM.Mode_κ(r1, σ1, N1, (FT(1.0),), (FT(1.0),), (salt.M,), (salt.κ,), 1)
-    crs = AM.Mode_κ(r2, σ2, N2, (FT(1.0),), (FT(1.0),), (salt.M,), (salt.κ,), 1)
-    ad = AM.AerosolDistribution((crs, acc))
+    acc = AM.Mode_κ(r1, σ1, N1, (FT(1.0),), (FT(1.0),), (salt.M,), (salt.κ,))
+    crs = AM.Mode_κ(r2, σ2, N2, (FT(1.0),), (FT(1.0),), (salt.M,), (salt.κ,))
+    ad = AM.AerosolDistribution(crs, acc)
 
     calib_params, errs = calibrate_ARG(FT, N_samples = N_samples_calib)
     ap_calib = CMP.AerosolActivationParameters(calib_params)

--- a/test/aerosol_activation_tests.jl
+++ b/test/aerosol_activation_tests.jl
@@ -67,7 +67,6 @@ function test_aerosol_activation(FT)
         (seasalt.M,),
         (seasalt.ν,),
         (seasalt.ρ,),
-        1,
     )
     accum_seasalt_κ = AM.Mode_κ(
         r_dry_accum,
@@ -77,7 +76,6 @@ function test_aerosol_activation(FT)
         (FT(1.0),),
         (seasalt.M,),
         (seasalt.κ,),
-        1,
     )
 
     coarse_seasalt_B = AM.Mode_B(
@@ -90,7 +88,6 @@ function test_aerosol_activation(FT)
         (seasalt.M,),
         (seasalt.ν,),
         (seasalt.ρ,),
-        1,
     )
     coarse_seasalt_κ = AM.Mode_κ(
         r_dry_coarse,
@@ -100,7 +97,6 @@ function test_aerosol_activation(FT)
         (FT(1.0),),
         (seasalt.M,),
         (seasalt.κ,),
-        1,
     )
 
     paper_mode_1_B = AM.Mode_B(
@@ -113,7 +109,6 @@ function test_aerosol_activation(FT)
         (sulfate.M,),
         (sulfate.ν,),
         (sulfate.ρ,),
-        1,
     )
     paper_mode_1_κ = AM.Mode_κ(
         r_dry_paper,
@@ -123,7 +118,6 @@ function test_aerosol_activation(FT)
         (FT(1.0),),
         (sulfate.M,),
         (sulfate.κ,),
-        1,
     )
 
     # Aerosol size distributions
@@ -246,7 +240,6 @@ function test_aerosol_activation(FT)
                     (sulfate.M,),
                     (sulfate.ν,),
                     (sulfate.ρ,),
-                    1,
                 )
                 paper_mode_2_κ = AM.Mode_κ(
                     r_dry_paper,
@@ -256,7 +249,6 @@ function test_aerosol_activation(FT)
                     (FT(1.0),),
                     (sulfate.M,),
                     (sulfate.κ,),
-                    1,
                 )
 
                 AD_B = AM.AerosolDistribution((paper_mode_1_B, paper_mode_2_B))

--- a/test/gpu_tests.jl
+++ b/test/gpu_tests.jl
@@ -75,7 +75,6 @@ const ArrayType = CuArray
             (M[i],),
             (ν[i],),
             (ρ[i],),
-            1,
         )
         mode_κ = AM.Mode_κ(
             r[i],
@@ -85,7 +84,6 @@ const ArrayType = CuArray
             (FT(1.0),),
             (M[i],),
             (κ[i],),
-            1,
         )
 
         arsl_dst_B = AM.AerosolDistribution((mode_B,))
@@ -338,9 +336,27 @@ end
         output[13, i] =
             CM2.rain_terminal_velocity(SB2006, SB2006Vel, qr[i], ρ[i], Nr[i])[2]
         output[14, i] =
-            CM2.rain_evaporation(SB2006, aps, tps, q, qr[i], ρ[i], Nr[i], T[i])[1]
+            CM2.rain_evaporation(
+                SB2006,
+                aps,
+                tps,
+                q,
+                qr[i],
+                ρ[i],
+                Nr[i],
+                T[i],
+            ).evap_rate_0
         output[15, i] =
-            CM2.rain_evaporation(SB2006, aps, tps, q, qr[i], ρ[i], Nr[i], T[i])[2]
+            CM2.rain_evaporation(
+                SB2006,
+                aps,
+                tps,
+                q,
+                qr[i],
+                ρ[i],
+                Nr[i],
+                T[i],
+            ).evap_rate_1
     end
 end
 

--- a/test/microphysics2M_tests.jl
+++ b/test/microphysics2M_tests.jl
@@ -462,9 +462,9 @@ function test_microphysics2M(FT)
         evap1 = 2 * FT(π) * G * S * N_rai * Dr * Fv1 / ρ
 
         #test
-        TT.@test evap isa Tuple
-        TT.@test evap[1] ≈ (evap0 - 2.5) rtol = 1e-4
-        TT.@test evap[2] ≈ evap1 rtol = 1e-5
+        TT.@test evap isa NamedTuple
+        TT.@test evap.evap_rate_0 ≈ (evap0 - 2.5) rtol = 1e-4
+        TT.@test evap.evap_rate_1 ≈ evap1 rtol = 1e-5
         TT.@test CM2.rain_evaporation(
             SB2006,
             aps,
@@ -474,7 +474,7 @@ function test_microphysics2M(FT)
             ρ,
             N_rai,
             T,
-        )[1] ≈ 0 atol = eps(FT)
+        ).evap_rate_0 ≈ 0 atol = eps(FT)
         TT.@test CM2.rain_evaporation(
             SB2006,
             aps,
@@ -484,11 +484,11 @@ function test_microphysics2M(FT)
             ρ,
             N_rai,
             T,
-        )[2] ≈ 0 atol = eps(FT)
+        ).evap_rate_1 ≈ 0 atol = eps(FT)
     end
 
     TT.@testset "2M_microphysics - Seifert and Beheng 2006 radar reflectivity" begin
-        #setup 
+        #setup
         ρ_air = FT(1)
         ρ_w = FT(1000)
         q_liq = FT(2.128e-4)
@@ -516,7 +516,7 @@ function test_microphysics2M(FT)
     end
 
     TT.@testset "2M_microphysics - Seifert and Beheng 2006 effective radius" begin
-        #setup 
+        #setup
         ρ_air = FT(1)
         ρ_w = FT(1000)
         q_liq = FT(2.128e-4)
@@ -545,7 +545,7 @@ function test_microphysics2M(FT)
     end
 
     TT.@testset "2M_microphysics - '1/3' power law from Liu and Hallett (1997)" begin
-        #setup 
+        #setup
         ρ_air = FT(1)
         ρ_w = FT(1000)
         q_liq = FT(2.128e-4)

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -113,7 +113,6 @@ function benchmark_test(FT)
         (FT(1),),
         (M_seasalt,),
         (κ_seasalt,),
-        1,
     )
     aer_distr = AM.AerosolDistribution((seasalt_mode,))
 


### PR DESCRIPTION
There are some changes in aerosol size distribution constructors that I needed in order to be able to broadcast in KinematicDriver.

I don't understand why, but it broke the ARG calibration test. @nefrathenrici, @sajjadazimi or @edejong-caltech - could I ask you to take a look? I'm not very familiar with that test. The ARG tests themselves seem fine, so maybe it's just something with the setup?

Aside from that I think that my life in KinematicDriver would be easier if rain_evaporation in 2-moment microphysics was returning a named tuple. So I changed that also.