### PR TITLE
run freezing modes simultaneously in AIDA calibs

### DIFF
--- a/papers/ice_nucleation_2024/AIDA_calibrations.jl
+++ b/papers/ice_nucleation_2024/AIDA_calibrations.jl
@@ -53,6 +53,8 @@ R_v = TD.Parameters.R_v(tps)
 R_d = TD.Parameters.R_d(tps)
 ϵₘ = R_d / R_v
 
+global EKI_calibratated_coeff_dict = Dict()
+global UKI_calibratated_coeff_dict = Dict()
 
 for (exp_index, data_file_name) in enumerate(data_file_names)
     @info(data_file_name)
@@ -108,6 +110,8 @@ for (exp_index, data_file_name) in enumerate(data_file_names)
     EKI_calibrated_parameters = EKI_output[1]
     UKI_calibrated_parameters = UKI_output[1]
     calibrated_ensemble_means = ensemble_means(EKI_output[2], EKI_n_iterations, EKI_n_ensembles)
+    merge!(EKI_calibratated_coeff_dict, Dict(plot_name => EKI_calibrated_parameters))
+    merge!(UKI_calibratated_coeff_dict, Dict(plot_name => UKI_calibrated_parameters))
 
     ## Calibrated parcel.
     EKI_parcel = run_model(params, EKI_calibrated_parameters, FT, IC, end_sim)
@@ -126,10 +130,10 @@ for (exp_index, data_file_name) in enumerate(data_file_names)
     #  Did they converge?
     calibrated_coeffs_fig = MK.Figure(size = (1100, 900), fontsize = 24)
     ax3 = MK.Axis(calibrated_coeffs_fig[1, 1], ylabel = "ABDINM m coefficient [-]", title = "$plot_name")
-    ax4 = MK.Axis(calibrated_coeffs_fig[1, 2], ylabel = "ABDINM c coefficient [-]", xlabel = "iteration #")
-    ax5 = MK.Axis(calibrated_coeffs_fig[2, 1], ylabel = "ABIFM m coefficient [-]", title = "$plot_name")
+    ax4 = MK.Axis(calibrated_coeffs_fig[1, 2], ylabel = "ABDINM c coefficient [-]", xlabel = "iteration #", title = "EKI")
+    ax5 = MK.Axis(calibrated_coeffs_fig[2, 1], ylabel = "ABIFM m coefficient [-]")
     ax6 = MK.Axis(calibrated_coeffs_fig[2, 2], ylabel = "ABIFM c coefficient [-]", xlabel = "iteration #")
-    ax7 = MK.Axis(calibrated_coeffs_fig[3, 1], ylabel = "ABHOM m coefficient [-]", title = "$plot_name")
+    ax7 = MK.Axis(calibrated_coeffs_fig[3, 1], ylabel = "ABHOM m coefficient [-]")
     ax8 = MK.Axis(calibrated_coeffs_fig[3, 2], ylabel = "ABHOM c coefficient [-]", xlabel = "iteration #")
     
     MK.lines!(ax3, collect(1:EKI_n_iterations), calibrated_ensemble_means[1], label = "ensemble mean", color = :orange, linewidth = 2.5)
@@ -155,8 +159,9 @@ for (exp_index, data_file_name) in enumerate(data_file_names)
     
     MK.lines!(ax_parcel_1, EKI_parcel.t, EKI_parcel[1, :], label = "EKI Calib Liq", color = :orange) # label = "liquid"
     MK.lines!(ax_parcel_1, UKI_parcel.t, UKI_parcel[1, :], label = "UKI Calib Liq", color = :fuchsia) # label = "liquid"
-    MK.lines!(ax_parcel_1, EKI_parcel.t, S_i.(tps, EKI_parcel[3, :], EKI_parcel[1, :]), label = "EKI Calib Ice", color = :green)
-    MK.lines!(ax_parcel_1, t_profile, S_l_profile, label = "chamber", color = :blue)
+    MK.lines!(ax_parcel_1, EKI_parcel.t, S_i.(tps, EKI_parcel[3, :], EKI_parcel[1, :]), label = "EKI Calib Ice", color = :orange, linestyle = :dash)
+    MK.lines!(ax_parcel_1, UKI_parcel.t, S_i.(tps, UKI_parcel[3, :], UKI_parcel[1, :]), label = "UKI Calib Ice", color = :fuchsia, linestyle = :dash)
+   # MK.lines!(ax_parcel_1, t_profile, S_l_profile, label = "chamber", color = :blue)
     
     MK.lines!(ax_parcel_2, EKI_parcel.t, EKI_parcel[5, :], color = :orange)
     MK.lines!(ax_parcel_2, UKI_parcel.t, UKI_parcel[5, :], color = :fuchsia)

--- a/papers/ice_nucleation_2024/AIDA_calibrations.jl
+++ b/papers/ice_nucleation_2024/AIDA_calibrations.jl
@@ -110,8 +110,8 @@ for (exp_index, data_file_name) in enumerate(data_file_names)
     calibrated_ensemble_means = ensemble_means(EKI_output[2], EKI_n_iterations, EKI_n_ensembles)
 
     ## Calibrated parcel.
-    EKI_parcel = run_calibrated_model(FT, nuc_mode, EKI_calibrated_parameters, params, IC)
-    UKI_parcel = run_calibrated_model(FT, nuc_mode, UKI_calibrated_parameters, params, IC)
+    EKI_parcel = run_model(params, EKI_calibrated_parameters, FT, IC, end_sim)
+    UKI_parcel = run_model(params, UKI_calibrated_parameters, FT, IC, end_sim)
 
     ### Plots.
     ## Plotting AIDA data.
@@ -124,11 +124,21 @@ for (exp_index, data_file_name) in enumerate(data_file_names)
 
     ## Calibrated coefficients.
     #  Did they converge?
