### PR TITLE
Update climacommon to 2024_10_09

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_mem: 8G
-  modules: climacommon/2024_05_27
+  modules: climacommon/2024_10_09
 
 env:
   OPENBLAS_NUM_THREADS: 1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_mem: 8G
-  modules: climacommon/2024_05_27
+  modules: climacommon/2024_10_09
 
 env:
   OPENBLAS_NUM_THREADS: 1

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -249,7 +249,7 @@ function benchmark_test(FT)
             TD.PhasePartition(FT(0), FT(0), FT(0.002)),
             TD.PhasePartition(FT(0), FT(0), FT(0.001)),
         ),
-        10,
+        12,
     )
     bench_press(
         CMN.conv_q_vap_to_q_liq_ice_MM2015,


### PR DESCRIPTION
🤖 Beep boop. I am GabrieleBOT. 🤖

I received an update so that I can inform you directly of the changes (but feel free to check the [release notes](https://github.com/CliMA/ClimaModules/blob/main/NEWS.md)).

The most recent version of climacommon uses the newly released Julia 1.11.0.