### PR TITLE
specific contents jargon clarifications (to avoid humidity of snow, ice, rain, ...)

### DIFF
--- a/docs/src/Glossary.md
+++ b/docs/src/Glossary.md
@@ -2,14 +2,14 @@
 
 A scheme that predicts one moment of the particle size distribution (PSD).
 Typically it's the 3rd moment of PSD.
-The scheme's prognostic variable is the specific humidity (mass fraction)
+The scheme's prognostic variable is the specific content (mass fraction)
   of water in each category, which is proportional to the 3rd moment of PSD.
 
 ## 2-moment scheme
 
 A scheme that predicts two moments of the particle size distribution (PSD).
 Typically those are the 3rd and the 0th moments of PSD.
-The scheme's prognostic variables are the specific humidity (mass fraction)
+The scheme's prognostic variables are the specific content (mass fraction)
   and number concentration of particles in each category,
   which are proportional to the 3rd and 0th moment of (PSD)
 

--- a/docs/src/IceNucleationParcel0D.md
+++ b/docs/src/IceNucleationParcel0D.md
@@ -31,7 +31,7 @@ e = q_v p \frac{R_v}{R_a}
 \end{equation}
 ```
 where:
-- ``q_v`` is the water vapor specific humidity
+- ``q_v`` is the specific humidity
 - ``p`` is the air pressure
 - ``R_v``, ``R_a`` are the gas constants for water vapor and air.
 
@@ -59,9 +59,9 @@ From the moist adiabatic assumption
 \end{equation}
 ```
 where:
-- ``q_{l,vap}`` is the cloud liquid water specific humidity from vaporization/condensation,
-- ``q_{i,subl}`` is the cloud ice specific humidity from sublimation/deposition,
-- ``q_{i,fus}`` is the cloud ice specific humidity from melting/freezing,
+- ``q_{l,vap}`` is the cloud liquid water specific content from vaporization/condensation,
+- ``q_{i,subl}`` is the cloud ice specific content from sublimation/deposition,
+- ``q_{i,fus}`` is the cloud ice specific content from melting/freezing,
 - ``L_s`` is the latent heat of sublimation,
 - ``L_f`` is the latent heat of fusion.
 
