### PR TITLE
update notation q -> L

### DIFF
--- a/docs/src/P3Scheme.md
+++ b/docs/src/P3Scheme.md
@@ -3,8 +3,8 @@
 The `P3Scheme.jl` module implements the predicted particle properties
  (P3) scheme for ice-phase microphysics developed by [MorrisonMilbrandt2015](@cite).
 The P3 scheme is a 2-moment, bulk scheme involving a
- single ice-phase category with 4 degrees of freedom: total mass,
- rime mass, rime volume, and number mixing ratios.
+ single ice-phase category with 4 degrees of freedom: total ice content,
+ rime content, rime volume, and number mixing ratios.
 Traditionally, cloud ice microphysics schemes use various predefined
  categories (such as ice, graupel, or hail) to represent ice modes, but the P3 scheme sidesteps the
  problem of prescribing transitions between ice categories by adopting
@@ -13,12 +13,18 @@ This simplification aids in attempts to constrain the scheme's free parameters.
 
 The prognostic variables are:
  - ``N_{ice}`` - number concentration 1/m3
- - ``q_{ice}`` - ice mass density kg/m3
- - ``q_{rim}`` - rime mass density kg/m3
+ - ``L_{ice}`` - ice mass content kg/m3
+ - ``L_{rim}`` - rime mass content kg/m3
  - ``B_{rim}`` - rime volume - (volume of rime per total air volume: dimensionless)
 
 !!! note
-    TODO - At some point we should switch to specific humidities...
+    The original paper [MorrisonMilbrandt2015](@cite) uses symbol ``q``
+    to denote the mass of a tracer per volume of air (named mass mixing ratio).
+    In our documentation of the 1-moment and 2-moment schemes we used ``q``
+    to denote the mass of a tracer per mass of air (named specific humidity).
+    To keep the notation consistent between the 1,2-moment schemes and P3,
+    and to highlight the difference between normalizing by air mass or volume,
+    we denote the mass of a tracer per volume of air as ``L`` (named content).
 
 ## Assumed particle size relationships
 
@@ -30,10 +36,10 @@ The mass ``m`` and projected area ``A`` of particles
 | particle properties                  |      condition(s)                            |    m(D) relation                             |    A(D) relation                                           |
 |:-------------------------------------|:---------------------------------------------|:---------------------------------------------|:-----------------------------------------------------------|
 |small, spherical ice                  | ``D < D_{th}``                               | ``\frac{\pi}{6} \rho_i \ D^3``               | ``\frac{\pi}{4} D^2``                                      |
-|large, unrimed ice                    | ``q_{rim} = 0`` and ``D > D_{th}``           | ``\alpha_{va} \ D^{\beta_{va}}``             | ``\gamma \ D^{\sigma}``                                    |
-|dense nonspherical ice                | ``q_{rim} > 0`` and ``D_{gr} > D > D_{th}``  | ``\alpha_{va} \ D^{\beta_{va}}``             | ``\gamma \ D^{\sigma}``                                    |
-|graupel (completely rimed, spherical) | ``q_{rim} > 0`` and ``D_{cr} > D > D_{gr}``  | ``\frac{\pi}{6} \rho_g \ D^3``               | ``\frac{\pi}{4} D^2``                                      |
-|partially rimed ice                   | ``q_{rim} > 0`` and ``D > D_{cr}``           | ``\frac{\alpha_{va}}{1-F_r} D^{\beta_{va}}`` | ``F_{r} \frac{\pi}{4} D^2 + (1-F_{r})\gamma \ D^{\sigma}`` |
+|large, unrimed ice                    | ``L_{rim} = 0`` and ``D > D_{th}``           | ``\alpha_{va} \ D^{\beta_{va}}``             | ``\gamma \ D^{\sigma}``                                    |
+|dense nonspherical ice                | ``L_{rim} > 0`` and ``D_{gr} > D > D_{th}``  | ``\alpha_{va} \ D^{\beta_{va}}``             | ``\gamma \ D^{\sigma}``                                    |
+|graupel (completely rimed, spherical) | ``L_{rim} > 0`` and ``D_{cr} > D > D_{gr}``  | ``\frac{\pi}{6} \rho_g \ D^3``               | ``\frac{\pi}{4} D^2``                                      |
+|partially rimed ice                   | ``L_{rim} > 0`` and ``D > D_{cr}``           | ``\frac{\alpha_{va}}{1-F_r} D^{\beta_{va}}`` | ``F_{r} \frac{\pi}{4} D^2 + (1-F_{r})\gamma \ D^{\sigma}`` |
 
 where:
  - ``D_{th}``, ``D_{gr}``, ``D_{cr}`` are particle size thresholds in ``m``,
