### PR TITLE
Get rid of FT in noneq cloud formation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.22.10"
+version = "0.22.11"
 
 [deps]
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"

--- a/src/AerosolActivation.jl
+++ b/src/AerosolActivation.jl
@@ -210,7 +210,7 @@ function N_activated_per_mode(
         mode_i = ad.modes[i]
         u_i::FT = 2 * log(sm[i] / smax) / 3 / sqrt(2) / log(mode_i.stdev)
 
-        mode_i.N * (1 / 2) * (1 - SF.erf(u_i))
+        mode_i.N * FT(0.5) * (1 - SF.erf(u_i))
     end
 end
 

--- a/src/CloudDiagnostics.jl
+++ b/src/CloudDiagnostics.jl
@@ -143,7 +143,7 @@ function effective_radius_2M(
         Ac *
         C^(νc + 1) *
         (Bc * C^μc)^(-(5 + 3 * νc) / (3 * μc)) *
-        SF.gamma((5 + 3 * νc) / (3 * μc)) / μc / FT(10)^(χ * 2 / 3)
+        SF.gamma((5 + 3 * νc) / (3 * μc)) / μc / 10^(χ * FT(2) / 3)
     M2_r =
         Br == 0 ? FT(0) :
         Ar *

--- a/src/IceNucleation.jl
+++ b/src/IceNucleation.jl
@@ -220,7 +220,7 @@ function INP_concentration_mean(T::FT) where {FT}
 
     T_celsius = T - FT(273.15)
 
-    return log(-(T_celsius)^9 * 10^(-9))
+    return log(-(T_celsius)^9 * FT(10)^(-9))
 end
 
 end # end module
@@ -253,7 +253,7 @@ function homogeneous_J_cubic(ip::CMP.Koop2000, Δa_w::FT) where {FT}
 
     logJ::FT = ip.c₁ + ip.c₂ * Δa_w - ip.c₃ * Δa_w^2 + ip.c₄ * Δa_w^3
 
-    return FT(10)^(logJ) * 1e6
+    return 10^logJ * FT(1e6)
 end
 
 """
@@ -270,7 +270,7 @@ function homogeneous_J_linear(ip::CMP.Koop2000, Δa_w::FT) where {FT}
 
     logJ::FT = ip.linear_c₂ * Δa_w + ip.linear_c₁
 
-    return FT(10)^(logJ) * 1e6
+    return 10^logJ * FT(1e6)
 end
 
 end # end module

--- a/src/MicrophysicsNonEq.jl
+++ b/src/MicrophysicsNonEq.jl
@@ -76,12 +76,12 @@ The formulation is based on Morrison and Grabowski 2008 and
 Morrison and Milbrandt 2015
 """
 function conv_q_vap_to_q_liq_ice_MM2015(
-    (; τ_relax)::CMP.CloudLiquid{FT},
-    tps::TDP.ThermodynamicsParameters{FT},
-    q::TD.PhasePartition{FT},
-    ρ::FT,
-    T::FT,
-) where {FT}
+    (; τ_relax)::CMP.CloudLiquid,
+    tps::TDP.ThermodynamicsParameters,
+    q::TD.PhasePartition,
+    ρ,
+    T,
+)
     Rᵥ = TD.Parameters.R_v(tps)
     cₚ_air = TD.cp_m(tps, q)
     Lᵥ = TD.latent_heat_vapor(tps, T)
@@ -91,17 +91,17 @@ function conv_q_vap_to_q_liq_ice_MM2015(
     qᵥ_sat_liq = TD.q_vap_saturation_from_density(tps, T, ρ, pᵥ_sat_liq)
 
     dqsldT = qᵥ_sat_liq * (Lᵥ / (Rᵥ * T^2) - 1 / T)
-    Γₗ = FT(1) + (Lᵥ / cₚ_air) * dqsldT
+    Γₗ = 1 + (Lᵥ / cₚ_air) * dqsldT
 
     return (qᵥ - qᵥ_sat_liq) / (τ_relax * Γₗ)
 end
 function conv_q_vap_to_q_liq_ice_MM2015(
-    (; τ_relax)::CMP.CloudIce{FT},
-    tps::TDP.ThermodynamicsParameters{FT},
-    q::TD.PhasePartition{FT},
-    ρ::FT,
-    T::FT,
-) where {FT}
+    (; τ_relax)::CMP.CloudIce,
+    tps::TDP.ThermodynamicsParameters,
+    q::TD.PhasePartition,
+    ρ,
+    T,
+)
     Rᵥ = TD.Parameters.R_v(tps)
     cₚ_air = TD.cp_m(tps, q)
     Lₛ = TD.latent_heat_sublim(tps, T)
@@ -111,7 +111,7 @@ function conv_q_vap_to_q_liq_ice_MM2015(
     qᵥ_sat_ice = TD.q_vap_saturation_from_density(tps, T, ρ, pᵥ_sat_ice)
 
     dqsidT = qᵥ_sat_ice * (Lₛ / (Rᵥ * T^2) - 1 / T)
-    Γᵢ = FT(1) + (Lₛ / cₚ_air) * dqsidT
+    Γᵢ = 1 + (Lₛ / cₚ_air) * dqsidT
 
     return (qᵥ - qᵥ_sat_ice) / (τ_relax * Γᵢ)
 end

--- a/src/Nucleation.jl
+++ b/src/Nucleation.jl
@@ -55,12 +55,13 @@ function h2so4_nucleation_rate(
     temp,
     params,
 )
+    FT = eltype(params)
     # Change units from 1/m³ to 1/cm³
-    h2so4_conc *= 1e-6
-    nh3_conc *= 1e-6
+    h2so4_conc *= FT(1e-6)
+    nh3_conc *= FT(1e-6)
 
     # Reference concentration for h2so4 and nh3 (Units: 1e6/cm³)
-    ref_conc = 1e6
+    ref_conc = FT(1e6)
 
     # Calculate factors
     k(T, u, v, w) = exp(u - exp(v * (T / 1000 - w)))
@@ -83,8 +84,8 @@ function h2so4_nucleation_rate(
         k_t_i * f_i * (h2so4_conc / ref_conc)^params.p_t_i * negative_ion_conc
     # Convert to 1/m³/s
     return (;
-        binary_rate = binary_rate * 1e6,
-        ternary_rate = ternary_rate * 1e6,
+        binary_rate = binary_rate * FT(1e6),
+        ternary_rate = ternary_rate * FT(1e6),
     )
 end
 
@@ -111,11 +112,12 @@ function organic_nucleation_rate(
     condensation_sink,
     params,
 )
+    FT = eltype(params)
     # Convert units from 1/m³ to 1/cm³ - assume units are meant to be in 1/cm³
-    negative_ion_conc *= 1e-6
-    monoterpene_conc *= 1e-6
-    O3_conc *= 1e-6
-    OH_conc *= 1e-6
+    negative_ion_conc *= FT(1e-6)
+    monoterpene_conc *= FT(1e-6)
+    O3_conc *= FT(1e-6)
+    OH_conc *= FT(1e-6)
 
     # Y_* params from Dunne et al. 2016
     k_MTO3 = params.k_MTO3 * exp(params.exp_MTO3 / temp)
@@ -137,8 +139,9 @@ function organic_nucleation_rate_hom_prescribed(
     HOM_conc,
     params,
 )
+    FT = eltype(params)
     # HOM reference concentration: 1e7/cm³
-    ref_conc = 1e7
+    ref_conc = FT(1e7)
     rate =
         params.a_1 *
         (
@@ -150,7 +153,7 @@ function organic_nucleation_rate_hom_prescribed(
         )^(params.a_4 + params.a_5 / (HOM_conc / ref_conc)) *
         negative_ion_conc
     # Convert from (1/cm³/s) to (1/m³/s)
-    return rate * 1e6
+    return rate * FT(1e6)
 end
 
 """
@@ -174,10 +177,11 @@ function organic_and_h2so4_nucleation_rate(
     condensation_sink,
     params,
 )
+    FT = eltype(params)
     k_MTOH = params.k_MTOH * exp(params.exp_MTOH / temp) # Units: 1/cm³/s
     bioOxOrg = k_MTOH * monoterpene_conc * OH_conc / condensation_sink
     # Convert from 1/cm³ to 1/m³
-    bioOxOrg *= 1e6
+    bioOxOrg *= FT(1e6)
     return organic_and_h2so4_nucleation_rate_bioOxOrg_prescribed(
         h2so4_conc,
         bioOxOrg,
@@ -190,14 +194,15 @@ function organic_and_h2so4_nucleation_rate_bioOxOrg_prescribed(
     bioOxOrg,
     params,
 )
+    FT = eltype(params)
     # Convert bioOxOrg and k_H2SO4org from 1/m³ to 1/cm³
-    k_H2SO4org = 1e-6 * params.k_H2SO4org
-    bioOxOrg *= 1e-6
+    k_H2SO4org = FT(1e-6) * params.k_H2SO4org
+    bioOxOrg *= FT(1e-6)
     # Convert from 1/m³ to 10⁶/cm³
     # h2so4_conc *= 1e-6
-    rate = 0.5 * k_H2SO4org * h2so4_conc^2 * bioOxOrg
+    rate = FT(0.5) * k_H2SO4org * h2so4_conc^2 * bioOxOrg
     # Convert from 1/cm³/s to 1/m³/s
-    return rate * 1e6
+    return rate * FT(1e6)
 end
 
 end


### PR DESCRIPTION
Hi @dennisYatunin . Here is a PR that fixes things for the two functions you see in the Jacobian.

I tried adding a test that checks the output type for all the functions in performance tests that I have. However I do have more complicated outputs than just FT:

```
 Expression: typeof(foo(args...)) == FT
   Evaluated: @NamedTuple{au::CloudMicrophysics.Microphysics2M.LiqRaiRates{Float64}, sc::Float64} == Float64

```
Do you see an easy way to include that sort of output? If not, thats fine, I'll undo  the performance tests change and just add the one for cloud formation.