### PR TITLE
P3 shedding!

### DIFF
--- a/docs/src/P3Scheme.md
+++ b/docs/src/P3Scheme.md
@@ -366,6 +366,26 @@ include("plots/P3Melting.jl")
 ```
 ![](P3_ice_melt.svg)
 
+## Shedding
+
+Shedding is a sink of ``L_{liq}`` that transfers liquid mass on large, mixed-phase particles to rain.
+  Following [Choletteetal2019](@cite), shedding occurs only for ``D > 9 mm``, and it is scaled
+  with ``F_{rim}`` such that more in-filling with rime translates to more liquid mass being
+  shed from the ice core. It is calculated as follows by numerically integrating over the
+  whole mixed-phase particle PSD:
+```math
+\begin{equation}
+ \left. \frac{dL}{dt} \right|_{shed} =  \int_{9 mm}^{\infty} F_{rim} F_{liq} m(D) N_{0} D^{\mu} \exp^{- \lambda D} dD
+\end{equation}
+```
+The source of rain number concentration from shedding is computed as described by [Choletteetal2019](@cite)
+  assuming mean raindrop diameter ``D = 1 mm``:
+```math
+\begin{equation}
+  \left. \frac{dN_{rai}}{dt} \right|_{shed} = \frac{1}{\frac{\pi}{6}\rho_{l}D^{3}} \left. \frac{dL}{dt} \right|_{shed}
+\end{equation}
+```
+
 ## Acknowledgments
 
 Click on the P3 mascot duck to be taken to the repository

--- a/src/P3_particle_properties.jl
+++ b/src/P3_particle_properties.jl
@@ -102,10 +102,10 @@ function thresholds(p3::PSP3{FT}, ρ_r::FT, F_rim::FT) where {FT}
     @assert F_rim >= FT(0)   # rime mass fraction must be positive ...
     @assert F_rim < FT(1)    # ... and there must always be some unrimed part
 
-    if F_rim == FT(0)
+    if F_rim == FT(0) || ρ_r == FT(0)
         return (; D_cr = FT(0), D_gr = FT(0), ρ_g = FT(0), ρ_d = FT(0))
     else
-        @assert ρ_r > FT(0)   # rime density must be positive ...
+        @assert ρ_r >= FT(0)   # rime density must be positive ...
         @assert ρ_r <= p3.ρ_l # ... and as a bulk ice density can't exceed the density of water
 
         P3_problem(ρ_d) =

--- a/src/P3_processes.jl
+++ b/src/P3_processes.jl
@@ -159,7 +159,7 @@ function ice_shed(
     dt::FT,
 ) where {FT}
     dLdt = FT(0)
-    if L_p3_tot > eps(FT) && N_ice > eps(FT)
+    if L_p3_tot > eps(FT) && N_ice > eps(FT) && F_liq > eps(FT)
         # process dependent on F_liq
         # (we want whole particle shape params)
         # Get the P3 diameter distribution...

--- a/src/P3_processes.jl
+++ b/src/P3_processes.jl
@@ -180,8 +180,6 @@ function ice_shed(
         # (i.e. if only 1% of the particles are bigger than 9 mm
         # is it really worth doing a computation and returning a tiny dLdt?)
         bound = get_ice_bound(p3, λ, FT(1e-6))
-        # hard-coding another bound for testing:
-        bound = FT(2e-2)
 
         # critical size for shedding
         shed_bound = FT(9e-3)

--- a/test/p3_tests.jl
+++ b/test/p3_tests.jl
@@ -868,6 +868,53 @@ function test_p3_melting(FT)
     end
 end
 
+function test_p3_shedding(FT)
+
+    TT.@testset "Shedding Smoke Test" begin
+
+        p3 = CMP.ParametersP3(FT)
+
+        qᵢ = FT(5e-3)
+        ρₐ = FT(1.2)
+        Lᵢ = qᵢ * ρₐ
+        Nᵢ = FT(5e3) * ρₐ
+        F_rim = FT(0.8)
+        ρ_rim = FT(800)
+        dt = FT(1)
+        F_liq = FT(0)
+
+        rate = P3.ice_shed(p3, Lᵢ, Nᵢ, F_rim, ρ_rim, F_liq, dt)
+
+        TT.@test rate.dLdt_p3_tot == 0
+        TT.@test rate.dLdt_liq == 0
+        TT.@test rate.dLdt_rai == 0
+        TT.@test rate.dNdt_rai == 0
+
+        F_liq = FT(0.9)
+
+        rate = P3.ice_shed(p3, Lᵢ, Nᵢ, F_rim, ρ_rim, F_liq, dt)
+
+        TT.@test rate.dLdt_p3_tot >= 0
+        TT.@test rate.dLdt_liq >= 0
+        TT.@test rate.dLdt_rai >= 0
+        TT.@test rate.dNdt_rai >= 0
+
+        TT.@test rate.dLdt_p3_tot == 5.80171629651495e-6
+        TT.@test rate.dNdt_rai == 11.080461924085903
+
+        Lᵢ = FT(0)
+        Nᵢ = FT(0)
+
+        rate = P3.ice_shed(p3, Lᵢ, Nᵢ, F_rim, ρ_rim, F_liq, dt)
+
+        TT.@test rate.dLdt_p3_tot == 0
+        TT.@test rate.dLdt_liq == 0
+        TT.@test rate.dLdt_rai == 0
+        TT.@test rate.dNdt_rai == 0
+
+    end
+end
+
 
 println("Testing Float32")
 test_p3_thresholds(Float32)
@@ -886,4 +933,5 @@ test_bulk_terminal_velocities(Float64)
 test_integrals(Float64)
 test_p3_het_freezing(Float64)
 test_p3_melting(Float64)
+test_p3_shedding(Float64)
 #test_tendencies(Float64)

--- a/test/p3_tests.jl
+++ b/test/p3_tests.jl
@@ -899,8 +899,8 @@ function test_p3_shedding(FT)
         TT.@test rate.dLdt_rai >= 0
         TT.@test rate.dNdt_rai >= 0
 
-        TT.@test rate.dLdt_p3_tot == 5.80171629651495e-6
-        TT.@test rate.dNdt_rai == 11.080461924085903
+        TT.@test rate.dLdt_p3_tot == 3.929198115623993e-6
+        TT.@test rate.dNdt_rai == 7.504215629867026
 
         Lᵢ = FT(0)
         Nᵢ = FT(0)

--- a/test/p3_tests.jl
+++ b/test/p3_tests.jl
@@ -23,8 +23,8 @@ function test_p3_thresholds(FT)
         F_rim_good = (FT(0.5), FT(0.8), FT(0.95)) # representative F_rim values
 
         # test asserts
-        for _ρ_r in (FT(0), FT(-1))
-            TT.@test_throws AssertionError("ρ_r > FT(0)") P3.thresholds(
+        for _ρ_r in (FT(-1))
+            TT.@test_throws AssertionError("ρ_r >= FT(0)") P3.thresholds(
                 p3,
                 _ρ_r,
                 F_rim,

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -199,6 +199,13 @@ function benchmark_test(FT)
             2e3,
             3,
         )
+        bench_press(
+            P3.ice_shed,
+            (p3, L, N, F_rim, ρ_r, F_liq, Δt),
+            1.5e5,
+            1.5e3,
+            2,
+        )
     end
 
     # aerosol activation


### PR DESCRIPTION
- This PR implements shedding for P3 liquid mass content as described in Cholette (2019).
- See [liquid fraction issue](https://github.com/CliMA/CloudMicrophysics.jl/issues/406) for the parameterization, or the docs build!
- I have not added any plots to the docs, but I could see it being interesting to plot shedding as a function of `L_p3_tot` keeping `L_ice` and `N_ice` constant and increasing `L_liq` for a few different `F_rim` values. Maybe I will try to do that this week.
- TODO - Once `get_ice_bound()` is merged, change the code in src accordingly, and test away!
- Finally, for catching cases when we have no particles over which to compute shedding, I have currently implemented to compute shedding if `L > eps && N > eps` but am unsure whether the condition should be that or ``L > eps || N > eps``.

