### PR TITLE
Run 3 freeze modes in HOM calibrations

### DIFF
--- a/papers/ice_nucleation_2024/calibration.jl
+++ b/papers/ice_nucleation_2024/calibration.jl
@@ -89,6 +89,8 @@ function run_model(p, coefficients, IN_mode, FT, IC, end_sim)
             aerosol_act = aerosol_act,
             aerosol = aerosol,
             aero_σ_g = aero_σ_g,
+            deposition = dep_nucleation,
+            heterogeneous = heterogeneous,
             homogeneous = homogeneous,
             condensation_growth = condensation_growth,
             deposition_growth = deposition_growth,

--- a/papers/ice_nucleation_2024/calibration_setup.jl
+++ b/papers/ice_nucleation_2024/calibration_setup.jl
@@ -146,8 +146,8 @@ function AIDA_IN05_params(FT, w, t_max)
     const_dt = FT(1)
     aerosol_act = "AeroAct"
     aerosol = CMP.Sulfate(FT)
-    dep_nucleation = "None"
-    heterogeneous = "None"
+    dep_nucleation = "ABDINM"
+    heterogeneous = "ABIFM"
     homogeneous = "ABHOM"
     condensation_growth = "Condensation"
     deposition_growth = "Deposition"
@@ -162,6 +162,7 @@ function AIDA_IN05_params(FT, w, t_max)
         liq_size_distribution, ice_size_distribution,   # size distribution
         dep_nucleation, heterogeneous, homogeneous,     # ice nucleation
     )
+
     return params
 end
 

--- a/parcel/ParcelModel.jl
+++ b/parcel/ParcelModel.jl
@@ -65,6 +65,8 @@ function parcel_model(dY, Y, p, t)
         ln_INPC = Y[10],   # needed only in stochastic Frostenberg
         t = t,
     )
+    println(dep_params, imm_params,hom_params)
+    sleep(5)
 
     # Constants
     Rᵥ = TD.Parameters.R_v(tps)

--- a/parcel/ParcelTendencies.jl
+++ b/parcel/ParcelTendencies.jl
@@ -96,6 +96,7 @@ function deposition_nucleation(params::ABDINM, state, dY)
     Δa_w = CMO.a_w_eT(tps, e, T) - CMO.a_w_ice(tps, T)
     J = CMI_het.deposition_J(aerosol, Δa_w)
     A = 4 * FT(π) * r_nuc^2
+    @info("ABDINM ABDINM ABDINM ABDINM ABDINM ABDINM ABDINM ABDINM ABDINM ABDINM ABDINM ABDINM ABDINM")
     return min(max(FT(0), J * Nₐ * A), Nₐ / const_dt)
 end
 
@@ -125,6 +126,7 @@ function immersion_freezing(params::ABIFM, PSD_liq, state)
     Δa_w = CMO.a_w_eT(tps, e, T) - CMO.a_w_ice(tps, T)
 
     J = CMI_het.ABIFM_J(aerosol, Δa_w)
+    @info("ABIFM ABIFM ABIFM ABIFM ABIFM ABIFM ABIFM ABIFM ABIFM ABIFM ABIFM ABIFM ABIFM ABIFM ABIFM ABIFM")
     return min((J * Nₗ * A_aer), (Nₗ / const_dt))
 end
 


### PR DESCRIPTION
- need to allow deposition nucleation and immersion freezing to run with soluble or no aerosols 