### PR TITLE
functionalizing particle operations

### DIFF
--- a/src/Common.jl
+++ b/src/Common.jl
@@ -210,16 +210,15 @@ end
 """
     Chen2022_vel_coeffs_B1(coeffs, ρₐ)
 
- - coeffs - a struct with terminal velocity free parameters
- - ρₐ - air density
-
 Returns the coefficients from Table B1 Appendix B in Chen et al 2022
+
+# Arguments
+ - `coeffs`: a struct with terminal velocity free parameters
+ - `ρₐ`: air density [kg/m³]
+
 DOI: 10.1016/j.atmosres.2022.106171
 """
-function Chen2022_vel_coeffs_B1(
-    coeffs::CMP.Chen2022VelTypeRain,
-    ρₐ::FT,
-) where {FT}
+function Chen2022_vel_coeffs_B1(coeffs::CMP.Chen2022VelTypeRain, ρₐ)
     (; ρ0, a, a3_pow, b, b_ρ, c) = coeffs
     # Table B1
     q = exp(ρ0 * ρₐ)
@@ -235,11 +234,13 @@ end
 """
     Chen2022_vel_coeffs_B2(coeffs, ρₐ, ρᵢ)
 
- - coeffs - a struct with terminal velocity free parameters
- - ρₐ - air density
- - ρᵢ - apparent density of ice particles
-
 Returns the coefficients from Table B2 Appendix B in Chen et al 2022
+
+# Arguments
+ - `coeffs`: a struct with terminal velocity free parameters
+ - `ρₐ`: air density [kg/m³]
+ - `ρᵢ`: apparent density of ice particles [kg/m³]
+
 DOI: 10.1016/j.atmosres.2022.106171
 """
 function Chen2022_vel_coeffs_B2(
@@ -249,12 +250,13 @@ function Chen2022_vel_coeffs_B2(
 ) where {FT}
     (; A, B, C, E, F, G) = coeffs
     # Table B3
-    As = A[2] * (log(ρᵢ))^2 − A[3] * log(ρᵢ) + A[1]
-    Bs = FT(1) / (B[1] + B[2] * log(ρᵢ) + B[3] / sqrt(ρᵢ))
+    log_ρᵢ = log(ρᵢ)
+    As = A[2] * log_ρᵢ^2 − A[3] * log_ρᵢ + A[1]
+    Bs = FT(1) / (B[1] + B[2] * log_ρᵢ + B[3] / sqrt(ρᵢ))
     Cs = C[1] + C[2] * exp(C[3] * ρᵢ) + C[4] * sqrt(ρᵢ)
-    Es = E[1] - E[2] * (log(ρᵢ))^2 + E[3] * sqrt(ρᵢ)
-    Fs = -exp(F[1] - F[2] * (log(ρᵢ))^2 + F[3] * log(ρᵢ))
-    Gs = FT(1) / (G[1] + G[2] / (log(ρᵢ)) - G[3] * log(ρᵢ) / ρᵢ)
+    Es = E[1] - E[2] * log_ρᵢ^2 + E[3] * sqrt(ρᵢ)
+    Fs = -exp(F[1] - F[2] * log_ρᵢ^2 + F[3] * log_ρᵢ)
+    Gs = FT(1) / (G[1] + G[2] / log_ρᵢ - G[3] * log_ρᵢ / ρᵢ)
     # Table B2
     ai = (Es * ρₐ^As, Fs * ρₐ^As)
     bi = (Bs + ρₐ * Cs, Bs + ρₐ * Cs)
@@ -268,11 +270,13 @@ end
 """
     Chen2022_vel_coeffs_B4(coeffs, ρₐ, ρᵢ)
 
- - coeffs - a struct with terminal velocity free parameters
- - ρₐ - air density
- - ρᵢ - apparent density of ice particles
-
 Returns the coefficients from Table B4 Appendix B in Chen et al 2022
+
+# Arguments
+ - `coeffs`: a struct with terminal velocity free parameters
+ - `ρₐ`: air density [kg/m³]
+ - `ρᵢ`: apparent density of ice particles [kg/m³]
+
 DOI: 10.1016/j.atmosres.2022.106171
 """
 function Chen2022_vel_coeffs_B4(
@@ -282,13 +286,14 @@ function Chen2022_vel_coeffs_B4(
 ) where {FT}
     (; A, B, C, E, F, G, H) = coeffs
     # Table B5
-    Al = A[1] + A[2] * log(ρᵢ) + A[3] * (ρᵢ)^FT(-3 / 2)
-    Bl = exp(B[1] + B[2] * log(ρᵢ)^2 + B[3] * log(ρᵢ))
-    Cl = exp(C[1] + C[2] / log(ρᵢ) + C[3] / ρᵢ)
-    El = E[1] + E[2] * log(ρᵢ) * sqrt(ρᵢ) + E[3] * sqrt(ρᵢ)
-    Fl = F[1] + F[2] * log(ρᵢ) - exp(log(-F[3]) - ρᵢ)
-    Gl = (G[1] + G[2] * log(ρᵢ) * sqrt(ρᵢ) + G[3] / sqrt(ρᵢ))^(-1)
-    Hl = H[1] + H[2] * (ρᵢ)^FT(5 / 2) + exp(log(-H[3]) - ρᵢ)
+    log_ρᵢ = log(ρᵢ)
+    Al = A[1] + A[2] * log_ρᵢ + A[3] * ρᵢ^FT(-3 / 2)
+    Bl = exp(B[1] + B[2] * log_ρᵢ^2 + B[3] * log_ρᵢ)
+    Cl = exp(C[1] + C[2] / log_ρᵢ + C[3] / ρᵢ)
+    El = E[1] + E[2] * log_ρᵢ * sqrt(ρᵢ) + E[3] * sqrt(ρᵢ)
+    Fl = F[1] + F[2] * log_ρᵢ - exp(log(-F[3]) - ρᵢ)
+    Gl = (G[1] + G[2] * log_ρᵢ * sqrt(ρᵢ) + G[3] / sqrt(ρᵢ))^(-1)
+    Hl = H[1] + H[2] * ρᵢ^FT(5 / 2) + exp(log(-H[3]) - ρᵢ)
     # Table B4
     ai = (Bl * ρₐ^Al, El * ρₐ^Al * exp(Hl * ρₐ))
     bi = (Cl, Fl)
@@ -328,6 +333,39 @@ function Chen2022_exponential_pdf(a::FT, b::FT, c::FT, λ_inv::FT, k::Int) where
     μ = 0 # Exponential instead of gamma distribution
     δ = FT(μ + k + 1)
     return a * exp(δ * log(1 / λ_inv) - (b + δ) * log(1 / λ_inv + c)) * SF.gamma(b + δ) / SF.gamma(δ)
+end
+
+"""
+    liquid_particle_terminal_velocity(velocity, ρₐ)
+    liquid_particle_terminal_velocity(velocity, ρₐ, D)
+
+Compute the terminal velocity of a liquid particle as a function of its size 
+    (maximum dimension, `D`) using the Chen 2022 parametrization.
+
+# Arguments
+- `velocity`: a struct with terminal velocity parameters from Chen 2022
+- `ρₐ`: air density [kg/m³]
+- `D`: maximum particle dimension [m]
+
+# Returns
+- The first method returns a function of `D`, while the second evaluates at a specific `D`.
+
+Needed for numerical integrals in the P3 scheme.
+
+!!! note
+    We use the same terminal velocity parametrization for cloud and rain water.
+"""
+function liquid_particle_terminal_velocity(velocity::CMP.Chen2022VelTypeRain, ρₐ)
+    (ai, bi, ci) = Chen2022_vel_coeffs_B1(velocity, ρₐ)
+    v_term(D) = sum(@. sum(ai * D^bi * exp(-ci * D)))
+    return v_term
+end
+liquid_particle_terminal_velocity(velocity::CMP.Chen2022VelType, ρₐ) = 
+    liquid_particle_terminal_velocity(velocity.rain, ρₐ)
+
+function liquid_particle_terminal_velocity(velocity, ρₐ, D)
+    v_term = liquid_particle_terminal_velocity(velocity, ρₐ)
+    return v_term(D)
 end
 
 """

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -65,10 +65,7 @@ end
     assumed cloud droplet mass distribution.
 """
 function pdf_cloud_parameters(
-    pdf_c::CMP.CloudParticlePDF_SB2006{FT},
-    qₗ::FT,
-    ρₐ::FT,
-    Nₗ::FT,
+    pdf_c::CMP.CloudParticlePDF_SB2006{FT}, qₗ, ρₐ, Nₗ,
 ) where {FT}
 
     (; νc, μc, ρw) = pdf_c
@@ -103,10 +100,10 @@ end
 """
     pdf_rain_parameters(pdf_r, qᵣ, ρₐ, Nᵣ)
 
- - `pdf_r` - a struct with SB2006 raindrops size distribution parameters
- - `qᵣ` - rain water specific content
- - `ρₐ` - air density
- - `Nᵣ` rain drop number concentration
+ - `pdf_r`: a struct with SB2006 raindrops size distribution parameters
+ - `qᵣ`: rain water specific content [kg/kg]
+ - `ρₐ`: air density [kg/m³]
+ - `Nᵣ`: rain drop number concentration [1/m³]
 
     Returns the parameters of the rain drop diameter distribution λr [1/m], N₀r [1/m4],
     optionally limited within prescribed ranges.
@@ -114,10 +111,7 @@ end
     and the two rain drop mass distribution parameters Ar [1/m3 * (1/kg)^(νr+1)], Br [(1/kg)^μr].
 """
 function pdf_rain_parameters(
-    pdf_r::CMP.RainParticlePDF_SB2006{FT},
-    qᵣ::FT,
-    ρₐ::FT,
-    Nᵣ::FT,
+    pdf_r::CMP.RainParticlePDF_SB2006{FT}, qᵣ, ρₐ, Nᵣ
 ) where {FT}
     (; νr, μr, ρw) = pdf_r
 
@@ -135,10 +129,7 @@ function pdf_rain_parameters(
     end
 end
 function pdf_rain_parameters(
-    pdf_r::CMP.RainParticlePDF_SB2006_limited{FT},
-    qᵣ::FT,
-    ρₐ::FT,
-    Nᵣ::FT,
+    pdf_r::CMP.RainParticlePDF_SB2006_limited{FT}, qᵣ, ρₐ, Nᵣ
 ) where {FT}
     (; νr, μr, xr_min, xr_max, N0_min, N0_max, λ_min, λ_max, ρw) = pdf_r
 
@@ -159,36 +150,35 @@ function pdf_rain_parameters(
 end
 
 """
-    size_distribution(pdf, D, q, ρ, N)
+    size_distribution(pdf, q, ρₐ, N)
+    size_distribution(pdf, q, ρₐ, N, D)
 
- - pdf - struct containing size distribution parameters of cloud or rain
- - D - particle size (i.e. maximum dimension of particle)
- - q - cloud or rain water specific content
- - ρₐ - density of air
- - N - cloud or rain water number concentration
+Calculate the size distribution value for rain or cloud particles for a given particle size.
 
-    Returns the size distribution value for rain or cloud particles for a given
-    particle size
+# Arguments
+- `pdf`: Struct containing size distribution parameters of cloud or rain
+- `q`: Cloud or rain water specific content [kg/kg]
+- `ρₐ`: Density of air [kg/m³]
+- `N`: Cloud or rain water number concentration [1/m³]
+- `D`: Particle size (i.e. maximum dimension of particle) [m]
+
+# Returns
+- The first method returns a function that computes the size distribution value
+    for rain or cloud particles for a given particle size. 
+- The second method returns the size distribution value for rain or cloud particles 
+    for a given particle size.
 """
-function size_distribution(
-    pdf::Union{
-        CMP.RainParticlePDF_SB2006{FT},
-        CMP.RainParticlePDF_SB2006_limited{FT},
-    },
-    D::FT,
-    q::FT,
-    ρₐ::FT,
-    N::FT,
-) where {FT}
-    (; N₀r, λr) = pdf_rain_parameters(pdf, q, ρₐ, N)
-    return N₀r * exp(-λr * D)
+function size_distribution(pdf::CMP.RainParticlePDF_SB2006_MaybeLimited, q, ρₐ, N, D)
+    rain_psd = size_distribution(pdf, q, ρₐ, N)
+    return rain_psd(D)
 end
+function size_distribution(pdf::CMP.RainParticlePDF_SB2006_MaybeLimited, q, ρₐ, N)
+    (; N₀r, λr) = pdf_rain_parameters(pdf, q, ρₐ, N)
+    return rain_psd(D) = N₀r * exp(-λr * D)
+end  
 function size_distribution(
     pdf::CMP.CloudParticlePDF_SB2006{FT},
-    D::FT,
-    q::FT,
-    ρₐ::FT,
-    N::FT,
+    q, ρₐ, N,
 ) where {FT}
     (; Cc, Ec, ϕc, ψc) = pdf_cloud_parameters(pdf, q, ρₐ, N)
     # Convert values from mm to m assuming
@@ -197,7 +187,11 @@ function size_distribution(
     # works for Float64 right now. The solution is to non-dimensionalize
     # all distributions by a reference mass/size, similar to the 1M scheme.
     Cc *= Float64(10^((ϕc + 4) * 3))
-    return Cc * D^ϕc * exp(-Ec * D^ψc)
+    return cloud_psd(D) = Cc * D^ϕc * exp(-Ec * D^ψc)
+end
+function size_distribution(pdf::CMP.CloudParticlePDF_SB2006, q, ρₐ, N, D)
+    cloud_psd = size_distribution(pdf, q, ρₐ, N)
+    return cloud_psd(D)
 end
 
 """
@@ -509,35 +503,13 @@ function rain_self_collection_and_breakup(
 end
 
 """
-    rain_particle_terminal_velocity(D, Chen2022, ρₐ)
-
- - D - maximum particle dimension
- - Chen2022 - a struct with terminal velocity parameters from Chen 2022
- - ρₐ - air density
-
-Returns the terminal velocity of an individual rain drop as a function
-of its size (maximum dimension) following Chen 2022 velocity parametrization.
-Needed for numerical integrals in the P3 scheme.
-"""
-function rain_particle_terminal_velocity(
-    D::FT,
-    Chen2022::CMP.Chen2022VelTypeRain,
-    ρₐ::FT,
-) where {FT}
-    (ai, bi, ci) = CO.Chen2022_vel_coeffs_B1(Chen2022, ρₐ)
-
-    v = sum(@. sum(ai * D^bi * exp(-ci * D)))
-    return v
-end
-
-"""
     rain_terminal_velocity(SB2006, vel, q_rai, ρ, N_rai)
 
  - `SB2006` - a struct with SB2006 rain size distribution parameters
  - `vel` - a struct with terminal velocity parameters
  - `q_rai` - rain water specific content [kg/kg]
- - `ρ` - air density [kg/m^3]
- - `N_rai` - raindrops number density [1/m^3]
+ - `ρ` - air density [kg/m³]
+ - `N_rai` - raindrops number density [1/m³]
 
 Returns a tuple containing the number and mass weigthed mean fall velocities of raindrops in [m/s].
 Assuming an exponential size distribution from Seifert and Beheng 2006 for `scheme == SB2006Type`

--- a/src/P3_particle_properties.jl
+++ b/src/P3_particle_properties.jl
@@ -479,6 +479,34 @@ function ϕᵢ(state::P3State, D)
     return ifelse(D == 0, 0, ϕ_ob)
 end
 
+"""
+    ventilation_factor(state, vel, ρₐ, aps)
+
+Returns a function that computes the ventilation factor for an ice particle 
+    as a function of the maximum particle dimension, `D`.
+
+# Arguments
+- `state`: The [`P3State`](@ref)
+- `vel`: The [`Chen2022VelType`](@ref)
+- `ρₐ`: Air density [kg/m³]
+- `aps`: [`CMP.AirProperties`](@ref)
+
+# Returns
+- `vent_factor(D)`: The ventilation factor as a function of `D`
+"""
+function ventilation_factor(state, vel, ρₐ, aps)
+    (; ν_air, D_vapor) = aps
+    (; vent_a, vent_b) = state.params.vent
+    N_sc = ν_air / D_vapor
+    v_term = ice_particle_terminal_velocity(state, vel, ρₐ)
+
+    # Reynolds number
+    N_Re(D) = D * v_term(D) / ν_air
+    # Ventilation factor
+    vent_factor(D) = vent_a + vent_b * cbrt(N_sc) * sqrt(N_Re(D))
+    return vent_factor
+end
+
 ### ----------------- ###
 ### ----- UTILS ----- ###
 ### ----------------- ###

--- a/src/P3_processes.jl
+++ b/src/P3_processes.jl
@@ -76,23 +76,16 @@ function ice_melt(
     # Note: process not dependent on `F_liq`
     # (we want ice core shape params)
     # Get constants
-    (; ν_air, D_vapor, K_therm) = aps
+    (; K_therm) = aps
     L_f = TD.latent_heat_fusion(tps, Tₐ)
-    N_sc = ν_air / D_vapor
 
-    state = get_state(dist)
-    params = get_parameters(dist)
+    (; L, N, state) = dist
+    (; T_freeze) = state.params
 
-    # Ice particle terminal velocity
-    v(D) = ice_particle_terminal_velocity(state, D, Chen2022, ρₐ)
-    # Reynolds number
-    N_Re(D) = D * v(D) / ν_air
-    # Ventillation factor
-    (; vent_a, vent_b) = params.vent
-    F_v(D) = vent_a + vent_b * N_sc^FT(1 / 3) * N_Re(D)^FT(1 / 2)
+    F_v = ventilation_factor(state, Chen2022, ρₐ, aps)
 
     # Integrate
-    fac = 4 * K_therm / L_f * (Tₐ - params.T_freeze)
+    fac = 4 * K_therm / L_f * (Tₐ - T_freeze)
     dLdt = fac * ∫fdD(state; ∫kwargs...) do D
         ∂ice_mass_∂D(state, D) * F_v(D) * N′ice(dist, D) / D
     end
@@ -100,7 +93,6 @@ function ice_melt(
     # only consider melting (not fusion)
     dLdt = max(0, dLdt)
     # compute change of N_ice proportional to change in L
-    (; N, L) = dist
     dNdt = N / L * dLdt
 
     # ... and don't exceed the available number and mass of water droplets

--- a/src/P3_terminal_velocity.jl
+++ b/src/P3_terminal_velocity.jl
@@ -1,141 +1,57 @@
+
 """
-    ice_particle_terminal_velocity(state, D, Chen2022, ρₐ, use_aspect_ratio)
-Returns the terminal velocity of a single ice particle as a function
-    of its size (maximum dimension, D) using the Chen 2022 parametrization.
+    ice_particle_terminal_velocity(state, velocity, ρₐ; use_aspect_ratio)
+    ice_particle_terminal_velocity(state, velocity, ρₐ, D; use_aspect_ratio)
+
+Returns the terminal velocity of a single ice particle as a function of its size 
+    (maximum dimension, `D`) using the Chen 2022 parametrization.
+
+The first method returns a function of `D`, while the second evaluates at a specific `D`.
 
 # Arguments
- - `state`: The [`P3State`](@ref) object
- - `D`: Maximum particle dimension
- - `Chen2022`: The [`CMP.Chen2022VelType`](@ref) object with terminal velocity parameters
- - `ρₐ`: Air density
+ - `state`: A [`P3State`](@ref)
+ - `velocity`: A [`CMP.Chen2022VelType`](@ref) with terminal velocity parameters
+ - `ρₐ`: Air density [kg/m³]
+ - `D`: Maximum particle dimension [m]
+
+# Keyword arguments
  - `use_aspect_ratio`: Bool flag set to `true` if we want to consider the effects
     of particle aspect ratio on its terminal velocity (default: `true`)
 """
 function ice_particle_terminal_velocity(
-    state::P3State,
-    D::FT,
-    Chen2022::CMP.Chen2022VelType,
-    ρₐ::FT,
-    use_aspect_ratio = true,
-) where {FT}
-    # TODO - tmp
-    #ρᵢ = p3_density(p3, D, F_rim, th)
-    ρᵢ = FT(916.7)
-    if D <= Chen2022.small_ice.cutoff
-        (ai, bi, ci) = CO.Chen2022_vel_coeffs_B2(Chen2022.small_ice, ρₐ, ρᵢ)
-    else
-        (ai, bi, ci) = CO.Chen2022_vel_coeffs_B4(Chen2022.large_ice, ρₐ, ρᵢ)
+    state::P3State, velocity::CMP.Chen2022VelType, ρₐ; use_aspect_ratio = true,
+)
+    (; small_ice, large_ice) = velocity
+    
+    function v_term(D::FT) where {FT}
+        ρᵢ = FT(916.7) # ρᵢ = p3_density(p3, D, F_rim, th) # TODO: tmp
+        ϕ_factor = use_aspect_ratio ? cbrt(ϕᵢ(state, D)) : FT(1)
+        ice = D <= small_ice.cutoff ? small_ice : large_ice
+        (ai, bi, ci) = CO.Chen2022_vel_coeffs_B2(ice, ρₐ, ρᵢ)
+        ϕ_factor * sum(@. sum(ai * D^bi * exp(-ci * D)))
     end
-    v = sum(@. sum(ai * D^bi * exp(-ci * D)))
-
-    return ifelse(use_aspect_ratio, ϕᵢ(state, D)^FT(1 / 3) * v, v)
+    return v_term
+end
+function ice_particle_terminal_velocity(state, velocity, ρₐ, D; use_aspect_ratio = true)
+    v_term = ice_particle_terminal_velocity(state, velocity, ρₐ; use_aspect_ratio)
+    return v_term(D)
 end
 
 """
-   p3_particle_terminal_velocity(p3, D, Chen2022, ρₐ, use_aspect_ratio)
-
- - p3 - p3 parameters
- - D - maximum particle dimension
- - Chen2022 - struct with terminal velocity parameters from Chen 2022
- - ρₐ - air density
- - use_aspect_ratio - Bool flag set to true if we want to consider the effects
-   of particle aspect ratio on its terminal velocity (default: true)
-
-Returns the terminal velocity of a single mixed-phase particle using the Chen 2022
-parametrizations by computing an F_liq-weighted average of solid and liquid
-phase terminal velocities, using the maximum dimension of the whole particle for both.
-"""
-function p3_particle_terminal_velocity(
-    state::P3State,
-    D::FT,
-    Chen2022::CMP.Chen2022VelType,
-    ρₐ::FT,
-    use_aspect_ratio = true,
-) where {FT}
-    # TODO: Refactor to be a parameterization for use with `F_liq`
-    v_i =
-        ice_particle_terminal_velocity(state, D, Chen2022, ρₐ, use_aspect_ratio)
-    # v_r = CM2.rain_particle_terminal_velocity(D, Chen2022.rain, ρₐ)
-    return v_i
-    # return weighted_average(state.F_liq, v_r, v_i)
-end
-
-"""
-    velocity_difference(type, Dₗ, Dᵢ, p3, Chen2022, ρₐ, F_rim, F_liq, th, aspect_ratio)
-
- - type - a struct containing the size distribution parameters of the particle colliding with ice
- - Dₗ - maximum dimension of the particle colliding with ice
- - Dᵢ - maximum dimension of ice particle
- - p3 - a struct containing P3 parameters
- - Chen2022 - a struct containing Chen 2022 velocity parameters
- - ρ_a - density of air
- - F_rim - rime mass fraction (L_rim/L_ice) [-]
- - F_liq - liquid fraction (L_liq / L_p3_tot) [-]
- - th - P3 particle properties thresholds
- - use_aspect_ratio - Bool flag set to true if we want to consider the effects of
-   particle aspect ratio on its terminal velocity (default: true)
-
-Returns the absolute value of the velocity difference between a mixed-phase particle and
-cloud or rain drop as a function of their sizes. It uses Chen 2022 velocity
-parameterization for ice and rain and assumes no sedimentation of cloud droplets.
-"""
-function velocity_difference(
-    ::Union{
-        CMP.RainParticlePDF_SB2006{FT},
-        CMP.RainParticlePDF_SB2006_limited{FT},
-    },
-    Dₗ::FT,
-    Dᵢ::FT,
-    state::P3State,
-    Chen2022::CMP.Chen2022VelType,
-    ρₐ::FT,
-    use_aspect_ratio = true,
-) where {FT}
-    # velocity difference for rain-ice collisions
-    return abs(
-        p3_particle_terminal_velocity(
-            state,
-            Dᵢ,
-            Chen2022,
-            ρₐ,
-            use_aspect_ratio,
-        ) - CM2.rain_particle_terminal_velocity(Dₗ, Chen2022.rain, ρₐ),
-    )
-end
-function velocity_difference(
-    ::CMP.CloudParticlePDF_SB2006{FT},
-    Dₗ::FT,
-    Dᵢ::FT,
-    state::P3State,
-    Chen2022::CMP.Chen2022VelType,
-    ρₐ::FT,
-    use_aspect_ratio = true,
-) where {FT}
-    # velocity difference for cloud-ice collisions
-    return abs(
-        p3_particle_terminal_velocity(
-            state,
-            Dᵢ,
-            Chen2022,
-            ρₐ,
-            use_aspect_ratio,
-        ),
-    )
-end
-
-"""
-    ice_terminal_velocity(dist, Chen2022, ρₐ, use_aspect_ratio)
+    ice_terminal_velocity(dist, velocity, ρₐ, use_aspect_ratio)
 
 Compute the mass and number weighted fall speeds for ice
 
 See Eq. C10 of [MorrisonMilbrandt2015](@cite) and use the Chen 2022 terminal velocity scheme.
 
 # Arguments
-- `dist`: The [`P3Distribution`](@ref) object
-- `Chen2022`: The [`CMP.Chen2022VelType`](@ref) object
-- `ρₐ`: The density of air
+- `dist`: A [`P3Distribution`](@ref)
+- `velocity`: A [`CMP.Chen2022VelType`](@ref)
+- `ρₐ`: The density of air [kg/m³]
+
+# Keyword arguments
 - `use_aspect_ratio`: Bool flag set to true if we want to consider the effects
-   of particle aspect ratio on its terminal velocity (default: true)
+   of particle aspect ratio on its terminal velocity (default: `true`)
 - `accurate`: Set to `true` to perform a more accurate numerical integration
     see [`∫fdD`](@ref) for details. Default is `false`.
 
@@ -144,34 +60,22 @@ See Eq. C10 of [MorrisonMilbrandt2015](@cite) and use the Chen 2022 terminal vel
 - `v_m`: The mass weighted fall speed
 """
 function ice_terminal_velocity(
-    dist::P3Distribution{FT},
-    Chen2022::CMP.Chen2022VelType,
-    ρₐ::FT,
-    use_aspect_ratio = true;
-    accurate = false,
-) where {FT}
+    dist::P3Distribution, velocity::CMP.Chen2022VelType, ρₐ;
+    use_aspect_ratio = true, accurate = false,
+)
     (; state, L, N) = dist
-    if N < eps(FT) || L < eps(FT)
-        return FT(0), FT(0)
+    if N < eps(N) || L < eps(L)
+        return zero(N), zero(L)
     end
 
+    v_term = ice_particle_terminal_velocity(state, velocity, ρₐ; use_aspect_ratio)
+    
     # ∫N(D) m(D) v(D) dD
-    v_m = ∫fdD(state; accurate) do D
-        N′ice(dist, D) *
-        ice_mass(state, D) *
-        p3_particle_terminal_velocity(state, D, Chen2022, ρₐ, use_aspect_ratio)
-    end
-
+    mass_weighted_integrand(D) = N′ice(dist, D) * v_term(D) * ice_mass(state, D) 
     # ∫N(D) v(D) dD
-    v_n = ∫fdD(state; accurate) do D
-        N′ice(dist, D) * p3_particle_terminal_velocity(
-            state,
-            D,
-            Chen2022,
-            ρₐ,
-            use_aspect_ratio,
-        )
-    end
-
+    number_weighted_integrand(D) = N′ice(dist, D) * v_term(D)
+    
+    v_m = ∫fdD(mass_weighted_integrand, state; accurate)
+    v_n = ∫fdD(number_weighted_integrand, state; accurate)
     return (v_n / N, v_m / L)
 end

--- a/src/parameters/Microphysics2M.jl
+++ b/src/parameters/Microphysics2M.jl
@@ -419,6 +419,11 @@ function RainParticlePDF_SB2006(td::CP.AbstractTOMLDict)
     return RainParticlePDF_SB2006{FT}(; parameters...)
 end
 
+const RainParticlePDF_SB2006_MaybeLimited{FT} = Union{
+    RainParticlePDF_SB2006{FT},
+    RainParticlePDF_SB2006_limited{FT},
+} where {FT}
+
 """
     CloudParticlePDF_SB2006
 

--- a/src/parameters/TerminalVelocity.jl
+++ b/src/parameters/TerminalVelocity.jl
@@ -254,7 +254,7 @@ end
 
 The type for precipitation terminal velocity from Chen et al 2022
 DOI: 10.1016/j.atmosres.2022.106171
-(defied for rain, snow and cloud ice)
+(defined for rain, snow and cloud ice)
 
 # Fields
 $(DocStringExtensions.FIELDS)

--- a/test/microphysics2M_tests.jl
+++ b/test/microphysics2M_tests.jl
@@ -598,10 +598,10 @@ function test_microphysics2M(FT)
         m(D) = FT(π / 6) * ρₗ * D^3
 
         # rain drop diameter distribution (eq.(3) from 2M docs)
-        # the same as size_distribution(SB2006_no_limiters.pdf_r, D, qᵣ, ρₐ, Nᵣ)
+        # the same as size_distribution(SB2006_no_limiters.pdf_r, qᵣ, ρₐ, Nᵣ, D)
         f_D(D) = N₀r * exp(-λr * D)
         # rain drop diameter distribution, but using SB2006 limiters
-        # the same as size_distribution(SB2006.pdf_r, D, qᵣ, ρₐ, Nᵣ)
+        # the same as size_distribution(SB2006.pdf_r, qᵣ, ρₐ, Nᵣ, D)
         f_D_limited(D) = N₀r_l * exp(-λr_l * D)
 
         # rain drop mass distribution (eq.(4) from 2M docs)
@@ -631,18 +631,12 @@ function test_microphysics2M(FT)
         ND_lim = QGK.quadgk(x -> f_D_limited(x), D₀, D∞)[1]
         Nx_lim = QGK.quadgk(x -> f_x_limited(x), m₀, m∞)[1]
         ND_bounded = QGK.quadgk(
-            x -> CM2.size_distribution(
-                SB2006_no_limiters.pdf_r,
-                FT(x),
-                qᵣ,
-                ρₐ,
-                Nᵣ,
-            ),
+            CM2.size_distribution(SB2006_no_limiters.pdf_r, qᵣ, ρₐ, Nᵣ),
             0,
             D_max,
         )[1]
         ND_bounded_limited = QGK.quadgk(
-            x -> CM2.size_distribution(SB2006.pdf_r, FT(x), qᵣ, ρₐ, Nᵣ),
+            CM2.size_distribution(SB2006.pdf_r, qᵣ, ρₐ, Nᵣ),
             0,
             D_max_limited,
         )[1]

--- a/test/p3_tests.jl
+++ b/test/p3_tests.jl
@@ -233,13 +233,13 @@ function test_particle_terminal_velocities(FT)
     Chen2022 = CMP.Chen2022VelType(FT)
     ρ_a = FT(1.2)
 
-    @testset "Smoke tests for rain particle terminal vel from Chen 2022" begin
-        Ds = range(FT(1e-6), stop = FT(1e-5), length = 5)
+    @testset "Smoke tests for cloud/rain particle terminal vel from Chen 2022" begin
+        Ds = range(FT(1e-6), stop = FT(1e-5), length = 5)  # TODO: Add tests for larger sizes
         expected = [0.002508, 0.009156, 0.01632, 0.02377, 0.03144]
-        for i in axes(Ds, 1)
-            vel = CM2.rain_particle_terminal_velocity(Ds[i], Chen2022.rain, ρ_a)
+        for (D, vel_expected) in zip(Ds, expected)
+            vel = CO.liquid_particle_terminal_velocity(Chen2022, ρ_a, D)
             @test vel >= 0
-            @test vel ≈ expected[i] rtol = 1e-3
+            @test vel ≈ vel_expected rtol = 1e-3
         end
     end
 
@@ -293,7 +293,7 @@ function test_particle_terminal_velocities(FT)
         expected = [0.13192, 0.50457, 0.90753, 1.3015, 1.6757]
         for i in axes(Ds, 1)
             D = Ds[i]
-            vel = P3.p3_particle_terminal_velocity(
+            vel = P3.ice_particle_terminal_velocity(
                 state,
                 D,
                 Chen2022,
@@ -309,7 +309,7 @@ function test_particle_terminal_velocities(FT)
         expected = [0.13191, 0.50457, 0.90753, 1.301499, 1.67569]
         for i in axes(Ds, 1)
             D = Ds[i]
-            vel = P3.p3_particle_terminal_velocity(
+            vel = P3.ice_particle_terminal_velocity(
                 state,
                 D,
                 Chen2022,
@@ -578,6 +578,26 @@ function test_p3_melting(FT)
     end
 end
 
+function test_ventilation_factor(FT)
+    @testset "Ventilation factor smoke test ($FT)" begin
+        params = CMP.ParametersP3(FT)
+        vel = CMP.Chen2022VelType(FT)
+        aps = CMP.AirProperties(FT)
+        F_rim = FT(0.5)  # Riming fraction [-]
+        ρ_r = FT(500)    # Riming density [kg/m³]
+        ρₐ = FT(1.2)     # Air density [kg/m³]
+        state = P3.get_state(params; F_rim, ρ_r)
+        vent_factor = P3.ventilation_factor(state, vel, ρₐ, aps)
+        Ds = range(FT(0.5e-4), stop = FT(4.5e-4), length = 5)
+        calc_vents = vent_factor.(Ds)
+        smoke_vents = [0.91818553, 1.3191912, 1.7451854, 2.1598392, 2.5553002]
+        for (calc_vent, smoke_vent) in zip(calc_vents, smoke_vents)
+            @test calc_vent ≈ smoke_vent rtol = 1e-6
+        end
+    end
+end
+
+
 for FT in [Float32, Float64]
     @info("Testing " * string(FT))
 
@@ -592,6 +612,9 @@ for FT in [Float32, Float64]
     # velocity
     test_particle_terminal_velocities(FT)
     test_bulk_terminal_velocities(FT)
+    
+    # particle properties
+    test_ventilation_factor(FT)
 
     # processes
     test_p3_het_freezing(FT)


### PR DESCRIPTION
## Purpose
This pull request introduces several improvements and refactorings to the `src/Common.jl`, `src/Microphysics2M.jl`, and `src/P3_terminal_velocity.jl` files, focusing on code clarity, reusability, and performance. Key changes include refactoring terminal velocity computations, improving documentation for functions, and introducing new utility functions for particle size distributions and ventilation factor.

A common pattern that is now introduced for functions that can be evaluated at specific diameters `D` is to have them return a function in `D` by default[^1]:
```julia
function particle_function(state, vel, aps)
    (a, b) = get_coeffs(state, vel, aps)
    func(D) = D^a * exp( - b * D)
end
function particle_function(state, vel, aps, D)
    func = particle_function(state, vel, aps) 
    return func(D)
end
```

### `Common.jl`
- Updated docs for Chen2022 Table coefficients + precompute `log` when it is used frequently.
- Added `liquid_particle_terminal_velocity` (replacement for, now removed `rain_particle_terminal_velocity` in `Microphysics2M.jl`) with an additional signature that returns a function, as described above.

### `Microphysics2M.jl`
- Removed `FT` where not necessary.
- Updated docstrings
- Added "functionalized" version of `size_distribution` (as above)
- Added function for ventilation factor (useful for a future PR)

### `P3_terminal_velocity.jl`
- Added "functionalized" version of `ice_particle_terminal_velocity` (as above)
- Removed `p3_particle_terminal_velocity` (will add back once we return to liquid fraction)
- Removed `velocity_difference` (Not really needed)

### `src/parameters/Microphysics2M.jl`
- Added a constant alias for the union of `RainParticlePDF_SB2006` and `RainParticlePDF_SB2006_limited`.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.


[^1]: We could consider not having the signature that evaluates directly, for simplicity. Either way is fine with me.