@@ -123,7 +123,7 @@ The crux of the problem is modeling the ``\frac{dq_l}{dt}`` and ``\frac{dq_i}{dt
 
 ## Supported size distributions
 Currently the parcel model supports monodisperse and gamma size distributions of cloud droplets and ice crystals,
-  and solves prognostic equations for the cloud water and cloud ice specific humidities
+  and solves prognostic equations for the cloud water and cloud ice specific contents
   ``q_l``, ``q_i`` and number concentrations ``N_l``, ``N_i``.
 
 For a monodisperse size distribution of cloud droplets or ice crystals
@@ -386,7 +386,7 @@ The following examples show ice nucleation, starting with deposition
   freezing on dust.
 The model is run three times using the `"MohlerAF_Deposition"` approach
   for 30 minutes simulation time, (shown by three different colors on the plot).
-Between each run the water vapor specific humidity is changed,
+Between each run the specific humidity is changed,
   while keeping all other state variables the same as at the last time step
   of the previous run.
 The prescribed vertical velocity is equal to 3.5 cm/s.
@@ -463,7 +463,7 @@ and `stochastic` (solid lines) parameterization options. We show results for two
 ```
 ![](frostenberg_immersion_freezing.svg)
 
-Below, we show how the non-equilibrium formulation is able to represent the Wegener-Bergeron-Findeisen (WBF) regime in the parcel model. These plots show the liquid supersaturation percent, ice supersaturation percent, temperature, specific humidity of water vapor `q_{vap}`, specific humidity of liquid `q_{liq}`, and specific humidity of ice `q_{ice}` over time. When the supersaturation is negative evaporation/sublimation occurs and when it is positive condensation/deposition occurs. Because the water vapor pressure in the parcel is greater than the saturation water vapor pressure of liquid but larger than that of ice, liquid evaporates while ice grows.
+Below, we show how the non-equilibrium formulation is able to represent the Wegener-Bergeron-Findeisen (WBF) regime in the parcel model. These plots show the liquid supersaturation percent, ice supersaturation percent, temperature, specific humidity `q_{vap}`, specific content of liquid `q_{liq}`, and specific content of ice `q_{ice}` over time. When the supersaturation is negative evaporation/sublimation occurs and when it is positive condensation/deposition occurs. Because the water vapor pressure in the parcel is greater than the saturation water vapor pressure of liquid but larger than that of ice, liquid evaporates while ice grows.
 
 ```@example
   include("../../parcel/Example_NonEq.jl")

--- a/docs/src/Microphysics0M.md
+++ b/docs/src/Microphysics0M.md
@@ -6,11 +6,11 @@ It offers a simplified way of removing the excess water
   without assuming anything about the size distributions of cloud
   or precipitation particles.
 
-The ``q_{tot}`` (total water specific humidity) sink due to precipitation
+The ``q_{tot}`` (total water specific content) sink due to precipitation
   is obtained by relaxation with a constant timescale
   to a state with condensate exceeding a threshold value removed.
 The threshold for removing excess ``q_{tot}`` is defined either by the
-  condensate specific humidity or supersaturation.
+  condensate specific content or supersaturation.
 The thresholds and the relaxation timescale are defined in
   `ClimaParams.jl`.
 
@@ -21,7 +21,7 @@ The thresholds and the relaxation timescale are defined in
 
 ## Moisture sink due to precipitation
 
-If based on maximum condensate specific humidity, the sink is defined as:
+If based on maximum condensate specific content, the sink is defined as:
 ``` math
 \begin{equation}
   \left. \frac{d \, q_{tot}}{dt} \right|_{precip} =-
@@ -29,8 +29,8 @@ If based on maximum condensate specific humidity, the sink is defined as:
 \end{equation}
 ```
 where:
-  - ``q_{liq}``, ``q_{ice}`` are cloud liquid water and cloud ice specific humidities,
-  - ``q_{c0}`` is the condensate specific humidity threshold above which water is removed,
+  - ``q_{liq}``, ``q_{ice}`` are cloud liquid water and cloud ice specific contents,
+  - ``q_{c0}`` is the condensate specific content threshold above which water is removed,
   - ``\tau_{precip}`` is the relaxation timescale.
 
 If based on saturation excess, the sink is defined as:
@@ -41,7 +41,7 @@ If based on saturation excess, the sink is defined as:
 \end{equation}
 ```
 where:
-  - ``q_{liq}``, ``q_{ice}`` are cloud liquid water and cloud ice specific humidities,
+  - ``q_{liq}``, ``q_{ice}`` are cloud liquid water and cloud ice specific contents,
   - ``S_{0}`` is the supersaturation threshold above which water is removed,
-  - ``q_{vap}^{sat}`` is the saturation specific humidity,
+  - ``q_{vap}^{sat}`` is the saturation specific content,
   - ``\tau_{precip}`` is the relaxation timescale.

--- a/docs/src/Microphysics1M.md
+++ b/docs/src/Microphysics1M.md
@@ -7,13 +7,13 @@ The module is based on the ideas of
   [Grabowski1998](@cite)
   and [Kaul2015](@cite).
 
-The cloud microphysics variables are expressed as specific humidities:
-  - `q_tot` - total water specific humidity,
-  - `q_vap` - water vapor specific humidity,
-  - `q_liq` - cloud water specific humidity,
-  - `q_ice` - cloud ice specific humidity,
-  - `q_rai` - rain specific humidity,
-  - `q_sno` - snow specific humidity.
+The cloud microphysics variables are expressed as specific contents:
+  - `q_tot` - total water specific content,
+  - `q_vap` - water vapor specific content (i.e., specific humidity),
+  - `q_liq` - cloud water specific content,
+  - `q_ice` - cloud ice specific content,
+  - `q_rai` - rain specific content,
+  - `q_sno` - snow specific content.
 
 ## Assumed particle size relationships
 
@@ -133,7 +133,7 @@ The ``\lambda`` parameter is defined as
 \end{equation}
 ```
 where:
- - ``q`` is rain, snow or ice specific humidity
+ - ``q`` is rain, snow or ice specific content
  - ``\chi_m``, ``m_0``, ``m_e``, ``\Delta_m``, ``r_0``, and ``n_0``
    are the corresponding mass(radius) and size distribution parameters
  - ``\Gamma()`` is the gamma function
@@ -149,7 +149,7 @@ In other derivations cloud ice, similar to cloud liquid water,
 
      - Do we want to test different size distributions?
 
-Here we plot the Marshall-Palmer particle size distribution for 4 different values for the rain specific humidity (q_rai).
+Here we plot the Marshall-Palmer particle size distribution for 4 different values for the rain specific content (q_rai).
 
 ```@example
 include("plots/MarshallPalmer_distribution.jl")
@@ -282,7 +282,7 @@ It is parameterized following
 \end{equation}
 ```
 where:
- - ``q_{liq}`` - liquid water specific humidity,
+ - ``q_{liq}`` - liquid water specific content,
  - ``\tau_{acnv\_rain}`` - timescale,
  - ``q_{liq\_threshold}`` - autoconversion threshold.
 
@@ -374,7 +374,7 @@ It is formulated similarly to the rain autoconversion:
 \end{equation}
 ```
 where:
- - ``q_{liq}`` - liquid water specific humidity,
+ - ``q_{liq}`` - liquid water specific content,
  - ``\tau_{acnv\_rain}`` - timescale,
  - ``q_{liq\_threshold}`` - autoconversion threshold.
 

--- a/docs/src/Microphysics2M.md
+++ b/docs/src/Microphysics2M.md
@@ -4,9 +4,9 @@ The `Microphysics2M.jl` module provides 2-moment warm rain bulk parameterization
  - the double-moment [SeifertBeheng2006](@cite) parametrization, which includes autoconversion, accretion, cloud and rain self-collection rates, breakup, terminal velocity and evaporation;
  - and other double-moment autoconversion and accretions schemes from [Wood2005](@cite) based on the works of [KhairoutdinovKogan2000](@cite), [Beheng1994](@cite), [TripoliCotton1980](@cite) and [LiuDaum2004](@cite).
 
-The microphysics variables are expressed as specific humidities [kg/kg] and number densities [1/m^3]:
-  - `q_liq` - cloud water specific humidity,
-  - `q_rai` - rain specific humidity,
+The microphysics variables are expressed as specific contents [kg/kg] and number densities [1/m^3]:
+  - `q_liq` - cloud water specific content,
+  - `q_rai` - rain specific content,
   - `N_liq` - cloud droplets number density,
   - `N_rai` - raindrops number density.
 The default values of free parameters are defined in
@@ -117,14 +117,14 @@ The autoconversion rate can be estimated by looking at variations in the second 
 ```
 where ``Z`` represents the second moment, and ``c`` and ``r`` subscripts denote cloud and rain categories respectively. In the early stages of rain evolution, an estimate of the variations in the second moment of the particle mass spectrum is obtained from the stochastic collection equation: ``\partial Z / \partial t  \approx  2k_c L_c M_c^{(3)}``, where ``M_c^{(3)}`` is the third moment of the cloud droplets spectrum. Using these equations, along with computing ``Z_c``, ``M_c^{(3)}``, ``Z_r`` directly by integrating the distribution functions, allows us to derive an equation for the autoconversion rate. To simplify the derivation, we assume that in the initial stage of the rain evolution raindrops have sizes of the order of ``x^*`` and the mean radius of cloud droplets is much less than ``x^*``. This approach yields an approximation of the autoconversion rate in the early stages of rain evolution. The early stage rain evolution assumption is then relaxed by means of a universal function that depends on a process time scale.
 
-The rate of change of rain specific humidity by autoconversion is finally expressed as
+The rate of change of rain specific content by autoconversion is finally expressed as
 ``` math
 \begin{equation}
   \left. \frac{\partial q_{rai}}{\partial t} \right|_{acnv} = \frac{k_{cc}}{20 \; x^* \; \rho} \frac{(\nu+2)(\nu+4)}{(\nu+1)^2} (q_{liq} \rho)^2 \overline{x}_c^2 \left(1+\frac{\phi_{acnv}(\tau)}{1-\tau^2}\right)\frac{\rho_0}{\rho},
 \end{equation}
 ```
 where:
-  - ``q_{liq}`` is the cloud liquid water specific humidity,
+  - ``q_{liq}`` is the cloud liquid water specific content,
   - ``\rho`` is the moist air density,
   - ``\rho_0 = 1.225 \, kg \cdot m^{-3}`` is the air density at surface conditions,
   - ``k_{cc}`` is the cloud-cloud collection kernel constant,
@@ -139,7 +139,7 @@ The function ``\phi_{acnv}(\tau)`` is used to correct the autoconversion rate fo
 \end{equation}
 ```
 where
-  - ``\tau = 1 - q_{liq}/(q_{liq} + q_{rai})`` is a dimensionless internal time scale with ``q_{rai}`` being the cloud liquid water specific humidity.
+  - ``\tau = 1 - q_{liq}/(q_{liq} + q_{rai})`` is a dimensionless internal time scale with ``q_{rai}`` being the cloud liquid water specific content.
 
 The default free parameter values are:
 
@@ -156,7 +156,7 @@ The rate of change of raindrops number density is
   \left. \frac{\partial N_{rai}}{\partial t} \right|_{acnv} = \frac{\rho}{x^*} \left. \frac{d \, q_{rai}}{dt} \right|_{acnv},
 \end{equation}
 ```
-and the rate of change of liquid water specific humidity and cloud droplets number density are
+and the rate of change of liquid water specific content and cloud droplets number density are
 ``` math
 \begin{align}
   \left. \frac{\partial q_{liq}}{\partial t} \right|_{acnv} = - \left. \frac{\partial q_{rai}}{\partial t} \right|_{acnv},\\
@@ -164,7 +164,7 @@ and the rate of change of liquid water specific humidity and cloud droplets numb
 \end{align}
 ```
 !!! note
-    The Seifert and Beheng parametrization is formulated for the rate of change of liquid water content ``L = \rho q``. Here, we assume constant ``\rho`` and divide the rates by ``\rho`` to derive the equations for the rate of change of specific humidities.
+    The Seifert and Beheng parametrization is formulated for the rate of change of liquid water content ``L = \rho q``. Here, we assume constant ``\rho`` and divide the rates by ``\rho`` to derive the equations for the rate of change of specific contents.
 
 ### Accretion
 An approximation for the accretion rate is obtained by directly evaluating the integral:
@@ -173,7 +173,7 @@ An approximation for the accretion rate is obtained by directly evaluating the i
     \left. \frac{\partial q_{rai}}{\partial t} \right|_{accr} = \frac{1}{\rho} \int_{x=0}^\infty\int_{y=0}^\infty f_c(x) f_r(y) K(x,y) x dy dx.
 \end{align}
 ```
-Similar to the autoconversion rate, the accretion rate is modified by a universal function. Thus, the rate of change of rain specific humidity by accretion becomes
+Similar to the autoconversion rate, the accretion rate is modified by a universal function. Thus, the rate of change of rain specific content by accretion becomes
 ```math
 \begin{align}
   \left. \frac{\partial q_{rai}}{\partial t} \right|_{accr} = & \frac{k_{cr}}{\rho} (q_{liq} \rho) (q_{rai} \rho) \phi_{accr}(\tau),\nonumber\\
@@ -181,8 +181,8 @@ Similar to the autoconversion rate, the accretion rate is modified by a universa
 \end{align}
 ```
 where:
-  - ``q_{liq}`` is the cloud liquid water specific humidity,
-  - ``q_{rai}`` is the rain liquid water specific humidity,
+  - ``q_{liq}`` is the cloud liquid water specific content,
+  - ``q_{rai}`` is the rain liquid water specific content,
   - ``\rho`` is the moist air density,
   - ``\rho_0`` is the air density at surface conditions,
   - ``k_{cr}`` is the cloud-rain collection kernel constant.
@@ -203,7 +203,7 @@ The default free parameter values are:
 |``\tau_0``  | ``5 \times 10^{-5}``                |
 |``c``       | ``4``                               |
 
-The rate of change of raindrops number density by accretion is zero, and the rate of change of liquid water specific humidity and cloud droplets number density are
+The rate of change of raindrops number density by accretion is zero, and the rate of change of liquid water specific content and cloud droplets number density are
 ``` math
 \begin{align}
   \left. \frac{\partial q_{liq}}{dt} \right|_{accr} = - \left. \frac{\partial q_{rai}}{dt} \right|_{accr},\\
@@ -228,7 +228,7 @@ Direct evaluation of the integral results in the following approximation of the 
 \end{equation}
 ```
 where:
-  - ``q_{liq}`` is the cloud liquid water specific humidity,
+  - ``q_{liq}`` is the cloud liquid water specific content,
   - ``\rho`` is the moist air density,
   - ``\rho_0`` is the air density at surface conditions,
   - ``k_{cc}`` is the Long's collection kernel constant,
@@ -250,7 +250,7 @@ This yields,
 \end{equation}
 ```
 where:
-  - ``q_{rai}`` is the rain water specific humidity,
+  - ``q_{rai}`` is the rain water specific content,
   - ``\rho`` is the moist air density,
   - ``\rho_0`` is the air density at surface conditions,
   - ``N_{rai}`` is the raindrops number density,
@@ -482,7 +482,7 @@ From the above works:
 \end{equation}
 ```
 where:
-  - ``q_{liq}`` is the cloud liquid water specific humidity,
+  - ``q_{liq}`` is the cloud liquid water specific content,
   - ``N_d`` is the cloud droplet concentration,
   - ``\rho`` is the air density,
 
@@ -504,7 +504,7 @@ and the default free parameter values are:
 \end{equation}
 ```
 where:
-  - ``q_{liq}`` is the cloud liquid water specific humidity,
+  - ``q_{liq}`` is the cloud liquid water specific content,
   - ``N_d`` is the cloud droplet number concentration,
 
 and the default free parameter values are:
@@ -527,7 +527,7 @@ and the default free parameter values are:
 \end{equation}
 ```
 where:
-  - ``q_{liq}`` is the cloud liquid water specific humidity,
+  - ``q_{liq}`` is the cloud liquid water specific content,
   - ``q_{liq_threshold}`` is the cloud liquid to rain water threshold,
   - ``N_d`` is the cloud droplet number concentration,
   - ``\mathrm{H}(x)`` is the Heaviside step function.
@@ -560,7 +560,7 @@ and the default free parameter values are:
 \end{equation}
 ```
 where:
-  - ``q_{liq}`` is the cloud liquid water specific humidity,
+  - ``q_{liq}`` is the cloud liquid water specific content,
   - ``N_d`` is the cloud droplet number concentration,
   - ``\rho`` is the air density.
 
@@ -594,7 +594,7 @@ Then the ``R_6`` and ``R_{6C}`` are defined as
 \end{equation}
 ```
 where:
-  - ``q_{liq}`` is the cloud liquid water specific humidity,
+  - ``q_{liq}`` is the cloud liquid water specific content,
   - ``N_d`` is the cloud droplet number concentration,
   - ``\tau_{acnv,\, 0}`` is the auto-conversion time scale at ``N_d = 100 cm^{-3}``.
 
@@ -615,8 +615,8 @@ The default free parameter values are:
 \end{equation}
 ```
 where:
-  - ``q_{liq}`` is the cloud liquid water specific humidity,
-  - ``q_{rai}`` is the rain water specific humidity,
+  - ``q_{liq}`` is the cloud liquid water specific content,
+  - ``q_{rai}`` is the rain water specific content,
   - ``\rho``    is the air density,
 
 and the default free parameter values are:
@@ -636,8 +636,8 @@ and the default free parameter values are:
 \end{equation}
 ```
 where:
-  - ``q_{liq}`` is the cloud liquid water specific humidity,
-  - ``q_{rai}`` is the rain specific humidity,
+  - ``q_{liq}`` is the cloud liquid water specific content,
+  - ``q_{rai}`` is the rain specific content,
   - ``\rho``    is the air density,
 
 and the default free parameter values are:
@@ -655,8 +655,8 @@ and the default free parameter values are:
 \end{equation}
 ```
 where:
-  - ``q_{liq}`` is cloud liquid water specific humidity
-  - ``q_{rai}`` is rain specific humidity
+  - ``q_{liq}`` is cloud liquid water specific content
+  - ``q_{rai}`` is rain specific content
 
 and the default free parameter values are:
 

--- a/docs/src/MicrophysicsNonEq.md
+++ b/docs/src/MicrophysicsNonEq.md
@@ -4,11 +4,11 @@ The `MicrophysicsNonEq.jl` module describes a bulk parameterization of
   diffusion of water vapor on cloud droplets and cloud ice crystals
   modeled as a relaxation to equilibrium.
 
-The cloud microphysics variables are expressed as specific humidities:
-  - `q_tot` - total water specific humidity,
-  - `q_vap` - water vapor specific humidity,
-  - `q_liq` - cloud water specific humidity,
-  - `q_ice` - cloud ice specific humidity,
+The cloud microphysics variables are expressed as specific contents:
+  - `q_tot` - total water specific content,
+  - `q_vap` - water vapor specific content (i.e., specific humidity),
+  - `q_liq` - cloud water specific content,
+  - `q_ice` - cloud ice specific content,
 
 Parameters used in the parameterization are defined in
   [ClimaParams.jl](https://github.com/CliMA/ClimaParams.jl) package.
@@ -34,9 +34,9 @@ The equilibrium value is obtained based on a prescribed phase partition function
 \end{equation}
 ```
 where:
- - ``q^{eq}_{liq}, q^{eq}_{ice}`` - liquid and water specific humidity in equilibrium at current temperature and
+ - ``q^{eq}_{liq}, q^{eq}_{ice}`` - liquid and water specific content in equilibrium at current temperature and
    assuming some phase partition function based on temperature
- - ``q_{liq}, q_{ice}`` - current liquid water and ice specific humidity,
+ - ``q_{liq}, q_{ice}`` - current liquid water and ice specific content,
  - ``\tau_{l}, \tau_{i}`` - relaxation timescales.
 
 !!! note
@@ -50,15 +50,15 @@ where:
 ## Condensation/evaporation and deposition/sublimation from Morrison and Milbrandt 2015
 
 Condensation/evaporation and deposition/sublimation rates are based on
-  the difference between the water vapor specific humidity and saturation
-  vapor specific humidity over liquid and ice at the current temperature.
+  the difference between the specific humidity and the
+  specific humidity at saturation over liquid and ice at the current temperature.
 The process is modeled as a relaxation with a constant timescale.
 This formulation is derived from [MorrisonGrabowski2008_supersat](@cite)
   and [MorrisonMilbrandt2015](@cite), but without imposing exponential time integrators.
 
 !!! note
     The [MorrisonGrabowski2008_supersat](@cite) and [MorrisonMilbrandt2015](@cite)
-    papers use mass mixing ratios, not specific humidities.
+    papers use mass mixing ratios, not specific contents.
     Additionally, in their formulations they consider two different categories for liquid:
     cloud water and rain. For now we only consider cloud water and use a single relaxation timescale
     ``\tau_l`` (liquid) rather than separate ``\tau_c`` (cloud) and ``\tau_r`` (rain) values.
@@ -70,8 +70,8 @@ This formulation is derived from [MorrisonGrabowski2008_supersat](@cite)
 \end{equation}
 ```
 where:
-- ``q_{vap}`` is the water vapor specific humidity
-- ``q_{sl}``, ``q_{si}`` is the saturation specific humidity over liquid and ice
+- ``q_{vap}`` is the specific humidity
+- ``q_{sl}``, ``q_{si}`` is the specific humidity at saturation over liquid and ice
 - ``\tau_l``, ``\tau_i`` is the liquid and ice relaxation timescale
 - ``\Gamma_l``, ``\Gamma_i`` is a psychometric correction due to latent heating/cooling:
 
@@ -104,7 +104,7 @@ To see this, it is necessary to use the definitions of ``\tau``, ``q_{sl}``, and
   D_v = \frac{K}{\rho c_p}.
 \end{equation}
 ```
-If we then assume that the supersaturation ``S`` can be approximated by the specific humidities (this is only exactly true for mass mixing ratios):
+If we then assume that the supersaturation ``S`` can be approximated by the specific contents (this is only exactly true for mass mixing ratios):
 ```math
 \begin{equation}
     S_l = \frac{q_{vap}}{q_{sl}},
@@ -134,7 +134,7 @@ For simplicity, we assume a monodisperse size distribution
 ```
 where:
  - ``\rho_{air}`` is the air density,
- - ``q`` is the cloud liquid or cloud ice specific humidity,
+ - ``q`` is the cloud liquid or cloud ice specific content,
  - ``N`` is the prescribed number concentration (``500/cm^3`` by default),
  - ``\rho`` is the cloud water or cloud ice density.
 

--- a/docs/src/P3Scheme.md
+++ b/docs/src/P3Scheme.md
@@ -23,7 +23,7 @@ From these, we derive the following rime quantities:
 !!! note "Change of symbol convention"
     The original paper [MorrisonMilbrandt2015](@cite) uses the symbol ``q`` to denote the mass of a tracer per volume of air 
     (named mass mixing ratio). In our documentation of the 1-moment and 2-moment schemes we used ``q`` to denote the mass 
-    of a tracer per mass of air (named specific humidity). To keep the notation consistent between the 1,2-moment schemes 
+    of a tracer per mass of air (specific content). To keep the notation consistent between the 1,2-moment schemes 
     and P3, and to highlight the difference between normalizing by air mass or volume, we denote the mass of a tracer per 
     volume of air as ``L`` (named content).
 

--- a/docs/src/guides/GettingStarted.jl
+++ b/docs/src/guides/GettingStarted.jl
@@ -26,15 +26,15 @@ nothing #hide
 # Note that both the free parameters and the input values are of the same floating point type.
 # All values are defined in base SI units.
 const SB2006 = CMP.SB2006(FT)
-qₗ = FT(1e-3)  # Cloud liquid water specific humidity
-qᵣ = FT(5e-4)  # Rain water specific humidity
+qₗ = FT(1e-3)  # Cloud liquid water specific content
+qᵣ = FT(5e-4)  # Rain water specific content
 ρₐ = FT(1)     # Air density
 Nₗ = FT(1e8)   # Cloud droplet number concentration
 
 nothing #hide
 
 # Finally, we call `accretion`, which will return the accretion rates for
-# cloud and rain water specific humidities, as well as cloud and rain water number concentrations.
+# cloud and rain water specific contents, as well as cloud and rain water number concentrations.
 (; dq_rai_dt, dq_liq_dt, dN_rai_dt, dN_liq_dt) =
     CM2.accretion(SB2006, qₗ, qᵣ, ρₐ, Nₗ)
 @info("Accretion rates: ", dq_rai_dt, dq_liq_dt, dN_rai_dt, dN_liq_dt)

--- a/docs/src/guides/SimpleModel.jl
+++ b/docs/src/guides/SimpleModel.jl
@@ -20,8 +20,8 @@ function rain_formation(dY, Y, p, t)
     FT = eltype(Y) # Floating point precision type
     (; ρₐ, rain, liquid, ce, v_term) = p # Additional parameters passed through p
 
-    qₗ = Y[1] # Cloud water specific humidity
-    qᵣ = Y[2] # Rain water specific humidity
+    qₗ = Y[1] # Cloud water specific content
+    qᵣ = Y[2] # Rain water specific content
 
     acnv = CM1.conv_q_liq_to_q_rai(rain.acnv1M, qₗ) # Rain autoconversion rate
     accr = CM1.accretion(liquid, rain, v_term.rain, ce, qₗ, qᵣ, ρₐ) # Rain accretion rate
@@ -45,7 +45,7 @@ p = (; ρₐ, rain, liquid, ce, v_term)
 
 nothing #hide
 
-# Finally we define the simulation time and initial conditions for cloud and rain water specific humidities.
+# Finally we define the simulation time and initial conditions for cloud and rain water specific contents.
 # We define the ODE problem, pass it to the solver, and visualize the results.
 t₀ = FT(0)
 t_end = FT(10 * 60)

--- a/parcel/ParcelModel.jl
+++ b/parcel/ParcelModel.jl
@@ -159,8 +159,8 @@ function parcel_model(dY, Y, p, t)
     dY[2] = dp_air_dt   # pressure
     dY[3] = dT_dt       # temperature
     dY[4] = dqᵥ_dt      # vapor specific humidity
-    dY[5] = dqₗ_dt      # liquid water specific humidity
-    dY[6] = dqᵢ_dt      # ice specific humidity
+    dY[5] = dqₗ_dt      # liquid water specific content
+    dY[6] = dqᵢ_dt      # ice specific content
     dY[7] = dNₐ_dt      # number concentration of interstitial aerosol
     dY[8] = dNₗ_dt      # mumber concentration of droplets
     dY[9] = dNᵢ_dt      # number concentration of activated particles
@@ -183,8 +183,8 @@ Parcel state vector (all variables are in base SI units):
  - p_air - air pressure
  - T     - temperature
  - qᵥ    - vapor specific humidity
- - qₗ    - liquid water specific humidity
- - qᵢ    - ice specific humidity
+ - qₗ    - liquid water specific content
+ - qᵢ    - ice specific content
  - Nₐ    - number concentration of interstitial aerosol
  - Nₗ    - number concentration of existing water droplets
  - Nᵢ    - concentration of activated ice crystals

--- a/src/CloudDiagnostics.jl
+++ b/src/CloudDiagnostics.jl
@@ -16,7 +16,7 @@ import ..Microphysics2M as CM2
     radar_reflectivity_1M(precip, q, ρ)
 
   - `precip` - struct with 1-moment microphysics rain free parameters
-  - `q` - specific humidity of rain
+  - `q` - specific content of rain
   - `ρ` - air density
 
 Returns logarithmic radar reflectivity for the 1-moment microphysics
@@ -46,8 +46,8 @@ end
 
     - `structs` - structs microphysics 2-moment with SB2006 cloud droplets
                   and raindrops size distributions parameters
-    - `q_liq` - cloud water specific humidity
-    - `q_rai` - rain water specific humidity
+    - `q_liq` - cloud water specific content
+    - `q_rai` - rain water specific content
     - `N_liq` - cloud droplet number density
     - `N_rai` - rain droplet number density
     - `ρ_air` - air density
@@ -98,8 +98,8 @@ end
 
     - `structs` - structs with SB2006 cloud droplets and raindrops
                 size distribution parameters
-    - `q_liq` - cloud water specific humidity
-    - `q_rai` - rain water specific humidity
+    - `q_liq` - cloud water specific content
+    - `q_rai` - rain water specific content
     - `N_liq` - cloud droplet number density
     - `N_rai` - rain droplet number density
     - `ρ_air` - air density
@@ -157,8 +157,8 @@ end
 """
     effective_radius_Liu_Hallet_97(q_liq, q_rai, N_liq, N_rai, ρ_air, ρ_w)
 
-    - `q_liq` - cloud water specific humidity
-    - `q_rai` - rain water specific humidity
+    - `q_liq` - cloud water specific content
+    - `q_rai` - rain water specific content
     - `N_liq` - cloud droplet number density
     - `N_rai` - rain droplet number density
     - `ρ_air` - air density

--- a/src/Microphysics0M.jl
+++ b/src/Microphysics0M.jl
@@ -19,13 +19,13 @@ export remove_precipitation
 
  - `params_0M` - a struct with 0-moment parameters
  - `q` - current PhasePartition
- - `q_vap_sat` - water vapor specific humidity at saturation
+ - `q_vap_sat` - specific humidity at saturation
 
 Returns the `q_tot` tendency due to the removal of precipitation.
 The tendency is obtained assuming a relaxation with a constant timescale
 to a state with precipitable water removed.
 The threshold for when to remove `q_tot` is defined either by the
-condensate specific humidity or supersaturation.
+condensate specific content or supersaturation.
 The thresholds and the relaxation timescale are defined in
 ClimaParams.
 """

--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -49,7 +49,7 @@ Ec(::CMP.Snow, ::CMP.Rain, (; e_rai_sno)::CMP.CollisionEff) = e_rai_sno
     get_n0(pdf, q_sno, ρ)
 
  - `pdf` -  a struct with parameters for snow, ice, and rain size distribution
- - `q_sno` -  snow specific humidity (only for `Snow`)
+ - `q_sno` -  snow specific content (only for `Snow`)
  - `ρ` - air density (only for `Snow`)
 
 Returns the intercept parameter of the assumed Marshall-Palmer distribution
@@ -77,7 +77,7 @@ get_v0((; v0)::CMP.Blk1MVelTypeSnow{FT}, args...) where {FT} = v0
     lambda(pdf, mass, q, ρ)
 
  - `pdf`, `mass` - structs with particle size distribution and mass parameters
- - `q` - specific humidity of rain, ice or snow
+ - `q` - specific content of rain, ice or snow
  - `ρ` - air density
 
 Returns the rate parameter of the assumed size distribution of
@@ -145,7 +145,7 @@ end
  - `precip` - a struct with precipitation type (rain or snow)
  - `vel` - a struct with terminal velocity parameters
  - `ρ` - air density
- - `q` - rain or snow specific humidity
+ - `q` - rain or snow specific content
 
 Returns the mass weighted average terminal velocity assuming
 a Marshall-Palmer (1948) distribution of particles.
@@ -249,7 +249,7 @@ end
     conv_q_liq_to_q_rai(acnv, q_liq, smooth_transition)
 
  - `acnv` - 1M autoconversion parameters
- - `q_liq` - liquid water specific humidity
+ - `q_liq` - liquid water specific content
  - `smooth_transition` - a flag to switch on smoothing
 
 Returns the q_rai tendency due to collisions between cloud droplets
@@ -268,7 +268,7 @@ conv_q_liq_to_q_rai(
     conv_q_ice_to_q_sno_no_supersat(acnv, q_ice, smooth_transition)
 
  - `acnv` - 1M autoconversion parameters
- - `q_ice` -  cloud ice specific humidity
+ - `q_ice` -  cloud ice specific content
  - `smooth_transition` - a flag to switch on smoothing
 
 Returns the q_sno tendency due to autoconversion from ice.
@@ -330,9 +330,9 @@ end
  - `precip` - type for rain or snow
  - `vel` - a struct with terminal velocity parameters
  - `ce` - collision efficiency parameters
- - `q_clo` - cloud water or cloud ice specific humidity
- - `q_pre` - rain water or snow specific humidity
- - `ρ` - rain water or snow specific humidity
+ - `q_clo` - cloud water or cloud ice specific content
+ - `q_pre` - rain water or snow specific content
+ - `ρ` - rain water or snow specific content
 
 Returns the source of precipitating water (rain or snow)
 due to collisions with cloud water (liquid or ice).
@@ -374,8 +374,8 @@ end
  - `ice` - ice type parameters
  - `vel` - terminal velocity parameters for rain
  - `ce` - collision efficiency parameters
- - `q_ice` - cloud ice specific humidity
- - `q_rai` - rain water specific humidity
+ - `q_ice` - cloud ice specific content
+ - `q_rai` - rain water specific content
  - `ρ` - air density
 
 Returns the sink of rain water (partial source of snow) due to collisions
@@ -424,7 +424,7 @@ end
          or snow for temperatures above freezing
  - `type_i`, `type_j` - a type for snow or rain
  - `blk1mveltype_ti`, `blk1mveltype_tj` - 1M terminal velocity parameters
- - `q_` - specific humidity of snow or rain
+ - `q_` - specific content of snow or rain
  - `ρ` - air density
 
 Returns the accretion rate between rain and snow.
@@ -485,8 +485,8 @@ end
  - `aps` - a struct with air parameters
  - `tps` - a struct with thermodynamics parameters
  - `q` - phase partition
- - `q_rai` - rain specific humidity
- - `q_sno` - snow specific humidity
+ - `q_rai` - rain specific content
+ - `q_sno` - snow specific content
  - `ρ` - air density
  - `T` - air temperature
 
@@ -576,7 +576,7 @@ end
  - `vel` - terminal velocity parameters
  - `aps` - air properties
  - `tps` - thermodynamics parameters
- - `q_sno` - snow water specific humidity
+ - `q_sno` - snow water specific content
  - `ρ` - air density
  - `T` - air temperature
 

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -31,15 +31,15 @@ export autoconversion,
     get_size_distribution_bound
 
 """
-A structure containing the rates of change of the specific humidities and number
+A structure containing the rates of change of the specific contents and number
 densities of liquid and rain water.
 """
 Base.@kwdef struct LiqRaiRates{FT}
-    "Rate of change of the liquid water specific humidity"
+    "Rate of change of the liquid water specific content"
     dq_liq_dt::FT = FT(0)
     "Rate of change of the liquid water number density"
     dN_liq_dt::FT = FT(0)
-    "Rate of change of the rain water specific humidity"
+    "Rate of change of the rain water specific content"
     dq_rai_dt::FT = FT(0)
     "Rate of change of the rain water number density"
     dN_rai_dt::FT = FT(0)
@@ -52,7 +52,7 @@ end
     pdf_cloud_parameters(pdf_c, qₗ, ρₐ, Nₗ)
 
  - `pdf_c` - a struct with SB2006 cloud droplets size distribution parameters
- - `qₗ` - cloud water specific humidity
+ - `qₗ` - cloud water specific content
  - `ρₐ` - air density
  - `Nₗ` cloud droplet number concentration
 
@@ -104,7 +104,7 @@ end
     pdf_rain_parameters(pdf_r, qᵣ, ρₐ, Nᵣ)
 
  - `pdf_r` - a struct with SB2006 raindrops size distribution parameters
- - `qᵣ` - rain water specific humidity
+ - `qᵣ` - rain water specific content
  - `ρₐ` - air density
  - `Nᵣ` rain drop number concentration
 
@@ -163,7 +163,7 @@ end
 
  - pdf - struct containing size distribution parameters of cloud or rain
  - D - particle size (i.e. maximum dimension of particle)
- - q - cloud or rain water specific humidity
+ - q - cloud or rain water specific content
  - ρₐ - density of air
  - N - cloud or rain water number concentration
 
@@ -263,8 +263,8 @@ end
     autoconversion(scheme, q_liq, q_rai, ρ, N_liq)
 
  - `acnv`, `pdf_c` - structs with autoconversion and cloud size distribution parameters
- - `q_liq` - cloud water specific humidity
- - `q_rai` - rain water specific humidity
+ - `q_liq` - cloud water specific content
+ - `q_rai` - rain water specific content
  - `ρ` - air density
  - `N_liq` - cloud droplet number density
 
@@ -315,8 +315,8 @@ end
     accretion(scheme, q_liq, q_rai, ρ, N_liq)
 
  - `scheme` - type for 2-moment accretion parameterization
- - `q_liq` - cloud water specific humidity
- - `q_rai` - rain water specific humidity
+ - `q_liq` - cloud water specific content
+ - `q_rai` - rain water specific content
  - `ρ` - air density
  - `N_liq` - cloud droplet number density
 
@@ -353,7 +353,7 @@ end
     liquid_self_collection(scheme, q_liq, ρ, dN_liq_dt_au)
 
  - `scheme` - type for 2-moment liquid self-collection parameterization
- - `q_liq` - cloud water specific humidity
+ - `q_liq` - cloud water specific content
  - `ρ` - air density
  - `dN_liq_dt_au` - rate of change of cloud droplets number density due to autoconversion
 
@@ -386,8 +386,8 @@ end
     autoconversion_and_liquid_self_collection(scheme, q_liq, q_rai, ρ, N_liq)
 
  - `scheme` - type for 2-moment rain autoconversion parameterization
- - `q_liq` - cloud water specific humidity
- - `q_rai` - rain water specific humidity
+ - `q_liq` - cloud water specific content
+ - `q_rai` - rain water specific content
  - `ρ` - air density
  - `N_liq` - cloud droplet number density
 
@@ -412,7 +412,7 @@ end
     rain_self_collection(scheme, q_rai, ρ, N_rai)
 
  - `scheme` - type for 2-moment rain self-collection parameterization
- - `q_rai` - rain water specific humidity
+ - `q_rai` - rain water specific content
  - `ρ` - air density
  - `N_rai` - raindrops number density
 
@@ -448,7 +448,7 @@ end
     rain_breakup(scheme, q_rai, ρ, dN_rai_dt_sc)
 
  - `scheme` - type for 2-moment liquid self-collection parameterization
- - `q_rai` - rain water specific humidity
+ - `q_rai` - rain water specific content
  - `ρ` - air density
  - `N_rai` - raindrops number density
  - `dN_rai_dt_sc` - rate of change of raindrops number density due to self-collection
@@ -488,7 +488,7 @@ end
 
  - `SB2006` - a struct with SB2006 parameters for raindrops size
     distribution, self collection, and breakup
- - `q_rai` - rain water specific humidity
+ - `q_rai` - rain water specific content
  - `ρ` - air density
  - `N_rai` - raindrops number density
 
@@ -535,7 +535,7 @@ end
 
  - `SB2006` - a struct with SB2006 rain size distribution parameters
  - `vel` - a struct with terminal velocity parameters
- - `q_rai` - rain water specific humidity [kg/kg]
+ - `q_rai` - rain water specific content [kg/kg]
  - `ρ` - air density [kg/m^3]
  - `N_rai` - raindrops number density [1/m^3]
 
@@ -634,13 +634,13 @@ end
  - `aps` - air properties
  - `tps` - thermodynamics parameters
  - `q` - phase partition
- - `q_rai` - rain specific humidity
+ - `q_rai` - rain specific content
  - `ρ` - air density
  - `N_rai` - raindrops number density
  - `T` - air temperature
 
 Returns a named tuple containing the tendency of raindrops number density and rain water
-specific humidity due to rain rain_evaporation, assuming a power law velocity relation for
+specific content due to rain rain_evaporation, assuming a power law velocity relation for
 fall velocity of individual drops and an exponential size distribution, for `scheme == SB2006Type`
 """
 function rain_evaporation(
@@ -707,7 +707,7 @@ end
     conv_q_liq_to_q_rai(acnv, q_liq, ρ, N_d; smooth_transition)
 
  - `acnv` - 2-moment rain autoconversion parameterization
- - `q_liq` - cloud water specific humidity
+ - `q_liq` - cloud water specific content
  - `ρ` - air density
  - `N_d` - prescribed cloud droplet number concentration
 
@@ -754,7 +754,7 @@ function conv_q_liq_to_q_rai(
     N_d,
     smooth_transition = false,
 ) where {FT}
-    #TODO - The original paper is actually formulated for mixing ratios, not specific humidities
+    #TODO - The original paper is actually formulated for mixing ratios, not specific contents
     q_liq = max(0, q_liq)
     (; m0_liq_coeff, me_liq, D, a, b, r_0, k) = acnv
     q_liq_threshold::FT = m0_liq_coeff * N_d / ρ * r_0^me_liq
@@ -803,8 +803,8 @@ end
     accretion(accretion_scheme, q_liq, q_rai, ρ)
 
  - `accretion_scheme` - type for 2-moment rain accretion parameterization
- - `q_liq` - cloud water specific humidity
- - `q_rai` - rain water specific humidity
+ - `q_liq` - cloud water specific content
+ - `q_rai` - rain water specific content
  - `ρ` - air density (for `KK2000Type` and `Beheng1994Type`)
 
  Returns the accretion rate of rain, parametrized following
@@ -827,7 +827,7 @@ function accretion((; accr)::CMP.B1994{FT}, q_liq, q_rai, ρ) where {FT}
 end
 
 function accretion((; accr)::CMP.TC1980{FT}, q_liq, q_rai) where {FT}
-    #TODO - The original paper is actually formulated for mixing ratios, not specific humidities
+    #TODO - The original paper is actually formulated for mixing ratios, not specific contents
     q_liq = max(0, q_liq)
     q_rai = max(0, q_rai)
     (; A) = accr

--- a/src/MicrophysicsNonEq.jl
+++ b/src/MicrophysicsNonEq.jl
@@ -122,7 +122,7 @@ end
  - `sediment` - a struct with sedimentation type (cloud liquid or ice)
  - `vel` - a struct with terminal velocity parameters
  - `ρₐ` - air density
- - `q` - cloud liquid or ice specific humidity
+ - `q` - cloud liquid or ice specific content
 
 Returns the mass weighted average terminal velocity assuming a
 monodisperse size distribution with prescribed number concentration.

--- a/src/PrecipitationSusceptibility.jl
+++ b/src/PrecipitationSusceptibility.jl
@@ -10,7 +10,7 @@ export precipitation_susceptibility_accretion
 
 """
 A structure containing the logarithmic derivatives of the production of
-precipitation with respect to the specific humidities and number
+precipitation with respect to the specific contents and number
 densities of liquid and rain water.
 """
 Base.@kwdef struct precip_susceptibility_rates{FT}
@@ -24,8 +24,8 @@ end
     precipitation_susceptibility_autoconversion(param_set, scheme, q_liq, q_rai, ρ, N_liq)
 
 - `scheme` - type for 2-moment rain autoconversion parameterization
-- `q_liq` - cloud water specific humidity
-- `q_rai` - rain water specific humidity
+- `q_liq` - cloud water specific content
+- `q_rai` - rain water specific content
 - `ρ` - air density
 - `N_liq` - cloud droplet number density
 
@@ -58,8 +58,8 @@ end
     precipitation_susceptibility_accretion(param_set, scheme, q_liq, q_rai, ρ, N_liq)
 
 - `scheme` - type for 2-moment rain autoconversion parameterization
-- `q_liq` - cloud water specific humidity
-- `q_rai` - rain water specific humidity
+- `q_liq` - cloud water specific content
+- `q_rai` - rain water specific content
 - `ρ` - air density
 - `N_liq` - cloud droplet number density
 

--- a/src/parameters/Microphysics0M.jl
+++ b/src/parameters/Microphysics0M.jl
@@ -11,7 +11,7 @@ $(DocStringExtensions.FIELDS)
 Base.@kwdef struct Parameters0M{FT} <: ParametersType{FT}
     "precipitation timescale [s]"
     τ_precip::FT
-    "specific humidity precipitation threshold [-]"
+    "condensate specific content precipitation threshold [-]"
     qc_0::FT
     "supersaturation precipitation threshold [-]"
     S_0::FT

--- a/src/parameters/Microphysics1M.jl
+++ b/src/parameters/Microphysics1M.jl
@@ -114,7 +114,7 @@ $(DocStringExtensions.FIELDS)
 struct Acnv1M{FT} <: ParametersType{FT}
     "autoconversion timescale [s]"
     τ::FT
-    "specific humidity autoconversion threshold [-]"
+    "condensate specific content autoconversion threshold [-]"
     q_threshold::FT
     "threshold smooth transition steepness [-]"
     k::FT

--- a/test/microphysics2M_tests.jl
+++ b/test/microphysics2M_tests.jl
@@ -581,7 +581,7 @@ function test_microphysics2M(FT)
         ρₐ = FT(1.2)
         ρₗ = SB2006.pdf_r.ρw
 
-        # example number concentration and specific humidity
+        # example number concentration and specific content
         Nᵣ = FT(0.5 * 1e6)   # 0.5 1/cm3
         qᵣ = FT(0.5 * 1e-3)  # 0.5 g/kg
 
@@ -658,7 +658,7 @@ function test_microphysics2M(FT)
             TT.@test ND_bounded_limited ≈ Nᵣ rtol = 1e-6
         end
 
-        # Sanity checks for specific humidities for rain
+        # Sanity checks for specific contents for rain
         qD = QGK.quadgk(x -> m(x) * f_D(x), D₀, D∞)[1] / ρₐ
         qx = QGK.quadgk(x -> x * f_x(x), m₀, m∞)[1] / ρₐ
         qD_lim = QGK.quadgk(x -> m(x) * f_D_limited(x), D₀, D∞)[1] / ρₐ
@@ -699,7 +699,7 @@ function test_microphysics2M(FT)
 
     TT.@testset "2M_microphysics - Seifert and Beheng 2006 cloud distribution sanity checks" begin
 
-        # example number concentration and specific humidity
+        # example number concentration and specific content
         Nₗ = FT(1e3 * 1e6) # 1000 1/cm3
         qₗ = FT(1e-3)      # 1 g/kg
 
@@ -729,7 +729,7 @@ function test_microphysics2M(FT)
         m₀ = m(D₀)
         m∞ = m(D∞)
 
-        # Sanity checks of specific humidity and number concentration with mass distribution
+        # Sanity checks of specific content and number concentration with mass distribution
         # Sanity checks for number concentrations for cloud
         qx = QGK.quadgk(x -> x * f_x(x), m₀, m∞)[1] / (ρₐ * FT(10)^χ)
         Nx = QGK.quadgk(x -> f_x(x), m₀, m∞)[1]
@@ -742,7 +742,7 @@ function test_microphysics2M(FT)
         # integral bounds in millimiters
         _D₀ = 0.1 * 1e-6 * 1e3
         _D∞ = 100 * 1e-6 * 1e3
-        # Sanity checks specific humidity and number concentration with diameter distribution
+        # Sanity checks of specific content and number concentration with diameter distribution
         qD = QGK.quadgk(x -> _m(x) * f_D(x), _D₀, _D∞)[1] / ρₐ * FT(1e9) # convert from mm3 to m3
         ND = QGK.quadgk(x -> f_D(x), _D₀, _D∞)[1] * FT(1e9) # convert from mm3 to m3
         TT.@test ND ≈ Nₗ rtol = FT(1e-6)
@@ -756,7 +756,7 @@ function test_microphysics2M(FT)
             ρₐ,
             eps(FT),
         )
-        # Sanity checks specific humidity and number concentration with diameter distribution
+        # Sanity checks of specific content and number concentration with diameter distribution
         qD_bounded =
             QGK.quadgk(
                 x ->


### PR DESCRIPTION
## Purpose 
Avoid misleading jargon featuring humidities of snow, humidities of water, etc by reserving the term "humidity" for humidity, and using specific contents for all other solid and liquid phase water contents.


## To-do
n/a

## Content
jargon changes in docs and code comments