@@ -55,8 +61,8 @@ The remaining thresholds: ``D_{gr}``, ``D_{cr}``, as well as the
  - ``\rho_g = \rho_r F_r + (1 - F_r) \rho_d``
  - ``\rho_d = \frac{6\alpha_{va}(D_{cr}^{\beta{va} \ - 2} - D_{gr}^{\beta{va} \ - 2})}{\pi \ (\beta_{va} \ - 2)(D_{cr}-D_{gr})}``
 where
- - ``F_r = \frac{q_{rim}}{q_{ice}}`` is the rime mass fraction,
- - ``\rho_{r} = \frac{q_{rim}}{B_{rim}}`` is the predicted rime density.
+ - ``F_r = \frac{L_{rim}}{L_{ice}}`` is the rime mass fraction,
+ - ``\rho_{r} = \frac{L_{rim}}{B_{rim}}`` is the predicted rime density.
 
 !!! note
     TODO - Check units, see in [issue #151](https://github.com/CliMA/CloudMicrophysics.jl/issues/151)
@@ -89,42 +95,42 @@ We assume ``\mu \ = 0.00191 \; \lambda \ ^{0.8} - 2``.
 Following [MorrisonGrabowski2008](@cite) we limit ``\mu \ \in (0,6)``.
 A negative ``\mu`` can occur only for very small mean particle sizes``\frac{1}{\lambda} < ~0.17 mm``.
 
-The model predicted ice number concentration and ice mass density are defined as
+The model predicted ice number concentration and ice content are defined as
 ```math
 N_{ice} = \int_{0}^{\infty} \! N'(D) \mathrm{d}D
 ```
 ```math
-q_{ice} = \int_{0}^{\infty} \! m(D) N'(D) \mathrm{d}D
+L_{ice} = \int_{0}^{\infty} \! m(D) N'(D) \mathrm{d}D
 ```
 
 ## Calculating shape parameters
 
 As a next step we need to find the mapping between
-  predicted moments of the size distribution ``N_{ice}`` and ``q_{ice}``
+  predicted moments of the size distribution ``N_{ice}`` and ``L_{ice}``
   and the shape parameters ``\lambda`` and ``N_0``.
 Solving for ``N_{ice}`` is relatively straightforward:
 ```math
 N_{ice} = \int_{0}^{\infty} \! N'(D) \mathrm{d}D = \int_{0}^{\infty} \! N_{0} D^\mu \, e^{-\lambda \, D} \mathrm{d}D = N_{0} (\lambda \,^{-(\mu \, + 1)} \Gamma \,(1 + \mu \,))
 ```
 
-``q_{ice}`` depends on the variable mass-size relation ``m(D)`` defined above.
-We solve for ``q_{ice}`` in a piece-wise fashion defined by the same thresholds as ``m(D)``.
-As a result ``q_{ice}`` can be expressed as a sum of inclomplete gamma functions,
+``L_{ice}`` depends on the variable mass-size relation ``m(D)`` defined above.
+We solve for ``L_{ice}`` in a piece-wise fashion defined by the same thresholds as ``m(D)``.
+As a result ``L_{ice}`` can be expressed as a sum of inclomplete gamma functions,
   and the shape parameters are found using iterative solver.
 
-|      condition(s)                            |    ``q_{ice} = \int \! m(D) N'(D) \mathrm{d}D``                                          |         gamma representation          |
+|      condition(s)                            |    ``L_{ice} = \int \! m(D) N'(D) \mathrm{d}D``                                          |         gamma representation          |
 |:---------------------------------------------|:-----------------------------------------------------------------------------------------|:---------------------------------------------|
 | ``D < D_{th}``                               | ``\int_{0}^{D_{th}} \! \frac{\pi}{6} \rho_i \ D^3 N'(D) \mathrm{d}D``                    | ``\frac{\pi}{6} \rho_i N_0 \lambda \,^{-(\mu \, + 4)} (\Gamma \,(\mu \, + 4) - \Gamma \,(\mu \, + 4, \lambda \,D_{th}))``|
-| ``q_{rim} = 0`` and ``D > D_{th}``           | ``\int_{D_{th}}^{\infty} \! \alpha_{va} \ D^{\beta_{va}} N'(D) \mathrm{d}D``             | ``\alpha_{va} \ N_0 \lambda \,^{-(\mu \, + \beta_{va} \, + 1)} (\Gamma \,(\mu \, + \beta_{va} \, + 1, \lambda \,D_{th}))`` |
-| ``q_{rim} > 0`` and ``D_{gr} > D > D_{th}``  | ``\int_{D_{th}}^{D_{gr}} \! \alpha_{va} \ D^{\beta_{va}} N'(D) \mathrm{d}D``             | ``\alpha_{va} \ N_0 \lambda \,^{-(\mu \, + \beta_{va} \, + 1)} (\Gamma \,(\mu \, + \beta_{va} \, + 1, \lambda \,D_{th}) - \Gamma \,(\mu \, + \beta_{va} \, + 1, \lambda \,D_{gr}))`` |
-| ``q_{rim} > 0`` and ``D_{cr} > D > D_{gr}``  | ``\int_{D_{gr}}^{D_{cr}} \! \frac{\pi}{6} \rho_g \ D^3 N'(D) \mathrm{d}D``               | ``\frac{\pi}{6} \rho_g N_0 \lambda \,^{-(\mu \, + 4)} (\Gamma \,(\mu \, + 4, \lambda \,D_{gr}) - \Gamma \,(\mu \, + 4, \lambda \,D_{cr}))`` |
-| ``q_{rim} > 0`` and ``D > D_{cr}``           | ``\int_{D_{cr}}^{\infty} \! \frac{\alpha_{va}}{1-F_r} D^{\beta_{va}} N'(D) \mathrm{d}D`` | ``\frac{\alpha_{va}}{1-F_r} N_0 \lambda \,^{-(\mu \, + \beta_{va} \, + 1)} (\Gamma \,(\mu \, + \beta_{va} \, + 1, \lambda \,D_{cr}))``  |
+| ``L_{rim} = 0`` and ``D > D_{th}``           | ``\int_{D_{th}}^{\infty} \! \alpha_{va} \ D^{\beta_{va}} N'(D) \mathrm{d}D``             | ``\alpha_{va} \ N_0 \lambda \,^{-(\mu \, + \beta_{va} \, + 1)} (\Gamma \,(\mu \, + \beta_{va} \, + 1, \lambda \,D_{th}))`` |
+| ``L_{rim} > 0`` and ``D_{gr} > D > D_{th}``  | ``\int_{D_{th}}^{D_{gr}} \! \alpha_{va} \ D^{\beta_{va}} N'(D) \mathrm{d}D``             | ``\alpha_{va} \ N_0 \lambda \,^{-(\mu \, + \beta_{va} \, + 1)} (\Gamma \,(\mu \, + \beta_{va} \, + 1, \lambda \,D_{th}) - \Gamma \,(\mu \, + \beta_{va} \, + 1, \lambda \,D_{gr}))`` |
+| ``L_{rim} > 0`` and ``D_{cr} > D > D_{gr}``  | ``\int_{D_{gr}}^{D_{cr}} \! \frac{\pi}{6} \rho_g \ D^3 N'(D) \mathrm{d}D``               | ``\frac{\pi}{6} \rho_g N_0 \lambda \,^{-(\mu \, + 4)} (\Gamma \,(\mu \, + 4, \lambda \,D_{gr}) - \Gamma \,(\mu \, + 4, \lambda \,D_{cr}))`` |
+| ``L_{rim} > 0`` and ``D > D_{cr}``           | ``\int_{D_{cr}}^{\infty} \! \frac{\alpha_{va}}{1-F_r} D^{\beta_{va}} N'(D) \mathrm{d}D`` | ``\frac{\alpha_{va}}{1-F_r} N_0 \lambda \,^{-(\mu \, + \beta_{va} \, + 1)} (\Gamma \,(\mu \, + \beta_{va} \, + 1, \lambda \,D_{cr}))``  |
 
 where ``\Gamma \,(a, z) = \int_{z}^{\infty} \! t^{a - 1} e^{-t} \mathrm{d}D``
   and ``\Gamma \,(a) = \Gamma \,(a, 0)`` for simplicity.
 
-In our solver, we approximate ``\mu`` from ``q/N`` and keep it constant throughout the solving step.
-We approximate ``\mu`` by an exponential function given by the ``q/N`` points
+In our solver, we approximate ``\mu`` from ``L/N`` and keep it constant throughout the solving step.
+We approximate ``\mu`` by an exponential function given by the ``L/N`` points
   corresponding to ``\mu = 6`` and ``\mu = 0``.
 This is shown below as well as how this affects the solvers ``\lambda`` solutions.
 
@@ -134,19 +140,19 @@ include("plots/P3LambdaErrorPlots.jl")
 ![](MuApprox.svg)
 
 An initial guess for the non-linear solver is found by approximating the gamma functions
-  as a simple linear function from ``x = \log{(q/N)}`` to ``y = \log{(\lambda)}``.
+  as a simple linear function from ``x = \log{(L/N)}`` to ``y = \log{(\lambda)}``.
 The equation is given by ``(x - x_1) = A \; (y - y_1)`` where
   ``A = \frac{x_1 - x_2}{y_1 - y_2}``.
-``y_1`` and ``y_2`` define ``log(\lambda)`` values for three ``q/N`` ranges
+``y_1`` and ``y_2`` define ``log(\lambda)`` values for three ``L/N`` ranges
 
-|             q/N                |         ``y_1``        |      ``y_2``         |
+|             L/N                |         ``y_1``        |      ``y_2``         |
 |:-------------------------------|:-----------------------|:---------------------|
-|        ``q/N >= 10^-8``        |         ``1``          |     ``6 * 10^3``     |
-|   ``2 * 10^9 <= q/N < 10^-8``  |     ``6 * 10^3``       |     ``3 * 10^4``     |
-|        ``q/N < 2 * 10^9``      |     ``4 * 10^4``       |       ``10^6``       |
+|        ``L/N >= 10^-8``        |         ``1``          |     ``6 * 10^3``     |
+|   ``2 * 10^9 <= L/N < 10^-8``  |     ``6 * 10^3``       |     ``3 * 10^4``     |
+|        ``L/N < 2 * 10^9``      |     ``4 * 10^4``       |       ``10^6``       |
 
 We use this approximation to calculate initial guess for the shape parameter
-  ``\lambda_g = \lambda_1 (\frac{q}{q_1})^{(\frac{y_1 - y_2}{x_1 - x_2})}``.
+  ``\lambda_g = \lambda_1 (\frac{L}{L_1})^{(\frac{y_1 - y_2}{x_1 - x_2})}``.
 
 ```@example
 include("plots/P3ShapeSolverPlots.jl")

--- a/docs/src/plots/P3LambdaErrorPlots.jl
+++ b/docs/src/plots/P3LambdaErrorPlots.jl
@@ -20,9 +20,9 @@ function λ_diff(F_r::FT, ρ_r::FT, N::FT, λ_ex::FT, p3::PSP3) where {FT}
     # Convert λ to ensure it remains positive
     x = log(λ_ex)
     # Compute mass density based on input shape parameters
-    q_calc = N * P3.q_over_N_gamma(p3, F_r, x, μ, th)
+    L_calc = N * P3.L_over_N_gamma(p3, F_r, x, μ, th)
 
-    (λ_calculated,) = P3.distribution_parameter_solver(p3, q_calc, N, ρ_r, F_r)
+    (λ_calculated,) = P3.distribution_parameter_solver(p3, L_calc, N, ρ_r, F_r)
     return abs(λ_ex - λ_calculated)
 end
 
@@ -104,9 +104,9 @@ function μ_approximation_effects(F_r::FT, ρ_r::FT) where {FT}
 
     ax1 = CMK.Axis(
         f[1, 1],
-        xlabel = "q/N",
+        xlabel = "L/N",
         ylabel = "μ",
-        title = string("μ vs q/N for F_r = ", F_r, " ρ_r = ", ρ_r),
+        title = string("μ vs L/N for F_r = ", F_r, " ρ_r = ", ρ_r),
         width = 400,
         height = 300,
         xscale = log10,
@@ -125,8 +125,8 @@ function μ_approximation_effects(F_r::FT, ρ_r::FT) where {FT}
     ax3 = CMK.Axis(
         f[1, 3],
         xlabel = "λ",
-        ylabel = "q/N",
-        title = string("q/N vs λ for F_r = ", F_r, " ρ_r = ", ρ_r),
+        ylabel = "L/N",
+        title = string("L/N vs λ for F_r = ", F_r, " ρ_r = ", ρ_r),
         width = 400,
         height = 300,
         xscale = log10,
@@ -145,24 +145,24 @@ function μ_approximation_effects(F_r::FT, ρ_r::FT) where {FT}
     μs = [P3.DSD_μ(p3, λ) for λ in λs]
 
     μs_approx = [FT(0) for λ in λs]
-    qs = [FT(0) for λ in λs]
+    Ls = [FT(0) for λ in λs]
     λ_solved = [FT(0) for λ in λs]
 
     for i in 1:numpts
-        q = P3.q_over_N_gamma(p3, F_r, log(λs[i]), μs[i], th)
-        qs[i] = q
+        L_over_N = P3.L_over_N_gamma(p3, F_r, log(λs[i]), μs[i], th)
+        Ls[i] = L_over_N
         N = FT(1e6)
-        (L, N) = P3.distribution_parameter_solver(p3, q * N, N, ρ_r, F_r)
+        (L, N) = P3.distribution_parameter_solver(p3, L_over_N * N, N, ρ_r, F_r)
         λ_solved[i] = L
-        μs_approx[i] = P3.DSD_μ_approx(p3, N * q, N, ρ_r, F_r)
+        μs_approx[i] = P3.DSD_μ_approx(p3, N * L_over_N, N, ρ_r, F_r)
     end
 
     # Plot
-    CMK.lines!(ax3, λs, qs, label = "true distribution")
-    CMK.lines!(ax3, λ_solved, qs, label = "approximated")
+    CMK.lines!(ax3, λs, Ls, label = "true distribution")
+    CMK.lines!(ax3, λ_solved, Ls, label = "approximated")
 
-    CMK.lines!(ax1, qs, μs, label = "true distribution")
-    CMK.lines!(ax1, qs, μs_approx, label = "approximated")
+    CMK.lines!(ax1, Ls, μs, label = "true distribution")
+    CMK.lines!(ax1, Ls, μs_approx, label = "approximated")
     CMK.lines!(ax2, λs, μs, label = "true distribution")
     CMK.lines!(ax2, λ_solved, μs_approx, label = "approximated")
 

--- a/docs/src/plots/P3SchemePlots.jl
+++ b/docs/src/plots/P3SchemePlots.jl
@@ -9,8 +9,6 @@ FT = Float64
 const PSP3 = CMP.ParametersP3
 p3 = CMP.ParametersP3(FT)
 
-
-
 function define_axis(fig, row_range, col_range, title, ylabel, yticks, aspect)
     return CMK.Axis(
         fig[row_range, col_range],

--- a/docs/src/plots/P3ShapeSolverPlots.jl
+++ b/docs/src/plots/P3ShapeSolverPlots.jl
@@ -9,8 +9,8 @@ FT = Float64
 const PSP3 = CMP.ParametersP3
 p3 = CMP.ParametersP3(FT)
 
-function guess_value(λ::FT, p1::FT, p2::FT, q1::FT, q2::FT)
-    return q1 * (λ / p1)^((log(q1) - log(q2)) / (log(p1) - log(p2)))
+function guess_value(λ::FT, p1::FT, p2::FT, L1::FT, L2::FT)
+    return L1 * (λ / p1)^((log(L1) - log(L2)) / (log(p1) - log(p2)))
 end
 
 function lambda_guess_plot()
@@ -28,19 +28,18 @@ function lambda_guess_plot()
 
             Plt.Axis(
                 f[i, j],
-                xlabel = "log(q/N)",
+                xlabel = "log(L/N)",
                 ylabel = "log(λ)",
-                title = string("λ vs q/N for F_r = ", F_r, " and ρ_r = ", ρ_r),
+                title = string("λ vs L/N for F_r = ", F_r, " and ρ_r = ", ρ_r),
                 height = 300,
                 width = 400,
             )
 
-
             logλs = FT(1):FT(0.01):FT(6)
             λs = [10^logλ for logλ in logλs]
             th = P3.thresholds(p3, ρ_r, F_r)
-            qs = [
-                P3.q_over_N_gamma(p3, F_r, log(λ), P3.DSD_μ(p3, λ), th) for
+            Ls_over_N = [
+                P3.L_over_N_gamma(p3, F_r, log(λ), P3.DSD_μ(p3, λ), th) for
                 λ in λs
             ]
             guesses = [FT(0) for λ in λs]
@@ -48,8 +47,8 @@ function lambda_guess_plot()
             for i in 1:length(λs)
                 (min,) = P3.get_bounds(
                     N,
-                    qs[i] * N,
-                    P3.DSD_μ_approx(p3, qs[i] * N, N, ρ_r, F_r),
+                    Ls_over_N[i] * N,
+                    P3.DSD_μ_approx(p3, Ls_over_N[i] * N, N, ρ_r, F_r),
                     F_r,
                     p3,
                     th,
@@ -59,14 +58,14 @@ function lambda_guess_plot()
 
 
             Plt.lines!(
-                log10.(qs),
+                log10.(Ls_over_N),
                 log10.(λs),
                 linewidth = 3,
                 color = "Black",
                 label = "true",
             )
             Plt.lines!(
-                log10.(qs),
+                log10.(Ls_over_N),
                 log10.(guesses),
                 linewidth = 2,
                 linestyle = :dash,

--- a/docs/src/plots/P3TerminalVelocityPlots.jl
+++ b/docs/src/plots/P3TerminalVelocityPlots.jl
@@ -13,7 +13,7 @@ p3 = CMP.ParametersP3(FT)
 function get_values(
     p3::PSP3,
     Chen2022::CMP.Chen2022VelTypeSnowIce,
-    q::FT,
+    L::FT,
     N::FT,
     ρ_a::FT,
     x_resolution::Int,
@@ -31,9 +31,9 @@ function get_values(
             ρ_r = ρ_rs[j]
 
             V_m[i, j] =
-                P3.ice_terminal_velocity(p3, Chen2022, q, N, ρ_r, F_r, ρ_a)[2]
+                P3.ice_terminal_velocity(p3, Chen2022, L, N, ρ_r, F_r, ρ_a)[2]
             # get D_m in mm for plots
-            D_m[i, j] = 1e3 * P3.D_m(p3, q, N, ρ_r, F_r)
+            D_m[i, j] = 1e3 * P3.D_m(p3, L, N, ρ_r, F_r)
         end
     end
     return (; F_rs, ρ_rs, V_m, D_m)
@@ -69,20 +69,20 @@ function figure_2()
     # density of air in kg/m^3
     ρ_a = FT(1.2) #FT(1.293)
     # small D_m
-    q_s = FT(0.0008)
+    L_s = FT(0.0008)
     N_s = FT(1e6)
     # medium D_m
-    q_m = FT(0.22)
+    L_m = FT(0.22)
     N_m = FT(1e6)
     # large D_m
-    q_l = FT(0.7)
+    L_l = FT(0.7)
     N_l = FT(1e6)
     # get V_m and D_m
     xres = 100
     yres = 100
-    (F_rs, ρ_rs, V_ms, D_ms) = get_values(p3, Chen2022.snow_ice, q_s, N_s, ρ_a, xres, yres)
-    (F_rm, ρ_rm, V_mm, D_mm) = get_values(p3, Chen2022.snow_ice, q_m, N_m, ρ_a, xres, yres)
-    (F_rl, ρ_rl, V_ml, D_ml) = get_values(p3, Chen2022.snow_ice, q_l, N_l, ρ_a, xres, yres)
+    (F_rs, ρ_rs, V_ms, D_ms) = get_values(p3, Chen2022.snow_ice, L_s, N_s, ρ_a, xres, yres)
+    (F_rm, ρ_rm, V_mm, D_mm) = get_values(p3, Chen2022.snow_ice, L_m, N_m, ρ_a, xres, yres)
+    (F_rl, ρ_rl, V_ml, D_ml) = get_values(p3, Chen2022.snow_ice, L_l, N_l, ρ_a, xres, yres)
 
     fig = Plt.Figure()
 

--- a/src/P3_particle_properties.jl
+++ b/src/P3_particle_properties.jl
@@ -27,7 +27,7 @@ D_th_helper(p3::PSP3{FT}) where {FT} =
     D_cr_helper(p3, F_r, ρ_g)
 
  - p3 - a struct with P3 scheme parameters
- - F_r - rime mass fraction (q_rim/q_i) [-]
+ - F_r - rime mass fraction (L_rim/L_ice) [-]
  - ρ_g - is the effective density of a spherical graupel particle [kg/m^3]
 
 Returns the size of equal mass for graupel and partially rimed ice, in meters.
@@ -55,8 +55,8 @@ end
 """
     ρ_g_helper(ρ_r, F_r, ρ_d)
 
- - ρ_r - rime density (q_rim/B_rim) [kg/m^3]
- - F_r - rime mass fraction (q_rim/q_i) [-]
+ - ρ_r - rime density (L_rim/B_rim) [kg/m^3]
+ - F_r - rime mass fraction (L_rim/L_ice) [-]
  - ρ_g - is the effective density of a spherical graupel particle [kg/m^3]
 
 Returns the density of total (deposition + rime) ice mass for graupel, in kg/m3
@@ -85,8 +85,8 @@ end
     thresholds(p3, ρ_r, F_r)
 
  - p3 - a struct with P3 scheme parameters
- - ρ_r - rime density (q_rim/B_rim) [kg/m^3]
- - F_r - rime mass fraction (q_rim/q_i) [-]
+ - ρ_r - rime density (L_rim/B_rim) [kg/m^3]
+ - F_r - rime mass fraction (L_rim/L_ice) [-]
 
 Solves the nonlinear system consisting of D_cr, D_gr, ρ_g, ρ_d
 for a given rime density and rime mass fraction.
@@ -137,7 +137,7 @@ end
  - p3 - a struct with P3 scheme parameters
  - D - maximum particle dimension [m]
  - ρ - bulk ice density (ρ_i for small ice, ρ_g for graupel) [kg/m3]
- - F_r - rime mass fraction [q_rim/q_i]
+ - F_r - rime mass fraction [L_rim/L_ice]
 
 Returns mass as a function of size for differen particle regimes [kg]
 """
@@ -154,7 +154,7 @@ mass_r(p3::PSP3, D::FT, F_r::FT) where {FT <: Real} =
 
  - p3 - a struct with P3 scheme parameters
  - D - maximum particle dimension
- - F_r - rime mass fraction (q_rim/q_i)
+ - F_r - rime mass fraction (L_rim/L_ice)
  - th - P3Scheme nonlinear solve output tuple (D_cr, D_gr, ρ_g, ρ_d)
 
 Returns mass(D) regime, used to create figures for the docs page.
@@ -200,7 +200,7 @@ A_r(p3::PSP3, F_r::FT, D::FT) where {FT <: Real} =
 
  - p3 - a struct with P3 scheme parameters
  - D - maximum particle dimension
- - F_r - rime mass fraction (q_rim/q_i)
+ - F_r - rime mass fraction (L_rim/L_ice)
  - th - P3Scheme nonlinear solve output tuple (D_cr, D_gr, ρ_g, ρ_d)
 
 Returns area(D), used to create figures for the documentation.

--- a/src/P3_terminal_velocity.jl
+++ b/src/P3_terminal_velocity.jl
@@ -31,7 +31,7 @@ end
  - p3 - a struct containing P3 parameters
  - Chen2022 - a struct containing Chen 2022 velocity parameters
  - ρ_a - density of air
- - F_r - rime mass fraction (q_rim/ q_i)
+ - F_r - rime mass fraction (L_rim/ L_ice)
  - th - P3 particle properties thresholds
 
 Returns the absolute value of the velocity difference between an ice particle and
@@ -73,10 +73,10 @@ end
 
  - p3 - a struct with P3 scheme parameters
  - Chen2022 - a struch with terminal velocity parameters as in Chen(2022)
- - q - mass mixing ratio
+ - L - mass mixing ratio
  - N - number mixing ratio
- - ρ_r - rime density (q_rim/B_rim) [kg/m^3]
- - F_r - rime mass fraction (q_rim/q_i)
+ - ρ_r - rime density (L_rim/B_rim) [kg/m^3]
+ - F_r - rime mass fraction (L_rim/q_ice)
  - ρ_a - density of air
 
 Returns the mass and number weighted fall speeds for ice following
@@ -85,7 +85,7 @@ eq C10 of Morrison and Milbrandt (2015).
 function ice_terminal_velocity(
     p3::PSP3,
     Chen2022::CMP.Chen2022VelTypeSnowIce,
-    q::FT,
+    L::FT,
     N::FT,
     ρ_r::FT,
     F_r::FT,
@@ -95,7 +95,7 @@ function ice_terminal_velocity(
     # get the particle properties thresholds
     th = thresholds(p3, ρ_r, F_r)
     # get the size distribution parameters
-    (λ, N₀) = distribution_parameter_solver(p3, q, N, ρ_r, F_r)
+    (λ, N₀) = distribution_parameter_solver(p3, L, N, ρ_r, F_r)
     # get the integral limit
     D_max = get_ice_bound(p3, λ, eps(FT))
 
@@ -117,5 +117,5 @@ function ice_terminal_velocity(
         FT(0),
         D_max,
     )[1]
-    return (v_n / N, v_m / q)
+    return (v_n / N, v_m / L)
 end

--- a/test/p3_tests.jl
+++ b/test/p3_tests.jl
@@ -150,13 +150,13 @@ function test_p3_shape_solver(FT)
                         # Convert λ to ensure it remains positive
                         x = log(λ_ex)
                         # Compute mass density based on input shape parameters
-                        q_calc = N * P3.q_over_N_gamma(p3, F_r, x, μ_ex, th)
+                        L_calc = N * P3.L_over_N_gamma(p3, F_r, x, μ_ex, th)
 
-                        if q_calc < FT(1)
+                        if L_calc < FT(1)
                             # Solve for shape parameters
                             (λ, N₀) = P3.distribution_parameter_solver(
                                 p3,
-                                q_calc,
+                                L_calc,
                                 N,
                                 ρ_r,
                                 F_r,
@@ -208,7 +208,7 @@ end
 function test_bulk_terminal_velocities(FT)
     Chen2022 = CMP.Chen2022VelType(FT)
     p3 = CMP.ParametersP3(FT)
-    q = FT(0.22)
+    L = FT(0.22)
     N = FT(1e6)
     ρ_a = FT(1.2)
     ρ_rs = [FT(200), FT(400), FT(600), FT(800)]
@@ -235,7 +235,7 @@ function test_bulk_terminal_velocities(FT)
                 calculated_vel = P3.ice_terminal_velocity(
                     p3,
                     Chen2022.snow_ice,
-                    q,
+                    L,
                     N,
                     ρ_r,
                     F_r,
@@ -265,7 +265,7 @@ function test_bulk_terminal_velocities(FT)
                 ρ_r = ρ_rs[i]
                 F_r = F_rs[j]
 
-                calculated_dm = P3.D_m(p3, q, N, ρ_r, F_r) * 1e3
+                calculated_dm = P3.D_m(p3, L, N, ρ_r, F_r) * 1e3
 
                 TT.@test calculated_dm > 0
                 TT.@test paper_vals[i][j] ≈ calculated_dm atol = 3.14


### PR DESCRIPTION
The original paper uses symbol ``q`` to denote the mass of a tracer per volume of air (named mass mixing ratio). In our documentation of the 1-moment and 2-moment schemes we used ``q`` to denote the mass of a tracer per mass of air (named specific humidity). To keep the notation consistent between the 1,2-moment schemes and P3, and to highlight the difference between normalizing by air mass or volume, we denote the mass of a tracer per volume of air as ``L`` (named content).