### PR TITLE
Compute inverse lambda, safer cloud sources in non-eq.

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -26,7 +26,7 @@ Microphysics0M.remove_precipitation
 Microphysics1M
 Microphysics1M.get_v0
 Microphysics1M.get_n0
-Microphysics1M.lambda
+Microphysics1M.lambda_inverse
 Microphysics1M.terminal_velocity
 Microphysics1M.conv_q_liq_to_q_rai
 Microphysics1M.conv_q_ice_to_q_sno_no_supersat

--- a/docs/src/plots/MarshallPalmer_distribution.jl
+++ b/docs/src/plots/MarshallPalmer_distribution.jl
@@ -21,9 +21,9 @@ function Marshall_Palmer_distribution(
 ) where {FT}
 
     n₀::FT = CM1.get_n0(pdf)
-    λ = CM1.lambda(pdf, mass, q, ρ)
+    λ_inv = CM1.lambda_inverse(pdf, mass, q, ρ)
     # distribution
-    n_r = n₀ * exp(-λ * r)
+    n_r = n₀ * exp(-r / λ_inv)
 
     return n_r
 end

--- a/src/CloudDiagnostics.jl
+++ b/src/CloudDiagnostics.jl
@@ -32,9 +32,9 @@ function radar_reflectivity_1M(
 
     # change units for accuracy
     n0 = CM1.get_n0(pdf) * FT(1e-12)
-    λ = CM1.lambda(pdf, mass, q, ρ) * FT(1e-3)
+    λ_inv = CM1.lambda_inverse(pdf, mass, q, ρ) / FT(1e-3)
 
-    Z = (λ == FT(0)) ? FT(0) : (720 * n0 / λ^7)
+    Z = 720 * n0 * λ_inv^7
     log_10_Z₀ = FT(-18)
     log_Z = FT(10) * (log10(Z) - log_10_Z₀ - FT(9))
 

--- a/src/Common.jl
+++ b/src/Common.jl
@@ -314,20 +314,20 @@ function Chen2022_monodisperse_pdf(a, b, c, D)
 end
 
 """
-    Chen2022_exponential_pdf(a, b, c, λ, k)
+    Chen2022_exponential_pdf(a, b, c, λ_inv, k)
 
  - a, b, c, - free parameters defined in Chen etl al 2022
- - λ - size distribution parameter
+ - λ_inv - inverse of the size distribution parameter
  - k - size distribution moment for which we compute the bulk fall speed
 
 Returns the addends of the bulk fall speed of rain or ice particles
 following Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171 in [m/s].
 Assuming exponential size distribution and hence μ=0.
 """
-function Chen2022_exponential_pdf(a::FT, b::FT, c::FT, λ::FT, k::Int) where {FT}
+function Chen2022_exponential_pdf(a::FT, b::FT, c::FT, λ_inv::FT, k::Int) where {FT}
     μ = 0 # Exponential instead of gamma distribution
     δ = FT(μ + k + 1)
-    return a * exp(δ * log(λ) - (b + δ) * log(λ + c)) * SF.gamma(b + δ) / SF.gamma(δ)
+    return a * exp(δ * log(1 / λ_inv) - (b + δ) * log(1 / λ_inv + c)) * SF.gamma(b + δ) / SF.gamma(δ)
 end
 
 """

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -579,8 +579,8 @@ function rain_terminal_velocity(
     λ = pdf_rain_parameters(pdf_r, q_rai, ρ, N_rai).λr
 
     # eq 20 from Chen et al 2022
-    vt0 = sum(CO.Chen2022_exponential_pdf.(aiu, bi, ciu, λ, 0))
-    vt3 = sum(CO.Chen2022_exponential_pdf.(aiu, bi, ciu, λ, 3))
+    vt0 = sum(CO.Chen2022_exponential_pdf.(aiu, bi, ciu, 1 / λ, 0))
+    vt3 = sum(CO.Chen2022_exponential_pdf.(aiu, bi, ciu, 1 / λ, 3))
 
     vt0 = N_rai < eps(FT) ? FT(0) : max(FT(0), vt0)
     vt3 = q_rai < eps(FT) ? FT(0) : max(FT(0), vt3)

--- a/src/MicrophysicsNonEq.jl
+++ b/src/MicrophysicsNonEq.jl
@@ -82,18 +82,23 @@ function conv_q_vap_to_q_liq_ice_MM2015(
     ρ,
     T,
 )
-    Rᵥ = TD.Parameters.R_v(tps)
-    cₚ_air = TD.cp_m(tps, q)
-    Lᵥ = TD.latent_heat_vapor(tps, T)
-    qᵥ = TD.vapor_specific_humidity(q)
+    FT = eltype(tps)
+    if TD.vapor_specific_humidity(q) + TD.liquid_specific_humidity(q) > FT(0)
+        Rᵥ = TD.Parameters.R_v(tps)
+        cₚ_air = TD.cp_m(tps, q)
+        Lᵥ = TD.latent_heat_vapor(tps, T)
+        qᵥ = TD.vapor_specific_humidity(q)
 
-    pᵥ_sat_liq = TD.saturation_vapor_pressure(tps, T, TD.Liquid())
-    qᵥ_sat_liq = TD.q_vap_saturation_from_density(tps, T, ρ, pᵥ_sat_liq)
+        pᵥ_sat_liq = TD.saturation_vapor_pressure(tps, T, TD.Liquid())
+        qᵥ_sat_liq = TD.q_vap_saturation_from_density(tps, T, ρ, pᵥ_sat_liq)
 
-    dqsldT = qᵥ_sat_liq * (Lᵥ / (Rᵥ * T^2) - 1 / T)
-    Γₗ = 1 + (Lᵥ / cₚ_air) * dqsldT
+        dqsldT = qᵥ_sat_liq * (Lᵥ / (Rᵥ * T^2) - 1 / T)
+        Γₗ = 1 + (Lᵥ / cₚ_air) * dqsldT
 
-    return (qᵥ - qᵥ_sat_liq) / (τ_relax * Γₗ)
+        return (qᵥ - qᵥ_sat_liq) / (τ_relax * Γₗ)
+    else
+        return FT(0)
+    end
 end
 function conv_q_vap_to_q_liq_ice_MM2015(
     (; τ_relax)::CMP.CloudIce,
@@ -102,18 +107,23 @@ function conv_q_vap_to_q_liq_ice_MM2015(
     ρ,
     T,
 )
-    Rᵥ = TD.Parameters.R_v(tps)
-    cₚ_air = TD.cp_m(tps, q)
-    Lₛ = TD.latent_heat_sublim(tps, T)
-    qᵥ = TD.vapor_specific_humidity(q)
+    FT = eltype(tps)
+    if TD.vapor_specific_humidity(q) + TD.ice_specific_humidity(q) > FT(0)
+        Rᵥ = TD.Parameters.R_v(tps)
+        cₚ_air = TD.cp_m(tps, q)
+        Lₛ = TD.latent_heat_sublim(tps, T)
+        qᵥ = TD.vapor_specific_humidity(q)
 
-    pᵥ_sat_ice = TD.saturation_vapor_pressure(tps, T, TD.Ice())
-    qᵥ_sat_ice = TD.q_vap_saturation_from_density(tps, T, ρ, pᵥ_sat_ice)
+        pᵥ_sat_ice = TD.saturation_vapor_pressure(tps, T, TD.Ice())
+        qᵥ_sat_ice = TD.q_vap_saturation_from_density(tps, T, ρ, pᵥ_sat_ice)
 
-    dqsidT = qᵥ_sat_ice * (Lₛ / (Rᵥ * T^2) - 1 / T)
-    Γᵢ = 1 + (Lₛ / cₚ_air) * dqsidT
+        dqsidT = qᵥ_sat_ice * (Lₛ / (Rᵥ * T^2) - 1 / T)
+        Γᵢ = 1 + (Lₛ / cₚ_air) * dqsidT
 
-    return (qᵥ - qᵥ_sat_ice) / (τ_relax * Γᵢ)
+        return (qᵥ - qᵥ_sat_ice) / (τ_relax * Γᵢ)
+    else
+        return FT(0)
+    end
 end
 
 """

--- a/src/parameters/Microphysics1M.jl
+++ b/src/parameters/Microphysics1M.jl
@@ -24,7 +24,7 @@ A struct with snow size distribution parameters
 $(DocStringExtensions.FIELDS)
 """
 struct ParticlePDFIceRain{FT} <: ParametersType{FT}
-    "snow size distribution coefficient [1/m4]"
+    "Size distribution coefficient [1/m4]"
     n0::FT
 end
 


### PR DESCRIPTION
The (so far) learned lessons from debugging AMIP model configuration:
- Due to numerics it's easier to store inverse of lambda (size distribution parameter). Also, because of numerics I clip it at 1e-8. None of the tests in `CloudMicrophysics.jl` were affected by that change, so I'm planning to merge it as is. But I also intend to check if the clipping value affects the simulations in `Atmos`
- Only do cloud formation sources and sinks if there is water vapor or cloud present. This avoids some issues with cold temperatures high above, where we have no moisture anyway.
