### PR TITLE
Add bulk collision rate with liquid for P3 distribution

### DIFF
--- a/src/Common.jl
+++ b/src/Common.jl
@@ -337,6 +337,39 @@ function Chen2022_exponential_pdf(a::FT, b::FT, c::FT, λ_inv::FT, k::Int) where
 end
 
 """
+    liquid_particle_terminal_velocity(velocity_params, ρₐ)
+    liquid_particle_terminal_velocity(velocity_params, ρₐ, D)
+
+Compute the terminal velocity of a liquid particle as a function of its size 
+    (maximum dimension, `D`) using the Chen 2022 parametrization.
+
+# Arguments
+- `velocity_params`: a struct with terminal velocity parameters from Chen 2022
+- `ρₐ`: air density [kg/m³]
+- `D`: maximum particle dimension [m]
+
+# Returns
+- The first method returns a function of `D`, while the second evaluates at a specific `D`.
+
+Needed for numerical integrals in the P3 scheme.
+
+!!! note
+    We use the same terminal velocity parametrization for cloud and rain water.
+"""
+function liquid_particle_terminal_velocity(velocity_params::CMP.Chen2022VelTypeRain, ρₐ)
+    (ai, bi, ci) = Chen2022_vel_coeffs_B1(velocity_params, ρₐ)
+    v_term(D) = sum(@. sum(ai * D^bi * exp(-ci * D)))
+    return v_term
+end
+liquid_particle_terminal_velocity(velocity_params::CMP.Chen2022VelType, ρₐ) =
+    liquid_particle_terminal_velocity(velocity_params.rain, ρₐ)
+
+function liquid_particle_terminal_velocity(velocity_params, ρₐ, D)
+    v_term = liquid_particle_terminal_velocity(velocity_params, ρₐ)
+    return v_term(D)
+end
+
+"""
     volume_sphere_D(D)
 
 Calculate the volume of a sphere with diameter D.

--- a/src/P3_processes.jl
+++ b/src/P3_processes.jl
@@ -64,35 +64,25 @@ end
 Returns the melting rate of ice (QIMLT in Morrison and Mildbrandt (2015)).
 """
 function ice_melt(
-    dist::P3Distribution{FT},
-    Chen2022::CMP.Chen2022VelType,
-    aps::CMP.AirProperties{FT},
-    tps::TDP.ThermodynamicsParameters{FT},
-    Tₐ::FT,
-    ρₐ::FT,
-    dt::FT;
+    dist::P3Distribution, Chen2022::CMP.Chen2022VelType,
+    aps::CMP.AirProperties, tps::TDP.ThermodynamicsParameters,
+    Tₐ, ρₐ, dt;
     ∫kwargs = (;),
-) where {FT}
+)
     # Note: process not dependent on `F_liq`
     # (we want ice core shape params)
     # Get constants
-    (; ν_air, D_vapor, K_therm) = aps
+    (; K_therm) = aps
     L_f = TD.latent_heat_fusion(tps, Tₐ)
-    N_sc = ν_air / D_vapor
 
-    state = get_state(dist)
-    params = get_parameters(dist)
+    (; L, N, state) = dist
+    (; T_freeze, vent) = state.params
 
-    # Ice particle terminal velocity
-    v(D) = ice_particle_terminal_velocity(state, D, Chen2022, ρₐ)
-    # Reynolds number
-    N_Re(D) = D * v(D) / ν_air
-    # Ventillation factor
-    (; vent_a, vent_b) = params.vent
-    F_v(D) = vent_a + vent_b * N_sc^FT(1 / 3) * N_Re(D)^FT(1 / 2)
+    v_term = P3.ice_particle_terminal_velocity(state, Chen2022, ρₐ)
+    F_v = CO.ventilation_factor(vent, aps, v_term)
 
     # Integrate
-    fac = 4 * K_therm / L_f * (Tₐ - params.T_freeze)
+    fac = 4 * K_therm / L_f * (Tₐ - T_freeze)
     dLdt = fac * ∫fdD(state; ∫kwargs...) do D
         ∂ice_mass_∂D(state, D) * F_v(D) * N′ice(dist, D) / D
     end
