### PR TITLE
Bring back the velocity perf test

### DIFF
--- a/src/P3_particle_properties.jl
+++ b/src/P3_particle_properties.jl
@@ -174,8 +174,8 @@ function p3_mass(
         return mass_nl(p3, D)             # dense nonspherical ice
     elseif th.D_cr > D >= th.D_gr
         return mass_s(D, th.ρ_g)          # graupel
-    elseif D >= th.D_cr
-        return mass_r(p3, D, F_r)         # partially rimed ice
+    else #elseif D >= th.D_cr
+        mass_r(p3, D, F_r)                # partially rimed ice
     end
 end
 

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -155,14 +155,13 @@ function benchmark_test(FT)
             (p3, q_ice, N, ρ_r, F_r),
             1e5,
         )
-        # TODO
-        #bench_press(
-        #    P3.ice_terminal_velocity,
-        #    (p3, ch2022.snow_ice, q_ice, N, ρ_r, F_r, ρ_air),
-        #    2e5,
-        #    3e4,
-        #    2e3,
-        #)
+        bench_press(
+            P3.ice_terminal_velocity,
+            (p3, ch2022.snow_ice, q_ice, N, ρ_r, F_r, ρ_air),
+            2.1e5,
+            3e4,
+            2e3,
+        )
         bench_press(P3.D_m, (p3, q_ice, N, ρ_r, F_r), 1e5)
     end
 


### PR DESCRIPTION
The compiler was assuming there is an `else` at the end (even tho there wasn't) and assuming there was `Nothing` returned there. Hence the JET failures.  