-    calibrated_coeffs_fig = MK.Figure(size = (600, 600), fontsize = 24)
-    ax3 = MK.Axis(calibrated_coeffs_fig[1, 1], ylabel = "m coefficient [-]", title = "$plot_name")
-    ax4 = MK.Axis(calibrated_coeffs_fig[2, 1], ylabel = "c coefficient [-]", xlabel = "iteration #")
+    calibrated_coeffs_fig = MK.Figure(size = (1100, 900), fontsize = 24)
+    ax3 = MK.Axis(calibrated_coeffs_fig[1, 1], ylabel = "ABDINM m coefficient [-]", title = "$plot_name")
+    ax4 = MK.Axis(calibrated_coeffs_fig[1, 2], ylabel = "ABDINM c coefficient [-]", xlabel = "iteration #")
+    ax5 = MK.Axis(calibrated_coeffs_fig[2, 1], ylabel = "ABIFM m coefficient [-]", title = "$plot_name")
+    ax6 = MK.Axis(calibrated_coeffs_fig[2, 2], ylabel = "ABIFM c coefficient [-]", xlabel = "iteration #")
+    ax7 = MK.Axis(calibrated_coeffs_fig[3, 1], ylabel = "ABHOM m coefficient [-]", title = "$plot_name")
+    ax8 = MK.Axis(calibrated_coeffs_fig[3, 2], ylabel = "ABHOM c coefficient [-]", xlabel = "iteration #")
+    
     MK.lines!(ax3, collect(1:EKI_n_iterations), calibrated_ensemble_means[1], label = "ensemble mean", color = :orange, linewidth = 2.5)
     MK.lines!(ax4, collect(1:EKI_n_iterations), calibrated_ensemble_means[2], label = "ensemble mean", color = :orange, linewidth = 2.5)
+    MK.lines!(ax5, collect(1:EKI_n_iterations), calibrated_ensemble_means[3], label = "ensemble mean", color = :orange, linewidth = 2.5)
+    MK.lines!(ax6, collect(1:EKI_n_iterations), calibrated_ensemble_means[4], label = "ensemble mean", color = :orange, linewidth = 2.5)
+    MK.lines!(ax7, collect(1:EKI_n_iterations), calibrated_ensemble_means[5], label = "ensemble mean", color = :orange, linewidth = 2.5)
+    MK.lines!(ax8, collect(1:EKI_n_iterations), calibrated_ensemble_means[6], label = "ensemble mean", color = :orange, linewidth = 2.5)
+
     MK.save("$plot_name"*"_calibrated_coeffs_fig.svg", calibrated_coeffs_fig)
 
     ## Calibrated parcel simulations.
@@ -223,11 +233,11 @@ for (exp_index, data_file_name) in enumerate(data_file_names)
 
     ## Looking at spread in UKI calibrated parameters
     ϕ_UKI = UKI_output[2]
-    UKI_parcel_1 = run_calibrated_model(FT, nuc_mode, [ϕ_UKI[1,1], ϕ_UKI[2,1]], params, IC)
-    UKI_parcel_2 = run_calibrated_model(FT, nuc_mode, [ϕ_UKI[1,2], ϕ_UKI[2,2]], params, IC)
-    UKI_parcel_3 = run_calibrated_model(FT, nuc_mode, [ϕ_UKI[1,3], ϕ_UKI[2,3]], params, IC)
-    UKI_parcel_4 = run_calibrated_model(FT, nuc_mode, [ϕ_UKI[1,4], ϕ_UKI[2,4]], params, IC)
-    UKI_parcel_5 = run_calibrated_model(FT, nuc_mode, [ϕ_UKI[1,5], ϕ_UKI[2,5]], params, IC)
+    UKI_parcel_1 = run_model(params, [ϕ_UKI[1,1], ϕ_UKI[2,1], ϕ_UKI[3,1], ϕ_UKI[4,1], ϕ_UKI[5,1], ϕ_UKI[6,1]], FT, IC, end_sim)
+    UKI_parcel_2 = run_model(params, [ϕ_UKI[1,2], ϕ_UKI[2,2], ϕ_UKI[3,2], ϕ_UKI[4,2], ϕ_UKI[5,2], ϕ_UKI[6,2]], FT, IC, end_sim)
+    UKI_parcel_3 = run_model(params, [ϕ_UKI[1,3], ϕ_UKI[2,3], ϕ_UKI[3,3], ϕ_UKI[4,3], ϕ_UKI[5,3], ϕ_UKI[6,3]], FT, IC, end_sim)
+    UKI_parcel_4 = run_model(params, [ϕ_UKI[1,4], ϕ_UKI[2,4], ϕ_UKI[3,4], ϕ_UKI[4,4], ϕ_UKI[5,4], ϕ_UKI[6,4]], FT, IC, end_sim)
+    UKI_parcel_5 = run_model(params, [ϕ_UKI[1,5], ϕ_UKI[2,5], ϕ_UKI[3,5], ϕ_UKI[4,5], ϕ_UKI[5,5], ϕ_UKI[6,5]], FT, IC, end_sim)
 
     UKI_spread_fig = MK.Figure(size = (700, 600), fontsize = 24)
     ax_spread = MK.Axis(UKI_spread_fig[1, 1], ylabel = "Frozen Fraction [-]", xlabel = "time [s]", title = "$plot_name")

--- a/papers/ice_nucleation_2024/calibration.jl
+++ b/papers/ice_nucleation_2024/calibration.jl
@@ -11,7 +11,7 @@ import CloudMicrophysics.Parameters as CMP
 import Thermodynamics as TD
 import StatsBase as SB
 
-# format: off
+#! format: off
 # definition of the ODE problem for parcel model
 include(joinpath(pkgdir(CM), "parcel", "Parcel.jl"))
 include(joinpath(pkgdir(CM), "papers", "ice_nucleation_2024", "calibration_setup.jl"))