@@ -100,7 +90,6 @@ function ice_melt(
     # only consider melting (not fusion)
     dLdt = max(0, dLdt)
     # compute change of N_ice proportional to change in L
-    (; N, L) = dist
     dNdt = N / L * dLdt
 
     # ... and don't exceed the available number and mass of water droplets
@@ -108,3 +97,310 @@ function ice_melt(
     dLdt = min(dLdt, L / dt)
     return (; dNdt, dLdt)
 end
+
+function collision_cross_section_ice_liquid(state, Dᵢ, Dₗ)
+    rᵢ_eff(Dᵢ) = √(ice_area(state, Dᵢ) / π)
+    return π * (rᵢ_eff(Dᵢ) + Dₗ / 2)^2  # collision cross section  -- TODO: Check if this is correct
+end
+
+"""
+    volumetric_collision_rate_integrand(state, vel, ρₐ)
+
+Returns a function that computes the volumetric collision rate integrand for ice-liquid collisions [m³/s].
+The returned function takes ice and liquid particle diameters as arguments.
+
+# Arguments
+- `state`: a [`P3State`](@ref) object
+- `vel`: a [`Chen2022VelType`](@ref) object
+- `ρₐ`: air density
+
+# Returns
+A function `(D_ice, D_liq) -> E * K * |vᵢ - vₗ|` where:
+- `D_ice` and `D_liq` are the (maximum) diameters of the ice and liquid particles
+- `E` is the collision efficiency
+- `K` is the collision cross section
+- `vᵢ` and `vₗ` are the terminal velocities of ice and liquid particles
+
+Note that `E`, `K`, `vᵢ` and `vₗ` are all, in general, functions of `D_ice` and `D_liq`.
+
+This function is a component of integrals like
+
+```math
+∫ ∫ E * K * |vᵢ - vₗ| * N′_ice * N′_liq dDᵢ dDₗ
+```
+"""
+function volumetric_collision_rate_integrand(state, vel, ρₐ)
+    v_ice = ice_particle_terminal_velocity(state, vel, ρₐ)
+    v_liq = CO.liquid_particle_terminal_velocity(vel, ρₐ)
+    function integrand(D_ice::FT, D_liq::FT) where {FT}
+        E = FT(1)  # TODO - Make collision efficiency a function of Dᵢ and Dₗ
+        K = collision_cross_section_ice_liquid(state, D_ice, D_liq)
+        return E * K * abs(v_ice(D_ice) - v_liq(D_liq))
+    end
+
+    return integrand
+end
+
+function get_collision_integration_bounds(::Type{FT}) where {FT}
+    # TODO: Use mode/mean/std of relevant PSDs to set intermediate bounds
+    mm = FT(1e-3)
+    order_bnds = FT[0; 0.01mm; 0.1mm; 1mm; 10mm; 100mm; 1]
+    return order_bnds
+end
+
+"""
+    compute_max_freeze_rate(aps, tps, T, state, ρₐ, vel)
+
+Computes a function that returns the maximum possible freezing rate for an 
+ice particle of diameter `D_ice` [kg/s].
+
+This represents the thermodynamic upper limit to collisional freezing, which 
+occurs when the heat transfer from the ice particle to the environment is 
+balanced by the latent heat of fusion.
+
+# Arguments
+- `aps`: air properties
+- `tps`: thermodynamics parameters
+- `T`: temperature [K]
+- `state`: a [`P3State`](@ref) object
+- `ρₐ`: air density [kg/m³]
+- `vel`: a [`Chen2022VelType`](@ref) object
+
+# Returns
+A function that returns the maximum possible freezing rate for an ice particle 
+of diameter `D_ice` [kg/s]. Evaluates to 0 if T ≥ T_freeze.
+"""
+function compute_max_freeze_rate(aps, tps, T, state, ρₐ, vel)  # TODO: Consistent argument order
+    FT = eltype(state)
+    (; T_freeze, vent) = state.params
+    if T ≥ T_freeze
+        # Above freezing, no wet growth
+        return Returns(FT(0))
+    end
+
+    (; D_vapor, K_therm) = aps
+    HV = TD.latent_heat_vapor(tps, T)
+    Δqᵥ_sat =
+        TD.q_vap_saturation(tps, T_freeze, ρₐ, TD.PhaseNonEquil) -
+        TD.q_vap_saturation(tps, T, ρₐ, TD.PhaseNonEquil) # TODO: Check units w/ paper
+    ΔT = T - T_freeze
+    HF = TD.latent_heat_fusion(tps, T)
+    C = FT(4184)
+    v_term = P3.ice_particle_terminal_velocity(state, vel, ρₐ)
+    a = CO.ventilation_factor(vent, aps, v_term)
+    max_rate(D_ice) = 2FT(π) * D_ice * a(D_ice) * (-K_therm * ΔT + HV * D_vapor * Δqᵥ_sat) / (HF + C * ΔT)
+    return max_rate
+end
+
+"""
+    compute_local_rime_density(T, D_ice, D_liq, v_ice, v_liq)
+
+Provides a function that computes the local rime density [kg/m³] 
+
+From Milbrandt and Morrison (2013), based on the laboratory measurements of 
+Cober and List (1993).
+
+# Arguments
+- `state`: a [`P3State`](@ref) object
+- `vel`: a [`Chen2022VelType`](@ref) object
+- `ρₐ`: air density [kg/m³]
+- `T`: temperature [K]
+
+# Returns
+A function that computes the local rime density [kg/m³] using the equation:
+
+```math
+ρ′_r = 0.078 + 0.184 R_i - 0.015 R_i^2
+```
+where
+```math
+R_i = ( D_{liq} ⋅ |v_{liq} - v_{ice}| ) / ( 2 T_{sfc} )
+```
+and ``T_{sfc}`` is the surface temperature [°C], ``D_{liq}`` is the liquid particle
+diameter [μm], ``v_{liq/ice}`` is the particle terminal velocity [m/s].
+So the units of ``R_i`` are [μm m s⁻¹ / °C]. The units of ``ρ′_r`` are [g cm⁻³].
+This function does the appropriate unit conversions to return ``ρ′_r`` in [kg/m³].
+
+They assume for simplicity that `T_sfc` equals `T`, the ambient air temperature.
+For real graupel, `T_sfc` is slightly higher than `T` due to latent heat release 
+of freezing liquid particles onto the ice particle. MM13 found little sensitivity 
+to "realistic" increases in `T_sfc`.
+
+Implementation follows MM13, "Appendix B", part c. "Riming" (p. 427), which is based on 
+CL93, "4. Experimental results", part d. "Density measurement" (p. 1599)
+
+Note that MM15 only uses this parameterization for collisions with cloud droplets.
+For rain drops, they use the solid bulk ice density, ``ρ^* = 900 kg/m^3``.
+"""
+function compute_local_rime_density(state, vel, ρₐ, T)
+    FT = eltype(state)
+    # For now, use solid bulk ice density
+    return Returns(FT(900))
+
+    #=
+    # TODO: Implement MM13 / CL93. Draft below, but units are wrong.
+    (; T_freeze) = state.params
+    T°C = T - T_freeze  # Convert to °C
+    # TODO: Externalize these parameters
+    a, b, c = FT(0.078), FT(0.184), FT(-0.015)
+    ρ′ᵣ_min, ρ′ᵣ_max = FT(50), FT(900)
+    paper_to_si_factor = FT(1e-9)
+
+    v_ice = ice_particle_terminal_velocity(state, vel, ρₐ)
+    v_liq = CO.liquid_particle_terminal_velocity(vel, ρₐ)
+    function compute_ρ′ᵣ(D_ice, D_liq)
+        v_impact = abs(v_ice(D_ice) - v_liq(D_liq))  # Eq (B4)
+        Rᵢ = (D_liq * v_impact) / (2 * T°C)          # Eq (B2)
+        ρ′ᵣ = a + b * Rᵢ + c * Rᵢ^2                  # Eq (B1)
+        return ρ′ᵣ * paper_to_si_factor
+        # return clamp(ρ′ᵣ, ρ′ᵣ_min, ρ′ᵣ_max)
+    end
+    return compute_ρ′ᵣ
+    =#
+end
+
+function bulk_collision_rate_with_liquid(
+    ice_dist::P3Distribution{FT},             # Ice distribution
+    vel::CMP.Chen2022VelType,                 # Velocity distribution
+    cloud_dist::CMP.CloudParticlePDF_SB2006,  # Cloud distribution
+    rain_dist::CMP.RainParticlePDF_SB2006,    # Rain distribution
+    aps::CMP.AirProperties,
+    tps::TDP.ThermodynamicsParameters,
+    ρₐ,         # Air density, kg/m³
+    L_cloud,    # Cloud water content, kg/m³
+    N_cloud,    # Cloud water number concentration, 1/m³
+    L_rain,     # Rain water content, kg/m³
+    N_rain,     # Rain water number concentration, 1/m³
+    T,          # Temperature, K
+) where {FT}
+    (; state) = ice_dist
+    ρw = cloud_dist.ρw
+    @assert ρw == rain_dist.ρw "Cloud and rain should have the same liquid water density"
+
+    # Integrand components
+    ∂ₜvolume = volumetric_collision_rate_integrand(state, vel, ρₐ)
+    liq_mass(D_liq) = ρw * CO.volume_sphere_D(D_liq)
+    D_shed = FT(1e-3)  # 1mm
+    ρᵣ′ = compute_local_rime_density(state, vel, ρₐ, T)
+
+    max_freeze_rate = compute_max_freeze_rate(aps, tps, T, state, ρₐ, vel)
+
+    # Particle size distributions
+    N′_cloud_psd = FT ∘ CM2.size_distribution(cloud_dist, L_cloud / ρₐ, ρₐ, N_cloud)
+    N′_rain_psd = FT ∘ CM2.size_distribution(rain_dist, L_rain / ρₐ, ρₐ, N_rain)
+
+    # Initialize integration buffers by evaluating a representative integral
+    bounds = get_collision_integration_bounds(FT)
+    segbuf_liq = QGK.quadgk_segbuf(D_liq -> N′_cloud_psd(D_liq) + N′_rain_psd(D_liq), bounds...)[3]
+    segbuf_ice = QGK.quadgk_segbuf(D_ice -> N′ice(ice_dist, D_ice), bounds...)[3]
+
+    function bulk_liquid_sink_rate_at_D_ice(Nₗ′, D_ice)
+        ((∂ₜq_liq_part, ∂ₜN_liq_part), _) =
+            QGK.quadgk(bounds...; eval_segbuf = segbuf_liq) do D_liq
+                return (
+                    # ∂ₜq_cloud = ∫ (∫ ∂ₜvol ⋅ Nₗ′ ⋅ vol ⋅ dDₗ) ⋅ Nᵢ′ ⋅ dDᵢ
+                    ∂ₜvolume(D_ice, D_liq) * Nₗ′(D_liq) * CO.volume_sphere_D(D_liq),
+                    # ∂ₜN_cloud = ∫ (∫ ∂ₜvol ⋅ Nₗ′       ⋅ dDₗ) ⋅ Nᵢ′ ⋅ dDᵢ
+                    ∂ₜvolume(D_ice, D_liq) * Nₗ′(D_liq),
+                )
+            end
+        ∂ₜliq_mass_collisions = ρw * ∂ₜN_liq_part
+        return ∂ₜliq_mass_collisions, ∂ₜq_liq_part, ∂ₜN_liq_part
+    end
+
+
+    function ice_integrand(D_ice)
+        N′_ice_psd = N′ice(ice_dist, D_ice)
+
+        # Inner integral over liquid particle diameters
+        ∂ₜcloud_mass_collisions, ∂ₜq_cloud_part, ∂ₜN_cloud_part =
+            bulk_liquid_sink_rate_at_D_ice(N′_cloud_psd, D_ice)
+        ∂ₜrain_mass_collisions, ∂ₜq_rain_part, ∂ₜN_rain_part =
+            bulk_liquid_sink_rate_at_D_ice(N′_rain_psd, D_ice)
+
+        # Partition the mass collisions between freezing and shedding
+        ∂ₜmass_collisions = ∂ₜcloud_mass_collisions + ∂ₜrain_mass_collisions  # [kg / s]
+        ∂ₜmax_mass_freezing = max_freeze_rate(D_ice)
+
+        frac_cloud_collisions = ∂ₜcloud_mass_collisions / ∂ₜmass_collisions
+
+        ∂ₜmass_freezing = min(∂ₜmass_collisions, ∂ₜmax_mass_freezing)
+        ∂ₜmass_shedding = ∂ₜmass_collisions - ∂ₜmass_freezing
+        frac_freezing = ∂ₜmass_freezing / ∂ₜmass_collisions
+
+        # Assume that fraction of cloud/rain that is freezes/sheds is proportional to the relative proportion of cloud/rain that collides
+        ∂ₜcloud_mass_freezing = ∂ₜmass_freezing * frac_cloud_collisions
+        ∂ₜrain_mass_freezing = ∂ₜmass_freezing * (1 - frac_cloud_collisions)
+
+        ∂ₜcloud_mass_shedding = ∂ₜmass_shedding * frac_cloud_collisions
+        ∂ₜrain_mass_shedding = ∂ₜmass_shedding * (1 - frac_cloud_collisions)
+
+        # Rate conversion factors
+        shed_mass = ρw * CO.volume_sphere_D(D_shed)  # [kg]
+
+        # Resulting rates
+        ∂ₜL_rim_source_integrand = ∂ₜmass_freezing * N′_ice_psd               # [kg m⁻³ / s / m]
+        ∂ₜN_rain_source_integrand = ∂ₜmass_shedding / shed_mass * N′_ice_psd  # [   m⁻³ / s / m]
+        ∂ₜL_rain_source_integrand = ∂ₜmass_shedding * N′_ice_psd              # [kg m⁻³ / s / m]
+        ∂ₜB_rim_source_integrand = ∂ₜmass_freezing / ρᵣ′
+
+        # Integrating over `D_ice` gives another unit of `[m]`, so `[X / s / m]` --> `[X / s]`
+        return (
+            ∂ₜq_cloud_part * N′_ice_psd,   # ∂ₜq_cloud sink (QCCOL)
+            ∂ₜN_cloud_part * N′_ice_psd,   # ∂ₜN_cloud sink (NCCOL)
+            ∂ₜq_rain_part * N′_ice_psd,   # ∂ₜq_rain sink (QRCOL)
+            ∂ₜN_rain_part * N′_ice_psd,   # ∂ₜN_rain sink (NRCOL)
+            ∂ₜL_rim_source_integrand,       # ∂ₜL_rim & ∂ₜL_ice source ("QCCOL+QRCOL")
+            ∂ₜN_rain_source_integrand,      # ∂ₜN_rain source (NRSHD)
+            ∂ₜL_rain_source_integrand,      # ∂ₜL_rain source (QRSHD)
+            ∂ₜB_rim_source_integrand,       # ∂ₜB_rim source (BIWET)
+        )
+
+    end
+
+    (rates, _) = QGK.quadgk(ice_integrand, bounds...; eval_segbuf = segbuf_ice)
+    ∂ₜq_cloud_sink,
+    ∂ₜN_cloud_sink,
+    ∂ₜq_rain_sink,
+    ∂ₜN_rain_sink,
+    ∂ₜL_rim_source,
+    ∂ₜN_rain_source,
+    ∂ₜL_rain_source,
+    ∂ₜB_rim_source = rates
+
+    # Return the rates
+    return (;
+        # Liquid phase
+        ∂ₜq_cloud = -∂ₜq_cloud_sink,
+        ∂ₜq_rain = (∂ₜL_rain_source / ρₐ) - ∂ₜq_rain_sink,
+        ∂ₜN_cloud = -∂ₜN_cloud_sink,
+        ∂ₜN_rain = ∂ₜN_rain_source - ∂ₜN_rain_sink,
+        # Ice phase
+        ∂ₜL_rim = ∂ₜL_rim_source,
+        ∂ₜL_ice = ∂ₜL_rim_source,
+        ∂ₜN_ice = FT(0),
+        ∂ₜB_rim = ∂ₜB_rim_source,
+    )
+end
+
+#=
+Notes:
+- Source terms for the rime volume mixing ratio (B_rim), are calculated by the
+    ratio of the process rate for L_rim and the appropriate density.
+- Freezing of cloud water and rain and rime generated by collection of rain by ice
+    are assumed to produce ice with a density near solid bulk ice ρ^* = 900 kg/m³.
+- Wet growth (BIWET) represents an additional sink term for B_rim, whereby
+    B_rim decreases (i.e. particles become soaked and undergo densification).
+- We expect to see sink terms from collisions/collection for these terms:
+    - B_rim 
+        * +QRCOL: mass of rain collected by ice
+        * +BIWET: wet growth of rime
+    - L_rim
+        * +QCCOL: mass of cloud water collected by ice (sink to L_cloud)
+        * +QRCOL: mass of rain collected by ice (sink to L_rim)
+    - L_ice
+        * + all source terms for L_rim
+    - N_ice
+        * no collision/collection terms for N_ice
+    - 
+=#

--- a/src/P3_terminal_velocity.jl
+++ b/src/P3_terminal_velocity.jl
@@ -1,141 +1,53 @@
+
 """
-    ice_particle_terminal_velocity(state, D, Chen2022, ρₐ, use_aspect_ratio)
-Returns the terminal velocity of a single ice particle as a function
-    of its size (maximum dimension, D) using the Chen 2022 parametrization.
+    ice_particle_terminal_velocity(state, velocity_params, ρₐ; [use_aspect_ratio])
+
+Returns the terminal velocity of a single ice particle as a function of its size 
+    (maximum dimension, `D`) using the Chen 2022 parametrization.
+
+The first method returns a function of `D`, while the second evaluates at a specific `D`.
 
 # Arguments
- - `state`: The [`P3State`](@ref) object
- - `D`: Maximum particle dimension
- - `Chen2022`: The [`CMP.Chen2022VelType`](@ref) object with terminal velocity parameters
- - `ρₐ`: Air density
+ - `state`: A [`P3State`](@ref)
+ - `velocity_params`: A [`CMP.Chen2022VelType`](@ref) with terminal velocity parameters
+ - `ρₐ`: Air density [kg/m³]
+
+# Keyword arguments
  - `use_aspect_ratio`: Bool flag set to `true` if we want to consider the effects
     of particle aspect ratio on its terminal velocity (default: `true`)
 """
 function ice_particle_terminal_velocity(
-    state::P3State,
-    D::FT,
-    Chen2022::CMP.Chen2022VelType,
-    ρₐ::FT,
-    use_aspect_ratio = true,
-) where {FT}
-    # TODO - tmp
-    #ρᵢ = p3_density(p3, D, F_rim, th)
-    ρᵢ = FT(916.7)
-    if D <= Chen2022.small_ice.cutoff
-        (ai, bi, ci) = CO.Chen2022_vel_coeffs_B2(Chen2022.small_ice, ρₐ, ρᵢ)
-    else
-        (ai, bi, ci) = CO.Chen2022_vel_coeffs_B4(Chen2022.large_ice, ρₐ, ρᵢ)
+    state::P3State, velocity_params::CMP.Chen2022VelType, ρₐ; use_aspect_ratio = true,
+)
+    function v_term(D::FT) where {FT}
+        (; small_ice, large_ice) = velocity_params
+        ρᵢ = FT(916.7) # ρᵢ = p3_density(p3, D, F_rim, th) # TODO: tmp
+        ϕ_factor = use_aspect_ratio ? cbrt(ϕᵢ(state, D)) : FT(1)
+        (ai, bi, ci) = if D <= small_ice.cutoff
+            CO.Chen2022_vel_coeffs_B2(small_ice, ρₐ, ρᵢ)
+        else
+            CO.Chen2022_vel_coeffs_B4(large_ice, ρₐ, ρᵢ)
+        end
+        ϕ_factor * sum(@. sum(ai * D^bi * exp(-ci * D)))
     end
-    v = sum(@. sum(ai * D^bi * exp(-ci * D)))
-
-    return ifelse(use_aspect_ratio, ϕᵢ(state, D)^FT(1 / 3) * v, v)
+    return v_term
 end
 
 """
-   p3_particle_terminal_velocity(p3, D, Chen2022, ρₐ, use_aspect_ratio)
-
- - p3 - p3 parameters
- - D - maximum particle dimension
- - Chen2022 - struct with terminal velocity parameters from Chen 2022
- - ρₐ - air density
- - use_aspect_ratio - Bool flag set to true if we want to consider the effects
-   of particle aspect ratio on its terminal velocity (default: true)
-
-Returns the terminal velocity of a single mixed-phase particle using the Chen 2022
-parametrizations by computing an F_liq-weighted average of solid and liquid
-phase terminal velocities, using the maximum dimension of the whole particle for both.
-"""
-function p3_particle_terminal_velocity(
-    state::P3State,
-    D::FT,
-    Chen2022::CMP.Chen2022VelType,
-    ρₐ::FT,
-    use_aspect_ratio = true,
-) where {FT}
-    # TODO: Refactor to be a parameterization for use with `F_liq`
-    v_i =
-        ice_particle_terminal_velocity(state, D, Chen2022, ρₐ, use_aspect_ratio)
-    # v_r = CM2.rain_particle_terminal_velocity(D, Chen2022.rain, ρₐ)
-    return v_i
-    # return weighted_average(state.F_liq, v_r, v_i)
-end
-
-"""
-    velocity_difference(type, Dₗ, Dᵢ, p3, Chen2022, ρₐ, F_rim, F_liq, th, aspect_ratio)
-
- - type - a struct containing the size distribution parameters of the particle colliding with ice
- - Dₗ - maximum dimension of the particle colliding with ice
- - Dᵢ - maximum dimension of ice particle
- - p3 - a struct containing P3 parameters
- - Chen2022 - a struct containing Chen 2022 velocity parameters
- - ρ_a - density of air
- - F_rim - rime mass fraction (L_rim/L_ice) [-]
- - F_liq - liquid fraction (L_liq / L_p3_tot) [-]
- - th - P3 particle properties thresholds
- - use_aspect_ratio - Bool flag set to true if we want to consider the effects of
-   particle aspect ratio on its terminal velocity (default: true)
-
-Returns the absolute value of the velocity difference between a mixed-phase particle and
-cloud or rain drop as a function of their sizes. It uses Chen 2022 velocity
-parameterization for ice and rain and assumes no sedimentation of cloud droplets.
-"""
-function velocity_difference(
-    ::Union{
-        CMP.RainParticlePDF_SB2006{FT},
-        CMP.RainParticlePDF_SB2006_limited{FT},
-    },
-    Dₗ::FT,
-    Dᵢ::FT,
-    state::P3State,
-    Chen2022::CMP.Chen2022VelType,
-    ρₐ::FT,
-    use_aspect_ratio = true,
-) where {FT}
-    # velocity difference for rain-ice collisions
-    return abs(
-        p3_particle_terminal_velocity(
-            state,
-            Dᵢ,
-            Chen2022,
-            ρₐ,
-            use_aspect_ratio,
-        ) - CM2.rain_particle_terminal_velocity(Dₗ, Chen2022.rain, ρₐ),
-    )
-end
-function velocity_difference(
-    ::CMP.CloudParticlePDF_SB2006{FT},
-    Dₗ::FT,
-    Dᵢ::FT,
-    state::P3State,
-    Chen2022::CMP.Chen2022VelType,
-    ρₐ::FT,
-    use_aspect_ratio = true,
-) where {FT}
-    # velocity difference for cloud-ice collisions
-    return abs(
-        p3_particle_terminal_velocity(
-            state,
-            Dᵢ,
-            Chen2022,
-            ρₐ,
-            use_aspect_ratio,
-        ),
-    )
-end
-
-"""
-    ice_terminal_velocity(dist, Chen2022, ρₐ, use_aspect_ratio)
+    ice_terminal_velocity(dist, velocity_params, ρₐ; [use_aspect_ratio], [accurate])
 
 Compute the mass and number weighted fall speeds for ice
 
 See Eq. C10 of [MorrisonMilbrandt2015](@cite) and use the Chen 2022 terminal velocity scheme.
 
 # Arguments
-- `dist`: The [`P3Distribution`](@ref) object
-- `Chen2022`: The [`CMP.Chen2022VelType`](@ref) object
-- `ρₐ`: The density of air
+- `dist`: A [`P3Distribution`](@ref)
+- `velocity_params`: A [`CMP.Chen2022VelType`](@ref)
+- `ρₐ`: The density of air [kg/m³]
+
+# Keyword arguments
 - `use_aspect_ratio`: Bool flag set to true if we want to consider the effects
-   of particle aspect ratio on its terminal velocity (default: true)
+   of particle aspect ratio on its terminal velocity (default: `true`)
 - `accurate`: Set to `true` to perform a more accurate numerical integration
     see [`∫fdD`](@ref) for details. Default is `false`.
 
@@ -144,34 +56,22 @@ See Eq. C10 of [MorrisonMilbrandt2015](@cite) and use the Chen 2022 terminal vel
 - `v_m`: The mass weighted fall speed
 """
 function ice_terminal_velocity(
-    dist::P3Distribution{FT},
-    Chen2022::CMP.Chen2022VelType,
-    ρₐ::FT,
-    use_aspect_ratio = true;
-    accurate = false,
-) where {FT}
+    dist::P3Distribution, velocity_params::CMP.Chen2022VelType, ρₐ;
+    use_aspect_ratio = true, accurate = false,
+)
     (; state, L, N) = dist
