### PR TITLE
Remove liq/ice lognormal distribution in parcel

### DIFF
--- a/parcel/ParcelDistributions.jl
+++ b/parcel/ParcelDistributions.jl
@@ -4,10 +4,6 @@ struct Monodisperse{FT} <: CMP.ParametersType{FT} end
 
 struct Gamma{FT} <: CMP.ParametersType{FT} end
 
-struct Lognormal{FT} <: CMP.ParametersType{FT}
-    σ_g::FT
-end
-
 #! format: off
 # Size distributiom moments
 function distribution_moments(::Monodisperse, q, N, ρ, ρ_air)
@@ -46,23 +42,4 @@ function distribution_moments(::Gamma, q, N, ρ, ρ_air)
     return (; r, A, V)
 end
 
-function distribution_moments(params::Lognormal, q, N, ρ, ρ_air)
-    FT = typeof(q)
-    # M_0 = N_0
-    # M_1 = N_0 * r_m * exp(1/2 * ln^2(σ_g))
-    # M_2 = N_0 * r_m^2 * exp(2 * ln^2(σ_g))
-    # M_3 = N_0 * r_m^3 * exp(9/2 * ln^2(σ_g))
-    (; σ_g) = params
-    if N == FT(0) || q == FT(0)
-        r = FT(0)
-        A = FT(0)
-        V = FT(0)
-    else
-        r_median = cbrt(3 / 4 / FT(π) / N * q / ρ * ρ_air / exp(9 / 2 * (log(σ_g))^2))
-        r = r_median * exp(0.5 * (log(σ_g))^2)
-        A = 4 * FT(π) * r_median^2 * exp(2 * (log(σ_g))^2)
-        V = 4 / 3 * FT(π) * r_median^3 * exp(9 / 2 * (log(σ_g))^2)
-    end
-    return (; r, A, V)
-end
 #! format: on

--- a/parcel/ParcelModel.jl
+++ b/parcel/ParcelModel.jl
@@ -17,7 +17,6 @@ Base.@kwdef struct parcel_params{FT} <: CMP.ParametersType{FT}
     deposition_growth = "None"
     liq_size_distribution = "Monodisperse"
     ice_size_distribution = "Monodisperse"
-    σ_g = FT(0)
     aerosol = Empty{FT}()
     aero_σ_g = FT(0)
     wps = CMP.WaterProperties(FT)
@@ -211,8 +210,6 @@ function run_parcel(IC, t_0, t_end, pp)
         liq_distr = Monodisperse{FT}()
     elseif pp.liq_size_distribution == "Gamma"
         liq_distr = Gamma{FT}()
-    elseif pp.liq_size_distribution == "Lognormal"
-        liq_distr = Lognormal{FT}(pp.σ_g)
     else
         throw("Unrecognized size distribution")
     end


### PR DESCRIPTION
Removing the option to have lognormal size distribution for droplets.