### PR TITLE
Bugfix SB2006 evaporation; return 0 instead of NaN for xr = 0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ main
 ------
 <!--- # Add changes since the most recent release here --->
 
+- Bugfix; fixed the evaporation scheme of SB2006 to prevent returning NaN values when limiters are not applied. ([#420](https://github.com/CliMA/CloudMicrophysics.jl/pull/415))
 
 v0.20.0
 ------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.22.0"
+version = "0.22.1"
 
 [deps]
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -560,7 +560,10 @@ function rain_evaporation(
         evap_rate_0 = min(FT(0), FT(2) * FT(π) * G * S * N_rai * Dr * Fv0 / xr)
         evap_rate_1 = min(FT(0), FT(2) * FT(π) * G * S * N_rai * Dr * Fv1 / ρ)
 
-        evap_rate_0 = N_rai < eps(FT) ? FT(0) : evap_rate_0
+        # When xr = 0 evap_rate_0 becomes NaN. We replace NaN with 0 which is the limit of 
+        # evap_rate_0 for xr -> 0.
+        evap_rate_0 =
+            N_rai < eps(FT) || xr / x_star < eps(FT) ? FT(0) : evap_rate_0
         evap_rate_1 = q_rai < eps(FT) ? FT(0) : evap_rate_1
     end
 

--- a/test/microphysics2M_tests.jl
+++ b/test/microphysics2M_tests.jl
@@ -553,6 +553,19 @@ function test_microphysics2M(FT)
                 T,
             ).evap_rate_1 ≈ 0 atol = eps(FT)
         end
+
+        # test limit case: xr = 0 for SB with no limiters
+        TT.@test CM2.rain_evaporation(
+            SB2006_no_limiters,
+            aps,
+            tps,
+            q,
+            FT(0),
+            ρ,
+            N_rai,
+            T,
+        ).evap_rate_0 ≈ 0 atol = eps(FT)
+
     end
 
     TT.@testset "2M_microphysics - Seifert and Beheng 2006 effective radius and reflectivity" begin


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
SB2006 evaporation scheme used to return NaN for xr = 0 when limiters are not applied. The reason is that in the computation of number density rate we have a 0/0 term. The limit of this equation for XR -> 0 is zero. This PR adds a check in the code to catch cases where xr/x_star is small and return 0 instead of NaN.

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.
- I have read and checked the items on the review checklist.