-    if N < eps(FT) || L < eps(FT)
-        return FT(0), FT(0)
+    if N < eps(N) || L < eps(L)
+        return zero(N), zero(L)
     end
+
+    v_term = ice_particle_terminal_velocity(state, velocity_params, ρₐ; use_aspect_ratio)
 
     # ∫N(D) m(D) v(D) dD
-    v_m = ∫fdD(state; accurate) do D
-        N′ice(dist, D) *
-        ice_mass(state, D) *
-        p3_particle_terminal_velocity(state, D, Chen2022, ρₐ, use_aspect_ratio)
-    end
-
+    mass_weighted_integrand(D) = N′ice(dist, D) * v_term(D) * ice_mass(state, D)
     # ∫N(D) v(D) dD
-    v_n = ∫fdD(state; accurate) do D
-        N′ice(dist, D) * p3_particle_terminal_velocity(
-            state,
-            D,
-            Chen2022,
-            ρₐ,
-            use_aspect_ratio,
-        )
-    end
+    number_weighted_integrand(D) = N′ice(dist, D) * v_term(D)
 
+    v_m = ∫fdD(mass_weighted_integrand, state; accurate)
+    v_n = ∫fdD(number_weighted_integrand, state; accurate)
     return (v_n / N, v_m / L)
 end