@@ -19,7 +19,9 @@ include(joinpath(pkgdir(CM), "papers", "ice_nucleation_2024", "calibration_setup
 # Define model which wraps around parcel and overwrites calibrated parameters
 function run_model(p, coefficients, FT, IC, end_sim; calibration = false)
     # grabbing parameters
-    ABDINM_m_calibrated, ABDINM_c_calibrated, ABIFM_m_calibrated, ABIFM_c_calibrated, ABHOM_m_calibrated, ABHOM_c_calibrated = coefficients
+    ABDINM_m_calibrated, ABDINM_c_calibrated,
+    ABIFM_m_calibrated, ABIFM_c_calibrated,
+    ABHOM_m_calibrated, ABHOM_c_calibrated = coefficients
     (; prescribed_thermodynamics, t_profile, T_profile, P_profile) = p
     (; const_dt, w, t_max, ips) = p
     (; aerosol_act, aerosol, r_nuc) = p
@@ -103,7 +105,7 @@ function run_model(p, coefficients, FT, IC, end_sim; calibration = false)
     # solve ODE
     local sol = run_parcel(IC, FT(0), t_max, params)
     if calibration == true
-        return sol[9, end - end_sim:end] ./ (IC[7] + IC[8] + IC[9])
+        return sol[9, (end - end_sim):end] ./ (IC[7] + IC[8] + IC[9])
     elseif calibration == false
         return sol
     end
@@ -197,7 +199,7 @@ function calibrate_J_parameters_EKI(FT, IN_mode, params, IC, y_truth, end_sim, �
     initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ensemble)
     EKI_obj = EKP.EnsembleKalmanProcess(
         initial_ensemble,
-        y_truth[end - end_sim:end],
+        y_truth[(end - end_sim):end],
         Γ,
         EKP.Inversion();
         rng = rng,
@@ -323,8 +325,11 @@ function ensemble_means(ϕ_n_values, N_iterations, N_ensemble)
             Distributions.mean(ϕ_n_values[iter][5, i] for i in 1:N_ensemble)
         ABHOM_c_mean[iter] =
             Distributions.mean(ϕ_n_values[iter][6, i] for i in 1:N_ensemble)
-    
     end
 
-    return [ABDINM_m_mean, ABDINM_c_mean, ABIFM_m_mean, ABIFM_c_mean, ABHOM_m_mean, ABHOM_c_mean]
+    return [
+        ABDINM_m_mean, ABDINM_c_mean,
+        ABIFM_m_mean, ABIFM_c_mean,
+        ABHOM_m_mean, ABHOM_c_mean
+    ]
 end

--- a/papers/ice_nucleation_2024/calibration.jl
+++ b/papers/ice_nucleation_2024/calibration.jl
@@ -11,15 +11,15 @@ import CloudMicrophysics.Parameters as CMP
 import Thermodynamics as TD
 import StatsBase as SB
 
-#! format: off
+# format: off
 # definition of the ODE problem for parcel model
 include(joinpath(pkgdir(CM), "parcel", "Parcel.jl"))
 include(joinpath(pkgdir(CM), "papers", "ice_nucleation_2024", "calibration_setup.jl"))
 
 # Define model which wraps around parcel and overwrites calibrated parameters
-function run_model(p, coefficients, IN_mode, FT, IC, end_sim)
+function run_model(p, coefficients, FT, IC, end_sim; calibration = false)
     # grabbing parameters
-    m_calibrated, c_calibrated = coefficients
+    ABDINM_m_calibrated, ABDINM_c_calibrated, ABIFM_m_calibrated, ABIFM_c_calibrated, ABHOM_m_calibrated, ABHOM_c_calibrated = coefficients
     (; prescribed_thermodynamics, t_profile, T_profile, P_profile) = p
     (; const_dt, w, t_max, ips) = p
     (; aerosol_act, aerosol, r_nuc) = p
@@ -27,55 +27,52 @@ function run_model(p, coefficients, IN_mode, FT, IC, end_sim)
     (; dep_nucleation, heterogeneous, homogeneous) = p
     (; liq_size_distribution, ice_size_distribution, aero_σ_g) = p
 
-    if IN_mode == "ABDINM"
-        # overwriting
-        if aerosol == CMP.Kaolinite(FT)
-            override_file = Dict(
-                "China2017_J_deposition_m_Kaolinite" =>
-                    Dict("value" => m_calibrated, "type" => "float"),
-                "China2017_J_deposition_c_Kaolinite" =>
-                    Dict("value" => c_calibrated, "type" => "float"),
-            )
-            kaolinite_calibrated = CP.create_toml_dict(FT; override_file)
-            aerosol = CMP.Kaolinite(kaolinite_calibrated)
-        elseif aerosol == CMP.ArizonaTestDust(FT)
-            override_file = Dict(
-                "J_ABDINM_m_ArizonaTestDust" =>
-                    Dict("value" => m_calibrated, "type" => "float"),
-                "J_ABDINM_c_ArizonaTestDust" =>
-                    Dict("value" => c_calibrated, "type" => "float"),
-            )
-            ATD_calibrated = CP.create_toml_dict(FT; override_file)
-            aerosol = CMP.ArizonaTestDust(ATD_calibrated)
-        elseif aerosol == CMP.Illite(FT)
-            override_file = Dict(
-                "J_ABDINM_m_Illite" =>
-                    Dict("value" => m_calibrated, "type" => "float"),
-                "J_ABDINM_c_Illite" =>
-                    Dict("value" => c_calibrated, "type" => "float"),
-            )
-            illite_calibrated = CP.create_toml_dict(FT; override_file)
-            aerosol = CMP.Illite(illite_calibrated)
-        end
-
-    elseif IN_mode == "ABIFM"
-        # overwriting
+    # overwriting
+    if aerosol == CMP.Kaolinite(FT)
         override_file = Dict(
+            "China2017_J_deposition_m_Kaolinite" =>
+                Dict("value" => ABDINM_m_calibrated, "type" => "float"),
+            "China2017_J_deposition_c_Kaolinite" =>
+                Dict("value" => ABDINM_c_calibrated, "type" => "float"),
             "KnopfAlpert2013_J_ABIFM_m_Kaolinite" =>
-                Dict("value" => m_calibrated, "type" => "float"),
+                Dict("value" => ABIFM_m_calibrated, "type" => "float"),
             "KnopfAlpert2013_J_ABIFM_c_Kaolinite" =>
-                Dict("value" => c_calibrated, "type" => "float"),
+                Dict("value" => ABIFM_c_calibrated, "type" => "float"),
         )
         kaolinite_calibrated = CP.create_toml_dict(FT; override_file)
         aerosol = CMP.Kaolinite(kaolinite_calibrated)
-
-    elseif IN_mode == "ABHOM"
-        # overwriting
+    elseif aerosol == CMP.ArizonaTestDust(FT)
+        override_file = Dict(
+            "J_ABDINM_m_ArizonaTestDust" =>
+                Dict("value" => ABDINM_m_calibrated, "type" => "float"),
+            "J_ABDINM_c_ArizonaTestDust" =>
+                Dict("value" => ABDINM_c_calibrated, "type" => "float"),
+            "J_ABIFM_m_ArizonaTestDust" =>
+                Dict("value" => ABIFM_m_calibrated, "type" => "float"),
+            "J_ABIFM_c_ArizonaTestDust" =>
+                Dict("value" => ABIFM_c_calibrated, "type" => "float"),
+        )
+        ATD_calibrated = CP.create_toml_dict(FT; override_file)
+        aerosol = CMP.ArizonaTestDust(ATD_calibrated)
+    elseif aerosol == CMP.Illite(FT)
+        override_file = Dict(
+            "J_ABDINM_m_Illite" =>
+                Dict("value" => ABDINM_m_calibrated, "type" => "float"),
+            "J_ABDINM_c_Illite" =>
+                Dict("value" => ABDINM_c_calibrated, "type" => "float"),
+            "KnopfAlpert2013_J_ABIFM_m_Illite" =>
+                Dict("value" => ABIFM_m_calibrated, "type" => "float"),
+            "KnopfAlpert2013_J_ABIFM_c_Illite" =>
+                Dict("value" => ABIFM_c_calibrated, "type" => "float"),
+        )
+        illite_calibrated = CP.create_toml_dict(FT; override_file)
+        aerosol = CMP.Illite(illite_calibrated)
+    elseif aerosol == CMP.Sulfate(FT)
         override_file = Dict(
             "Linear_J_hom_coeff2" =>
-                Dict("value" => m_calibrated, "type" => "float"),
+                Dict("value" => ABHOM_m_calibrated, "type" => "float"),
             "Linear_J_hom_coeff1" =>
-                Dict("value" => c_calibrated, "type" => "float"),
+                Dict("value" => ABHOM_c_calibrated, "type" => "float"),
         )
         ip_calibrated = CP.create_toml_dict(FT; override_file)
         ips = CMP.IceNucleationParameters(ip_calibrated)
@@ -105,152 +102,83 @@ function run_model(p, coefficients, IN_mode, FT, IC, end_sim)
 
     # solve ODE
     local sol = run_parcel(IC, FT(0), t_max, params)
-    return sol[9, end - end_sim:end] ./ (IC[7] + IC[8] + IC[9])
+    if calibration == true
+        return sol[9, end - end_sim:end] ./ (IC[7] + IC[8] + IC[9])
+    elseif calibration == false
+        return sol
+    end
 end
 
-function run_calibrated_model(FT, IN_mode, coefficients, p, IC)
-    # grabbing parameters
-    m_calibrated, c_calibrated = coefficients
-    (; prescribed_thermodynamics, t_profile, T_profile, P_profile) = p
-    (; const_dt, w, t_max, ips) = p
-    (; aerosol_act, aerosol, r_nuc) = p
-    (; liq_size_distribution, ice_size_distribution, aero_σ_g) = p
-    (; dep_nucleation, heterogeneous, homogeneous) = p
-    (; deposition_growth, condensation_growth) = p
-
-    if IN_mode == "ABDINM"
-        # overwriting
-        if aerosol == CMP.Kaolinite(FT)
-            override_file = Dict(
-                "China2017_J_deposition_m_Kaolinite" =>
-                    Dict("value" => m_calibrated, "type" => "float"),
-                "China2017_J_deposition_c_Kaolinite" =>
-                    Dict("value" => c_calibrated, "type" => "float"),
-            )
-            kaolinite_calibrated = CP.create_toml_dict(FT; override_file)
-            aerosol = CMP.Kaolinite(kaolinite_calibrated)
-        elseif aerosol == CMP.ArizonaTestDust(FT)
-            override_file = Dict(
-                "J_ABDINM_m_ArizonaTestDust" =>
-                    Dict("value" => m_calibrated, "type" => "float"),
-                "J_ABDINM_c_ArizonaTestDust" =>
-                    Dict("value" => c_calibrated, "type" => "float"),
-            )
-            ATD_calibrated = CP.create_toml_dict(FT; override_file)
-            aerosol = CMP.ArizonaTestDust(ATD_calibrated)
-        elseif aerosol == CMP.Illite(FT)
-            override_file = Dict(
-                "J_ABDINM_m_Illite" =>
-                    Dict("value" => m_calibrated, "type" => "float"),
-                "J_ABDINM_c_Illite" =>
-                    Dict("value" => c_calibrated, "type" => "float"),
-            )
-            illite_calibrated = CP.create_toml_dict(FT; override_file)
-            aerosol = CMP.Illite(illite_calibrated)
-        end
-
-    elseif IN_mode == "ABIFM"
-        # overwriting
-        override_file = Dict(
-            "KnopfAlpert2013_J_ABIFM_m_Kaolinite" =>
-                Dict("value" => m_calibrated, "type" => "float"),
-            "KnopfAlpert2013_J_ABIFM_c_Kaolinite" =>
-                Dict("value" => c_calibrated, "type" => "float"),
-        )
-        kaolinite_calibrated = CP.create_toml_dict(FT; override_file)
-        aerosol = CMP.Kaolinite(kaolinite_calibrated)
-    
-    elseif IN_mode == "ABHOM"
-        # overwriting
-        override_file = Dict(
-            "Linear_J_hom_coeff2" =>
-                Dict("value" => m_calibrated, "type" => "float"),
-            "Linear_J_hom_coeff1" =>
-                Dict("value" => c_calibrated, "type" => "float"),
-        )
-        ip_calibrated = CP.create_toml_dict(FT; override_file)
-        ips = CMP.IceNucleationParameters(ip_calibrated)
-    end
-
-    # run parcel with new coefficients
-    local params = parcel_params{FT}(
-        const_dt = const_dt,
-        prescribed_thermodynamics = prescribed_thermodynamics,
-        t_profile = t_profile,
-        T_profile = T_profile,
-        P_profile = P_profile,
-        w = w,
-        aerosol_act = aerosol_act,
-        aerosol = aerosol,
-        aero_σ_g = aero_σ_g,
-        homogeneous = homogeneous,
-        deposition = dep_nucleation,
-        heterogeneous = heterogeneous,
-        condensation_growth = condensation_growth,
-        deposition_growth = deposition_growth,
-        liq_size_distribution = liq_size_distribution,
-        ice_size_distribution = ice_size_distribution,
-        ips = ips,
-        r_nuc = r_nuc,
+function stats_to_prior(observation_name, stats)
+    prior = EKP.constrained_gaussian(
+        observation_name,
+        stats[1],
+        stats[2],
+        stats[3],
+        stats[4],
     )
-
-    # solve ODE
-    local sol = run_parcel(IC, FT(0), t_max, params)
-    return sol
+    return prior
 end
 
 function create_prior(FT, IN_mode, ; perfect_model = false, aerosol_type = nothing)
     # TODO - add perfect_model flag to plot_ensemble_mean.jl
-    observation_data_names = ["m_coeff", "c_coeff"]
+    observation_data_names = [
+        "ABDINM_m_coeff", "ABDINM_c_coeff",
+        "ABIFM_m_coeff", "ABIFM_c_coeff",
+        "ABHOM_m_coeff", "ABHOM_c_coeff",
+    ]
+
+    stats = [
+        [FT(0.001), FT(0), FT(0), Inf], # ABDINM m
+        [FT(0), FT(0), -Inf, Inf],  # ABDINM c
+        [FT(0.001), FT(0), FT(0), Inf], # ABIFM m
+        [FT(0), FT(0), -Inf, Inf],  # ABIFM c
+        [FT(0001), FT(0), FT(0), Inf], # ABHOM m
+        [FT(0), FT(0), -Inf, Inf],  # ABHOM c
+    ]
 
     # stats = [mean, std dev, lower bound, upper bound]
     # for perfect model calibration
     if perfect_model == true
-        if IN_mode == "ABDINM"
-            m_stats = [FT(20), FT(8), FT(0), Inf]
-            c_stats = [FT(-1), FT(2), -Inf, Inf]
-        elseif IN_mode == "ABIFM"
-            m_stats = [FT(50), FT(7), FT(0), Inf]
-            c_stats = [FT(-7), FT(4), -Inf, Inf]
-        elseif IN_mode == "ABHOM"
-            m_stats = [FT(251), FT(6), FT(0), Inf]
-            c_stats = [FT(-66), FT(3), -Inf, Inf]
-        end
+        stats[1] = [FT(20), FT(8), FT(0), Inf]
+        stats[2] = [FT(-1), FT(2), -Inf, Inf]
+
+        stats[3] = [FT(50), FT(7), FT(0), Inf]
+        stats[4] = [FT(-7), FT(4), -Inf, Inf]
+
+        stats[5] = [FT(251), FT(6), FT(0), Inf]
+        stats[6] = [FT(-66), FT(3), -Inf, Inf]
+
     elseif perfect_model == false
-        if IN_mode == "ABDINM"
-            if aerosol_type == CMP.ArizonaTestDust(FT)
-                m_stats = [FT(40), FT(20), FT(0), Inf]
-                c_stats = [FT(0.5), FT(20), -Inf, Inf]
-            elseif aerosol_type == CMP.Illite(FT)
-                m_stats = [FT(30), FT(20), FT(0), Inf]
-                c_stats = [FT(0.7), FT(7), -Inf, Inf]
-            end
-        elseif IN_mode == "ABIFM"
-            # m_stats = [FT(50), FT(1), FT(0), Inf]
-            # c_stats = [FT(-7), FT(1), -Inf, Inf]
-            error("ABIFM calibrations not yet supported.")
-        elseif IN_mode == "ABHOM"
-            m_stats = [FT(260.927125), FT(25), FT(0), Inf]
-            c_stats = [FT(-68.553283), FT(10), -Inf, Inf]
+        if aerosol_type == CMP.ArizonaTestDust(FT)
+            stats[1] = [FT(40), FT(20), FT(0), Inf]
+            stats[2] = [FT(0.5), FT(20), -Inf, Inf]
+
+            stats[3] = [FT(30), FT(30), FT(0), Inf]
+            stats[4] = [FT(-1), FT(20), -Inf, Inf]
+        elseif aerosol_type == CMP.Illite(FT)
+            stats[1] = [FT(30), FT(20), FT(0), Inf]
+            stats[2] = [FT(0.7), FT(7), -Inf, Inf]
+
+            stats[3] = [FT(30), FT(30), FT(0), Inf]
+            stats[4] = [FT(-1), FT(20), -Inf, Inf]
+        elseif aerosol_type == CMP.Sulfate(FT)
+            stats[5] = [FT(260.927125), FT(25), FT(0), Inf]
+            stats[6] = [FT(-68.553283), FT(10), -Inf, Inf]
         end
     end
 
-    m_prior = EKP.constrained_gaussian(
-        observation_data_names[1],
-        m_stats[1],
-        m_stats[2],
-        m_stats[3],
-        m_stats[4],
-    )
-    c_prior = EKP.constrained_gaussian(
-        observation_data_names[2],
-        c_stats[1],
-        c_stats[2],
-        c_stats[3],
-        c_stats[4],
-    )
-    prior = EKP.combine_distributions([m_prior, c_prior])
-    return prior
+    priors = [
+        stats_to_prior(observation_data_names[1], stats[1]),
+        stats_to_prior(observation_data_names[2], stats[2]),
+        stats_to_prior(observation_data_names[3], stats[3]),
+        stats_to_prior(observation_data_names[4], stats[4]),
+        stats_to_prior(observation_data_names[5], stats[5]),
+        stats_to_prior(observation_data_names[6], stats[6]),
+    ]
+
+    combined_prior = EKP.combine_distributions(priors)
+    return combined_prior
 end
 
 function calibrate_J_parameters_EKI(FT, IN_mode, params, IC, y_truth, end_sim, Γ,; perfect_model = false)
@@ -285,7 +213,7 @@ function calibrate_J_parameters_EKI(FT, IN_mode, params, IC, y_truth, end_sim, �
         ϕ_n = EKP.get_ϕ_final(prior, EKI_obj)
         G_ens = hcat(
             [
-                run_model(params, ϕ_n[:, i], IN_mode, FT, IC, end_sim) for
+                run_model(params, ϕ_n[:, i], FT, IC, end_sim, calibration = true) for
                 i in 1:N_ensemble
             ]...,
         )
@@ -301,16 +229,13 @@ function calibrate_J_parameters_EKI(FT, IN_mode, params, IC, y_truth, end_sim, �
     end
 
     # Mean coefficients of all ensembles in the final iteration
-    m_coeff_ekp = round(
-        Distributions.mean(ϕ_n_values[final_iter][1, 1:N_ensemble]),
-        digits = 6,
-    )
-    c_coeff_ekp = round(
-        Distributions.mean(ϕ_n_values[final_iter][2, 1:N_ensemble]),
-        digits = 6,
-    )
-
-    calibrated_coeffs = [m_coeff_ekp, c_coeff_ekp]
+    calibrated_coeffs = []
+    for i = 1:6
+        append!(calibrated_coeffs, round(
+            Distributions.mean(ϕ_n_values[final_iter][i, 1:N_ensemble]),
+            digits = 6)
+        )
+    end
 
     return [calibrated_coeffs, ϕ_n_values]
 end
@@ -346,7 +271,7 @@ function calibrate_J_parameters_UKI(FT, IN_mode, params, IC, y_truth, end_sim, �
         ϕ_n = EKP.get_ϕ_final(prior, UKI_obj)
         # Evaluate forward map
         G_n = [
-            run_model(params, ϕ_n[:, i], IN_mode, FT, IC, end_sim) for
+            run_model(params, ϕ_n[:, i], FT, IC, end_sim, calibration = true) for
             i in 1:size(ϕ_n)[2]  #i in 1:N_ensemble
         ]
         # Reformat into `d x N_ens` matrix
@@ -378,15 +303,28 @@ end
 
 function ensemble_means(ϕ_n_values, N_iterations, N_ensemble)
     iterations = collect(1:N_iterations)
-    m_mean = zeros(length(iterations))
-    c_mean = zeros(length(iterations))
+    ABDINM_m_mean = zeros(length(iterations))
+    ABDINM_c_mean = zeros(length(iterations))
+    ABIFM_m_mean = zeros(length(iterations))
+    ABIFM_c_mean = zeros(length(iterations))
+    ABHOM_m_mean = zeros(length(iterations))
+    ABHOM_c_mean = zeros(length(iterations))
 
     for iter in iterations
-        m_mean[iter] =
+        ABDINM_m_mean[iter] =
             Distributions.mean(ϕ_n_values[iter][1, i] for i in 1:N_ensemble)
-        c_mean[iter] =
+        ABDINM_c_mean[iter] =
             Distributions.mean(ϕ_n_values[iter][2, i] for i in 1:N_ensemble)
+        ABIFM_m_mean[iter] =
+            Distributions.mean(ϕ_n_values[iter][3, i] for i in 1:N_ensemble)
+        ABIFM_c_mean[iter] =
+            Distributions.mean(ϕ_n_values[iter][4, i] for i in 1:N_ensemble)
+        ABHOM_m_mean[iter] =
+            Distributions.mean(ϕ_n_values[iter][5, i] for i in 1:N_ensemble)
+        ABHOM_c_mean[iter] =
+            Distributions.mean(ϕ_n_values[iter][6, i] for i in 1:N_ensemble)
+    
     end
 
-    return [m_mean, c_mean]
+    return [ABDINM_m_mean, ABDINM_c_mean, ABIFM_m_mean, ABIFM_c_mean, ABHOM_m_mean, ABHOM_c_mean]
 end

--- a/papers/ice_nucleation_2024/calibration.jl
+++ b/papers/ice_nucleation_2024/calibration.jl
@@ -154,7 +154,7 @@ function create_prior(FT, IN_mode, ; perfect_model = false, aerosol_type = nothi
     elseif perfect_model == false
         if aerosol_type == CMP.ArizonaTestDust(FT)
             stats[1] = [FT(40), FT(20), FT(0), Inf]
-            stats[2] = [FT(0.5), FT(20), -Inf, Inf]
+            stats[2] = [FT(0.5), FT(20), FT(-2), Inf]
 
             stats[3] = [FT(30), FT(30), FT(0), Inf]
             stats[4] = [FT(-1), FT(20), -Inf, Inf]
@@ -166,7 +166,7 @@ function create_prior(FT, IN_mode, ; perfect_model = false, aerosol_type = nothi
             stats[4] = [FT(-1), FT(20), -Inf, Inf]
         elseif aerosol_type == CMP.Sulfate(FT)
             stats[5] = [FT(260.927125), FT(25), FT(0), Inf]
-            stats[6] = [FT(-68.553283), FT(10), -Inf, Inf]
+            stats[6] = [FT(-68.553283), FT(10), FT(-70), Inf]
         end
     end
 

--- a/papers/ice_nucleation_2024/calibration_setup.jl
+++ b/papers/ice_nucleation_2024/calibration_setup.jl
@@ -135,17 +135,15 @@ function perf_model_IC(FT, IN_mode)
     return [Sₗ, p₀, T₀, qᵥ, qₗ, qᵢ, Nₐ, Nₗ, Nᵢ, FT(0)]
 end
 
-function perf_model_pseudo_data(FT, IN_mode, params, IC)
+function perf_model_pseudo_data(FT, IN_mode, params, IC, end_sim)
     n_samples = 10
 
-    if IN_mode == "ABDINM"
-        coeff_true = [FT(27.551), FT(-2.2209)]
-    elseif IN_mode == "ABIFM"
-        coeff_true = [FT(54.58834), FT(-10.54758)]
-    elseif IN_mode == "ABHOM"
-        coeff_true = [FT(255.927125), FT(-68.553283)]
-    end
-    sol_ICNC = run_calibrated_model(FT, IN_mode, coeff_true, params, IC)[9, :]
+    coeff_true = [
+        FT(27.551), FT(-2.2209),        # ABDINM
+        FT(54.58834), FT(-10.54758),    # ABIFM
+        FT(255.927125), FT(-68.553283), # ABHOM
+    ]
+    sol_ICNC = run_model(params, coeff_true, FT, IC, end_sim)[9, :]
     G_truth = sol_ICNC ./ (IC[7] + IC[8] + IC[9])
     dim_output = length(G_truth)
 

--- a/papers/ice_nucleation_2024/calibration_setup.jl
+++ b/papers/ice_nucleation_2024/calibration_setup.jl
@@ -163,8 +163,8 @@ function AIDA_IN05_params(FT, w, t_max, t_profile, T_profile, P_profile)
     prescribed_thermodynamics = true
     aerosol_act = "AeroAct"
     aerosol = CMP.Sulfate(FT)
-    dep_nucleation = "None"
-    heterogeneous = "None"
+    dep_nucleation = "ABDINM"
+    heterogeneous = "ABIFM"
     homogeneous = "ABHOM"
     condensation_growth = "Condensation"
     deposition_growth = "Deposition"
@@ -256,8 +256,8 @@ function AIDA_IN07_params(FT, w, t_max, t_profile, T_profile, P_profile, plot_na
     aerosol_act = "None"
     aerosol = plot_name == "IN0701" ? CMP.ArizonaTestDust(FT) : CMP.Illite(FT)
     dep_nucleation = "ABDINM"
-    heterogeneous = "None"
-    homogeneous = "None"
+    heterogeneous = "ABIFM"
+    homogeneous = "ABHOM"
     condensation_growth = "Condensation"
     deposition_growth = "Deposition"
     liq_size_distribution = "Gamma"

--- a/papers/ice_nucleation_2024/perfect_calib.jl
+++ b/papers/ice_nucleation_2024/perfect_calib.jl
@@ -11,12 +11,12 @@ IN_mode_list = ["ABDINM", "ABIFM", "ABHOM"]
 for IN_mode in IN_mode_list
     params = perf_model_params(FT, IN_mode)
     IC = perf_model_IC(FT, IN_mode)
+    end_sim = 25
 
-    pseudo_data = perf_model_pseudo_data(FT, IN_mode, params, IC)
+    pseudo_data = perf_model_pseudo_data(FT, IN_mode, params, IC, end_sim)
     Γ = pseudo_data[2]
     y_truth = pseudo_data[1]
     coeff_true = pseudo_data[3]
-    end_sim = 25
 
     output = calibrate_J_parameters_EKI(
         FT,
@@ -31,29 +31,68 @@ for IN_mode in IN_mode_list
 
     iterations = collect(1:size(output[2])[1])
     calibrated_parameters = output[1]
-    m_mean = []
-    m_mean = ensemble_means(
+    ϕ_n_values = output[2]
+    ABDINM_m_mean = []
+    ABDINM_c_mean = []
+    ABIFM_m_mean = []
+    ABIFM_c_mean = []
+    ABHOM_m_mean = []
+    ABHOM_c_mean = []
+
+    ABDINM_m_mean = ensemble_means(
         output[2],
-        size(output[2])[1],
-        size(output[2][1])[2],
+        size(ϕ_n_values)[1],
+        size(ϕ_n_values[1])[2],
     )[1]
-    c_mean = []
-    c_mean = ensemble_means(
+    ABDINM_c_mean = ensemble_means(
         output[2],
-        size(output[2])[1],
-        size(output[2][1])[2],
+        size(ϕ_n_values)[1],
+        size(ϕ_n_values[1])[2],
     )[2]
+    ABIFM_m_mean = ensemble_means(
+        output[2],
+        size(ϕ_n_values)[1],
+        size(ϕ_n_values[1])[2],
+    )[3]
+    ABIFM_c_mean = ensemble_means(
+        output[2],
+        size(ϕ_n_values)[1],
+        size(ϕ_n_values[1])[2],
+    )[4]
+    ABHOM_m_mean = ensemble_means(
+        output[2],
+        size(ϕ_n_values)[1],
+        size(ϕ_n_values[1])[2],
+    )[5]
+    ABHOM_c_mean = ensemble_means(
+        output[2],
+        size(ϕ_n_values)[1],
+        size(ϕ_n_values[1])[2],
+    )[6]
 
     # Plotting calibrated parameters per iteration
-    fig = MK.Figure(size = (800, 600))
-    ax1 = MK.Axis(fig[1, 1], ylabel = "m coefficient [-]", xlabel = "iteration number", title = IN_mode)
-    ax2 = MK.Axis(fig[2, 1], ylabel = "c coefficient [-]", xlabel = "iteration number")
+    fig = MK.Figure(size = (1100, 900))
+    ax1 = MK.Axis(fig[1, 1], ylabel = "ABDINM m coefficient [-]", title = IN_mode)
+    ax2 = MK.Axis(fig[1, 2], ylabel = "ABDINM c coefficient [-]", xlabel = "iteration #")
+    ax3 = MK.Axis(fig[2, 1], ylabel = "ABIFM m coefficient [-]", title = IN_mode)
+    ax4 = MK.Axis(fig[2, 2], ylabel = "ABIFM c coefficient [-]", xlabel = "iteration #")
+    ax5 = MK.Axis(fig[3, 1], ylabel = "ABHOM m coefficient [-]", title = IN_mode)
+    ax6 = MK.Axis(fig[3, 2], ylabel = "ABHOM c coefficient [-]", xlabel = "iteration #")
     
-    MK.lines!(ax1, iterations, m_mean,                                 label = "ensemble mean", color = :orange)
-    MK.lines!(ax1, iterations, zeros(length(m_mean)) .+ coeff_true[1], label = "default value")
-    MK.lines!(ax2, iterations, c_mean,                                 label = "ensemble mean", color = :orange)
-    MK.lines!(ax2, iterations, zeros(length(c_mean)) .+ coeff_true[2], label = "default value")
-    
+
+    MK.lines!(ax1, iterations, ABDINM_m_mean,                                 label = "ensemble mean", color = :orange)
+    MK.lines!(ax1, iterations, zeros(length(ABDINM_m_mean)) .+ coeff_true[1], label = "default value")
+    MK.lines!(ax2, iterations, ABDINM_c_mean,                                 label = "ensemble mean", color = :orange)
+    MK.lines!(ax2, iterations, zeros(length(ABDINM_c_mean)) .+ coeff_true[2], label = "default value")
+    MK.lines!(ax3, iterations, ABIFM_m_mean,                                 label = "ensemble mean", color = :orange)
+    MK.lines!(ax3, iterations, zeros(length(ABIFM_m_mean)) .+ coeff_true[3], label = "default value")
+    MK.lines!(ax4, iterations, ABIFM_c_mean,                                 label = "ensemble mean", color = :orange)
+    MK.lines!(ax4, iterations, zeros(length(ABIFM_c_mean)) .+ coeff_true[4], label = "default value")
+    MK.lines!(ax5, iterations, ABHOM_m_mean,                                 label = "ensemble mean", color = :orange)
+    MK.lines!(ax5, iterations, zeros(length(ABHOM_m_mean)) .+ coeff_true[5], label = "default value")
+    MK.lines!(ax6, iterations, ABHOM_c_mean,                                 label = "ensemble mean", color = :orange)
+    MK.lines!(ax6, iterations, zeros(length(ABHOM_c_mean)) .+ coeff_true[6], label = "default value")
+
     MK.axislegend(ax1, framevisible = true, labelsize = 12, position = :rc)
     MK.axislegend(ax2, framevisible = true, labelsize = 12)
 
@@ -72,11 +111,11 @@ for IN_mode in IN_mode_list
     fig2 = MK.Figure(size = (800, 600))
     ax3 = MK.Axis(fig2[1, 1], ylabel = "Frozen Fraction [-]", xlabel = "time [s]", title = IN_mode)
     
-    soln = run_calibrated_model(FT, IN_mode, calibrated_parameters, params, IC)
-    soln_dflt = run_calibrated_model(FT, IN_mode, coeff_true, params, IC)
+    soln = run_model(params, calibrated_parameters, FT, IC, end_sim)
+    soln_dflt = run_model(params, coeff_true, FT, IC, end_sim)
 
     MK.lines!(ax3, soln.t, soln[9,:]./ (IC[7] + IC[8] + IC[9]), label = "calibrated")
-    MK.lines!(ax3, soln_dflt.t, soln_dflt[9,:]./ (IC[7] + IC[8] + IC[9]), label = "default", color = :orange)
+    MK.lines!(ax3, soln_dflt.t, soln_dflt[9,:]./ (IC[7] + IC[8] + IC[9]), label = "default", color = :orange, linestyle = :dot)
     plot_name = "perfect_calibration_ICNC_$mode_label.svg"
     MK.save(plot_name, fig2)
 end

--- a/src/IceNucleation.jl
+++ b/src/IceNucleation.jl
@@ -124,6 +124,7 @@ function ABIFM_J(
     return max(FT(0), FT(10)^logJ * FT(1e4)) # converts cm^-2 s^-1 to m^-2 s^-1
 end
 function ABIFM_J(dust::CMP.AerosolType, Δa_w::FT) where {FT}
+    println("Aerosol type not supported for ABIFM.")
     return FT(0)
 end
 

--- a/test/ice_nucleation_calibration.jl
+++ b/test/ice_nucleation_calibration.jl
@@ -8,12 +8,12 @@ include(joinpath(pkgdir(CM), "papers", "ice_nucleation_2024", "calibration.jl"))
 function test_J_calibration(FT, IN_mode)
     params = perf_model_params(FT, IN_mode)
     IC = perf_model_IC(FT, IN_mode)
+    end_sim = 25
 
-    pseudo_data = perf_model_pseudo_data(FT, IN_mode, params, IC)
+    pseudo_data = perf_model_pseudo_data(FT, IN_mode, params, IC, end_sim)
     Γ = pseudo_data[2]
     y_truth = pseudo_data[1]
     coeff_true = pseudo_data[3]
-    end_sim = 25
 
     EKI_output = calibrate_J_parameters_EKI(
         FT,
@@ -39,10 +39,10 @@ function test_J_calibration(FT, IN_mode)
     EKI_calibrated_parameters = EKI_output[1]
     UKI_calibrated_parameters = UKI_output[1]
     EKI_calibrated_soln =
-        run_calibrated_model(FT, IN_mode, EKI_calibrated_parameters, params, IC)
+        run_model(params, EKI_calibrated_parameters, FT, IC, end_sim)
     UKI_calibrated_soln =
-        run_calibrated_model(FT, IN_mode, UKI_calibrated_parameters, params, IC)
-    true_soln = run_calibrated_model(FT, IN_mode, coeff_true, params, IC)
+        run_model(params, UKI_calibrated_parameters, FT, IC, end_sim)
+    true_soln = run_model(params, coeff_true, FT, IC, end_sim)
 
     TT.@testset "EKI Perfect Model Calibrations on AIDA" begin
         # test that coeffs are close to "true" values and that end ICNC are similar
@@ -52,13 +52,13 @@ function test_J_calibration(FT, IN_mode)
             TT.@test EKI_calibrated_soln[9, end] ≈ true_soln[9, end] rtol =
                 FT(0.3)
         elseif IN_mode == "ABIFM"
-            TT.@test EKI_calibrated_parameters[1] ≈ coeff_true[1] rtol = FT(0.3)
-            TT.@test EKI_calibrated_parameters[2] ≈ coeff_true[2] rtol = FT(0.3)
+            TT.@test EKI_calibrated_parameters[3] ≈ coeff_true[3] rtol = FT(0.3)
+            TT.@test EKI_calibrated_parameters[4] ≈ coeff_true[4] rtol = FT(0.3)
             TT.@test EKI_calibrated_soln[9, end] ≈ true_soln[9, end] rtol =
                 FT(0.3)
         elseif IN_mode == "ABHOM"
-            TT.@test EKI_calibrated_parameters[1] ≈ coeff_true[1] rtol = FT(0.3)
-            TT.@test EKI_calibrated_parameters[2] ≈ coeff_true[2] rtol = FT(0.3)
+            TT.@test EKI_calibrated_parameters[5] ≈ coeff_true[5] rtol = FT(0.3)
+            TT.@test EKI_calibrated_parameters[6] ≈ coeff_true[6] rtol = FT(0.3)
             TT.@test EKI_calibrated_soln[9, end] ≈ true_soln[9, end] rtol =
                 FT(0.3)
         end
@@ -72,13 +72,13 @@ function test_J_calibration(FT, IN_mode)
             TT.@test UKI_calibrated_soln[9, end] ≈ true_soln[9, end] rtol =
                 FT(0.3)
         elseif IN_mode == "ABIFM"
-            TT.@test UKI_calibrated_parameters[1] ≈ coeff_true[1] rtol = FT(0.3)
-            TT.@test UKI_calibrated_parameters[2] ≈ coeff_true[2] rtol = FT(0.3)
+            TT.@test UKI_calibrated_parameters[3] ≈ coeff_true[3] rtol = FT(0.3)
+            TT.@test UKI_calibrated_parameters[4] ≈ coeff_true[4] rtol = FT(0.3)
             TT.@test UKI_calibrated_soln[9, end] ≈ true_soln[9, end] rtol =
                 FT(0.3)
         elseif IN_mode == "ABHOM"
-            TT.@test UKI_calibrated_parameters[1] ≈ coeff_true[1] rtol = FT(0.3)
-            TT.@test UKI_calibrated_parameters[2] ≈ coeff_true[2] rtol = FT(0.3)
+            TT.@test UKI_calibrated_parameters[5] ≈ coeff_true[5] rtol = FT(0.3)
+            TT.@test UKI_calibrated_parameters[6] ≈ coeff_true[6] rtol = FT(0.3)
             TT.@test UKI_calibrated_soln[9, end] ≈ true_soln[9, end] rtol =
                 FT(0.3)
         end


### PR DESCRIPTION
~Works! Nothing really changes, even if I make the initial droplet # concentration 1e6 in the deposition nucleation experiments so that homogeneous freezing can occur.~

First commit: only the ABHOM or ABIDNM parameters are being calibrated while all freezing modes are on.

Second commit: overwrites first commit so that all 3 pairs of parameters (i.e. ABDINM m, ABDINM c, ABIFM m, ...) are calibrated for each experiment
