### PR TITLE
P3 predicted variables helper

### DIFF
--- a/src/P3_particle_properties.jl
+++ b/src/P3_particle_properties.jl
@@ -22,12 +22,11 @@ function p3_predictor(
     F_rim = FT(0)
     ρ_rim = FT(0)
     F_liq = FT(0)
-    if N_ice > eps(FT) && L_p3_tot > eps(FT)
+    if L_p3_tot > eps(FT)
         # particle must always have some unrimed part
         F_rim = max(FT(0), min(L_rim / (L_p3_tot - L_liq), 1 - eps(FT)))
         if B_rim > eps(FT)
             # density must always be less than liquid
-            # TODO - maybe a nonzero lower limit is best here?
             ρ_rim = max(FT(0), min(L_rim / B_rim, p3.ρ_l))
         end
         # to be a mixed-phase particle, we must have some ice

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -195,9 +195,9 @@ function benchmark_test(FT)
         bench_press(
             P3.ice_melt,
             (p3, ch2022.snow_ice, aps, tps, L, N, T_air, ρ_air, F_rim, ρ_r, Δt),
-            3.7e5,
-            2e3,
-            3,
+            6e5,
+            3e3,
+            5,
         )
     end
 


### PR DESCRIPTION
During my brief testing of P3 in KiD I had the idea that a function like the one implemented here might be useful for calculating the "predicted variables"—`F_rim, p_rim, F_liq`. I'm envisioning that after the state variables are calculated at each time step, we call this `p3_predictor()`, or like we talked about throw it in with `thresholds()`, `distribution_parameter_solver()`, etc... using the computed `F_rim, p_rim, F_liq`.

The advantage of having a call to P3 to compute the predicted variables is to catch limit cases early and ensure that we're passing physically reasonable values to the rest of the P3 functions, instead of hard-coding these things in KiD every time we compute the predicted quantities, so I thought I may as well implement this solution for fun! But no hard feelings if this PR gets closed and is never merged!

> **_NOTE:_**  This PR also allows the rime density to be 0. (Previously it had to be greater than 0.) I thought maybe this change could be useful because we could return 0 rime density for when we have no rime or no total ice content.