### PR TITLE
Fix DocumenterCitations error

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -19,4 +19,4 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
 Documenter = "1.1"
-DocumenterCitations = "=1.3.3"
+DocumenterCitations = "1.3.3"

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -55,7 +55,7 @@ doi = "10.1039/D1EA00077B",
 }
 
 @Article{Baumgartner2022,
-author = {Baumgartner, M. and Rolf, C. and Groo{\ss}, J.-U. and Schneider, J. and Schorr, T. and M\"ohler, O. and Spichtinger, P. and Kr\"amer, M.},
+author = {Baumgartner, M. and Rolf, C. and Grooß, J.-U. and Schneider, J. and Schorr, T. and Möhler, O. and Spichtinger, P. and Krämer, M.},
 title = {New investigations on homogeneous ice nucleation: the effects of water activity and water saturation formulations},
 journal = {Atmospheric Chemistry and Physics},
 volume = {22},
@@ -282,7 +282,7 @@ URL = {https://doi.org/10.1021/acs.cgd.6b00794}
 
 @article{Kaul2015,
   title = {Sensitivities in large-eddy simulations of mixed-phase Arctic stratocumulus clouds using a simple microphysics approach},
-  author = {Kaul, Colleen M and Teixeira, Jo{\~a}o and Suzuki, Kentaroh},
+  author = {Kaul, Colleen M and Teixeira, João and Suzuki, Kentaroh},
   journal = {Monthly Weather Review},
   volume = {143},
   number = {11},
@@ -397,7 +397,7 @@ URL = {https://doi.org/10.1246/bcsj.75.2587}
 
 @article{Lehtinen2007,
   title = {Estimating nucleation rates from apparent particle formation rates and vice versa: Revised formulation of the Kerminen–Kulmala equation},
-  author = {Kari E.J. Lehtinen and Miikka {Dal Maso} and Markku Kulmala and Veli-Matti Kerminen},
+  author = {Kari E.J. Lehtinen and Miikka Dal Maso and Markku Kulmala and Veli-Matti Kerminen},
   journal = {Journal of Aerosol Science},
   volume = {38},
   number = {9},


### PR DESCRIPTION
Our docs stopped building with `DocumenterCitations v1.3.5` . They were working fine with previous versions. 

Following the discussion in https://github.com/JuliaDocs/DocumenterCitations.jl/issues/78 I removed the TeX commands in favor of unicode in authors names. The actual fix is removing `{` from `{Dal Maso}` in line 400. I want to keep the other changes too, because they are more in line with the above mentioned discussion.