--- a/test/ventilation_tests.jl
+++ b/test/ventilation_tests.jl
@@ -18,7 +18,7 @@ function test_ventilation_factor(FT)
         ρₐ = FT(1.2)     # Air density [kg/m³]
         state = P3.get_state(params; F_rim, ρ_r)
         vent = state.params.vent
-        v_term = D -> P3.ice_particle_terminal_velocity(state, D, vel, ρₐ)
+        v_term = P3.ice_particle_terminal_velocity(state, vel, ρₐ)
         vent_factor = CO.ventilation_factor(vent, aps, v_term)
         Ds = range(FT(0.5e-4), stop = FT(4.5e-4), length = 5)
         calc_vents = vent_factor.(Ds)


### PR DESCRIPTION
### TL;DR

Added a new function to calculate bulk collision rates between ice and liquid particles in the P3 microphysics scheme.

### What changed?

Implemented the `bulk_collision_rate_with_liquid` function in `P3_processes.jl` that:
- Calculates collision rates between ice distribution and liquid particles (rain or cloud)
- Computes changes in number concentration and mass for both ice and liquid phases
- Handles collision cross-section, terminal velocities, and particle size distributions
- Returns changes in ice number concentration, ice mass, rime mass, rime volume, and liquid properties

### How to test?

- Create instances of `P3Distribution` and liquid distribution (either `RainParticlePDF_SB2006` or `CloudParticlePDF_SB2006`)
- Call the function with appropriate parameters (ice distribution, velocity type, liquid distribution, air density, liquid mass, liquid number concentration)
- Verify the returned rates match expected physical behavior

### Why make this change?

This function is essential for modeling ice-liquid interactions in mixed-phase clouds. It enables the simulation of collision processes between ice particles and liquid droplets, which is a key mechanism for precipitation formation and cloud evolution in the P3 microphysics scheme.