### PR TITLE
Refactor: liquid (cloud/rain) terminal velocity

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -264,11 +264,9 @@ Common.H2SO4_soln_saturation_vapor_pressure
 Common.a_w_xT
 Common.a_w_eT
 Common.a_w_ice
+Common.Chen2022_vel_coeffs
 Common.Chen2022_monodisperse_pdf
 Common.Chen2022_exponential_pdf
-Common.Chen2022_vel_coeffs_B1
-Common.Chen2022_vel_coeffs_B2
-Common.Chen2022_vel_coeffs_B4
 Common.volume_sphere_D
 Common.volume_sphere_R
 Common.ventilation_factor

--- a/docs/src/plots/TerminalVelocity.jl
+++ b/docs/src/plots/TerminalVelocity.jl
@@ -47,30 +47,6 @@ function aspect_ratio_snow_1M_prolate(snow::CMP.Snow, D::FT) where {FT <: Real}
     return 16 * ρᵢ^2 * aᵢ^3 / (9 * FT(π) * mᵢ^2)
 end
 
-"""
-    rain_terminal_velocity_individual_Chen(velo_scheme ρₐ, ρᵢ, D_r)
-
- - `velo_scheme` - structs with free parameters
- - `ρₐ` - air density
- - `ρᵢ` - apparent density of ice particles
- - `D` - particle diameter
-
-Returns the fall velocity of a raindrops or ice crystals from Chen et al 2022
-"""
-function rain_terminal_velocity_individual_Chen(
-    velo_scheme::CMP.Chen2022VelTypeRain,
-    ρₐ::FT,
-    D::FT, #in m
-) where {FT <: Real}
-    ai, bi, ci = CMO.Chen2022_vel_coeffs_B1(velo_scheme, ρₐ)
-
-    v = 0
-    for i in 1:3
-        v += ai[i] * D^bi[i] * exp(-D * ci[i])
-    end
-    return v
-end
-
 function ice_terminal_velocity_individual_Chen(
     ice::CMP.CloudIce,
     velo_scheme::CMP.Chen2022VelTypeSmallIce,
@@ -181,12 +157,13 @@ q_range = range(0, stop = 5 * 1e-3, length = 100)
 
 #! format: off
 # velocity values for cloud particle sizes
+v_term_rain = CMO.liquid_particle_terminal_velocity(Chen2022.rain, ρ_air)
 SB_rain_small = [rain_terminal_velocity_individual_SB(SB2006Vel, ρ_air, D_r)                 for D_r in D_r_range_small]
 M1_rain_small = [terminal_velocity_individual_1M(Blk1MVel.rain, ρ_air, D_r)                  for D_r in D_r_range_small]
 M1_snow_small = [terminal_velocity_individual_1M(Blk1MVel.snow, ρ_air, D_r)                  for D_r in D_r_range_small]
-Ch_liq_small =  [rain_terminal_velocity_individual_Chen(Chen2022.rain, ρ_air, D_r)           for D_r in D_r_range_small]
+Ch_liq_small = v_term_rain.(D_r_range_small)
 Ch_ice_small =  [ice_terminal_velocity_individual_Chen(ice, Chen2022.small_ice, ρ_air, D_r)        for D_r in D_r_range_small]
-Ch_rain_small = [rain_terminal_velocity_individual_Chen(Chen2022.rain, ρ_air, D_r)           for D_r in D_r_range_small]
+Ch_rain_small = v_term_rain.(D_r_range_small)
 Ch_snow_small = [snow_terminal_velocity_individual_Chen(snow, Chen2022.large_ice, ρ_air, D_r) for D_r in D_r_range_small]
 Ch_snow_small_oblate = [snow_terminal_velocity_individual_Chen_oblate(snow, Chen2022.large_ice, ρ_air, D_r) for D_r in D_r_range_small]
 Ch_snow_small_prolate = [snow_terminal_velocity_individual_Chen_prolate(snow, Chen2022.large_ice, ρ_air, D_r) for D_r in D_r_range_small]
@@ -194,9 +171,9 @@ Ch_snow_small_prolate = [snow_terminal_velocity_individual_Chen_prolate(snow, Ch
 SB_rain = [rain_terminal_velocity_individual_SB(SB2006Vel, ρ_air, D_r)                 for D_r in D_r_range]
 M1_rain = [terminal_velocity_individual_1M(Blk1MVel.rain, ρ_air, D_r)                  for D_r in D_r_range]
 M1_snow = [terminal_velocity_individual_1M(Blk1MVel.snow, ρ_air, D_r)                  for D_r in D_r_range]
-Ch_liq =  [rain_terminal_velocity_individual_Chen(Chen2022.rain, ρ_air, D_r)           for D_r in D_r_range]
+Ch_liq = v_term_rain.(D_r_range)
 Ch_ice =  [ice_terminal_velocity_individual_Chen(ice, Chen2022.small_ice, ρ_air, D_r)        for D_r in D_r_range]
-Ch_rain = [rain_terminal_velocity_individual_Chen(Chen2022.rain, ρ_air, D_r)           for D_r in D_r_range]
+Ch_rain = v_term_rain.(D_r_range)
 Ch_snow = [snow_terminal_velocity_individual_Chen(snow, Chen2022.large_ice, ρ_air, D_r) for D_r in D_r_range]
 Ch_snow_oblate  = [snow_terminal_velocity_individual_Chen_oblate(snow, Chen2022.large_ice, ρ_air, D_r) for D_r in D_r_range]
 Ch_snow_prolate = [snow_terminal_velocity_individual_Chen_prolate(snow, Chen2022.large_ice, ρ_air, D_r) for D_r in D_r_range]

--- a/docs/src/plots/TerminalVelocity.jl
+++ b/docs/src/plots/TerminalVelocity.jl
@@ -47,35 +47,15 @@ function aspect_ratio_snow_1M_prolate(snow::CMP.Snow, D::FT) where {FT <: Real}
     return 16 * ρᵢ^2 * aᵢ^3 / (9 * FT(π) * mᵢ^2)
 end
 
-function ice_terminal_velocity_individual_Chen(
-    ice::CMP.CloudIce,
-    velo_scheme::CMP.Chen2022VelTypeSmallIce,
-    ρₐ::FT,
-    D::FT, #in m
-) where {FT <: Real}
-    ai, bi, ci = CMO.Chen2022_vel_coeffs_B2(velo_scheme, ρₐ, ice.ρᵢ)
-
-    v = 0
-    for i in 1:2
-        v += ai[i] * D^bi[i] * exp(-D * ci[i])
-    end
-    return v
-end
-
 function snow_terminal_velocity_individual_Chen(
     snow::CMP.Snow,
     velo_scheme::CMP.Chen2022VelTypeLargeIce,
     ρₐ::FT,
     D::FT, #in m
 ) where {FT <: Real}
-    ai, bi, ci = CMO.Chen2022_vel_coeffs_B4(velo_scheme, ρₐ, snow.ρᵢ)
+    vₜ = CMO.particle_terminal_velocity(velo_scheme, ρₐ, snow.ρᵢ)
     (; ϕ, κ) = snow.aspr
-
-    v = 0
-    for i in 1:2
-        v += ai[i] * D^bi[i] * exp(-D * ci[i])
-    end
-    v_term = ϕ^κ * v
+    v_term = ϕ^κ * vₜ(D)
     return max(FT(0), v_term)
 end
 function snow_terminal_velocity_individual_Chen_oblate(
@@ -84,15 +64,9 @@ function snow_terminal_velocity_individual_Chen_oblate(
     ρₐ::FT,
     D_r::FT, #in m
 ) where {FT <: Real}
-    ai, bi, ci = CMO.Chen2022_vel_coeffs_B4(velo_scheme, ρₐ, snow.ρᵢ)
-
+    vₜ = CMO.particle_terminal_velocity(velo_scheme, ρₐ, snow.ρᵢ)
     ϕ = aspect_ratio_snow_1M_oblate(snow, D_r)
-
-    v = 0
-    for i in 1:2
-        v += ai[i] * (D_r)^(bi[i]) * exp(-D_r * ci[i])
-    end
-    v_term = ϕ^(1 / 3) * v
+    v_term = ϕ^(1 // 3) * vₜ(D_r)
     return max(FT(0), v_term)
 end
 function snow_terminal_velocity_individual_Chen_prolate(
@@ -101,15 +75,9 @@ function snow_terminal_velocity_individual_Chen_prolate(
     ρₐ::FT,
     D_r::FT, #in m
 ) where {FT <: Real}
-    ai, bi, ci = CMO.Chen2022_vel_coeffs_B4(velo_scheme, ρₐ, snow.ρᵢ)
-
+    vₜ = CMO.particle_terminal_velocity(velo_scheme, ρₐ, snow.ρᵢ)
     ϕ = aspect_ratio_snow_1M_prolate(snow, D_r)
-
-    v = 0
-    for i in 1:2
-        v += ai[i] * (D_r)^(bi[i]) * exp(-D_r * ci[i])
-    end
-    v_term = ϕ^(-1 / 6) * v
+    v_term = ϕ^(-1 // 6) * vₜ(D_r)
     return max(FT(0), v_term)
 end
 
@@ -157,12 +125,13 @@ q_range = range(0, stop = 5 * 1e-3, length = 100)
 
 #! format: off
 # velocity values for cloud particle sizes
-v_term_rain = CMO.liquid_particle_terminal_velocity(Chen2022.rain, ρ_air)
+v_term_rain = CMO.particle_terminal_velocity(Chen2022.rain, ρ_air)
+v_term_small_ice = CMO.particle_terminal_velocity(Chen2022.small_ice, ρ_air, ice.ρᵢ)
 SB_rain_small = [rain_terminal_velocity_individual_SB(SB2006Vel, ρ_air, D_r)                 for D_r in D_r_range_small]
 M1_rain_small = [terminal_velocity_individual_1M(Blk1MVel.rain, ρ_air, D_r)                  for D_r in D_r_range_small]
 M1_snow_small = [terminal_velocity_individual_1M(Blk1MVel.snow, ρ_air, D_r)                  for D_r in D_r_range_small]
 Ch_liq_small = v_term_rain.(D_r_range_small)
-Ch_ice_small =  [ice_terminal_velocity_individual_Chen(ice, Chen2022.small_ice, ρ_air, D_r)        for D_r in D_r_range_small]
+Ch_ice_small = v_term_small_ice.(D_r_range_small)
 Ch_rain_small = v_term_rain.(D_r_range_small)
 Ch_snow_small = [snow_terminal_velocity_individual_Chen(snow, Chen2022.large_ice, ρ_air, D_r) for D_r in D_r_range_small]
 Ch_snow_small_oblate = [snow_terminal_velocity_individual_Chen_oblate(snow, Chen2022.large_ice, ρ_air, D_r) for D_r in D_r_range_small]
@@ -172,7 +141,7 @@ SB_rain = [rain_terminal_velocity_individual_SB(SB2006Vel, ρ_air, D_r)         
 M1_rain = [terminal_velocity_individual_1M(Blk1MVel.rain, ρ_air, D_r)                  for D_r in D_r_range]
 M1_snow = [terminal_velocity_individual_1M(Blk1MVel.snow, ρ_air, D_r)                  for D_r in D_r_range]
 Ch_liq = v_term_rain.(D_r_range)
-Ch_ice =  [ice_terminal_velocity_individual_Chen(ice, Chen2022.small_ice, ρ_air, D_r)        for D_r in D_r_range]
+Ch_ice = v_term_small_ice.(D_r_range)
 Ch_rain = v_term_rain.(D_r_range)
 Ch_snow = [snow_terminal_velocity_individual_Chen(snow, Chen2022.large_ice, ρ_air, D_r) for D_r in D_r_range]
 Ch_snow_oblate  = [snow_terminal_velocity_individual_Chen_oblate(snow, Chen2022.large_ice, ρ_air, D_r) for D_r in D_r_range]

--- a/src/Common.jl
+++ b/src/Common.jl
@@ -337,6 +337,34 @@ function Chen2022_exponential_pdf(a::FT, b::FT, c::FT, λ_inv::FT, k::Int) where
 end
 
 """
+    liquid_particle_terminal_velocity(velocity_params, ρₐ)
+
+Compute the terminal velocity of a liquid particle as a function of its size 
+    (maximum dimension, `D`) using the Chen 2022 parametrization.
+
+# Arguments
+- `velocity_params`: a struct with terminal velocity parameters from Chen 2022
+- `ρₐ`: air density [kg/m³]
+
+# Returns
+- The terminal velocity of a liquid particle as a function of its size (maximum dimension)
+    following Chen 2022 velocity parametrization.
+    
+Needed for numerical integrals in the P3 scheme.
+
+!!! note
+    We use the same terminal velocity parametrization for cloud and rain water.
+"""
+function liquid_particle_terminal_velocity(velocity_params::CMP.Chen2022VelTypeRain, ρₐ)
+    (ai, bi, ci) = Chen2022_vel_coeffs_B1(velocity_params, ρₐ)
+    v_term(D) = sum(@. sum(ai * D^bi * exp(-ci * D)))
+    return v_term
+end
+liquid_particle_terminal_velocity(velocity_params::CMP.Chen2022VelType, ρₐ) =
+    liquid_particle_terminal_velocity(velocity_params.rain, ρₐ)
+
+
+"""
     volume_sphere_D(D)
 
 Calculate the volume of a sphere with diameter D.

--- a/src/Common.jl
+++ b/src/Common.jl
@@ -16,11 +16,9 @@ export H2SO4_soln_saturation_vapor_pressure
 export a_w_xT
 export a_w_eT
 export a_w_ice
+export Chen2022_vel_coeffs
 export Chen2022_monodisperse_pdf
 export Chen2022_exponential_pdf
-export Chen2022_vel_coeffs_B1
-export Chen2022_vel_coeffs_B2
-export Chen2022_vel_coeffs_B4
 export ventilation_factor
 
 """
@@ -209,17 +207,23 @@ function a_w_ice(tps::TPS, T::FT) where {FT}
 end
 
 """
-    Chen2022_vel_coeffs_B1(coeffs, ρₐ)
+    Chen2022_vel_coeffs(coeffs, ρₐ)
+    Chen2022_vel_coeffs(coeffs, ρₐ, ρᵢ)
 
-Returns the coefficients from Table B1 Appendix B in Chen et al 2022
+Compute the coefficients for the Chen 2022 terminal velocity parametrization.
 
 # Arguments
  - `coeffs`: a struct with terminal velocity free parameters
+    - [`CMP.Chen2022VelTypeRain`](@ref): Fetch from Table B1
+    - [`CMP.Chen2022VelTypeSmallIce`](@ref): Fetch from Table B2
+    - [`CMP.Chen2022VelTypeLargeIce`](@ref): Fetch from Table B4
  - `ρₐ`: air density [kg/m³]
+ - `ρᵢ`: apparent density of ice particles [kg/m³],
+    only used for [`CMP.Chen2022VelTypeSmallIce`](@ref) and [`CMP.Chen2022VelTypeLargeIce`](@ref)
 
-DOI: 10.1016/j.atmosres.2022.106171
+See [Chen2022](@cite) for more details.
 """
-function Chen2022_vel_coeffs_B1(coeffs::CMP.Chen2022VelTypeRain, ρₐ)
+function Chen2022_vel_coeffs(coeffs::CMP.Chen2022VelTypeRain, ρₐ)
     (; ρ0, a, a3_pow, b, b_ρ, c) = coeffs
     # Table B1
     q = exp(ρ0 * ρₐ)
@@ -231,24 +235,8 @@ function Chen2022_vel_coeffs_B1(coeffs::CMP.Chen2022VelTypeRain, ρₐ)
     ciu = ci .* 1000
     return (aiu, bi, ciu)
 end
-
-"""
-    Chen2022_vel_coeffs_B2(coeffs, ρₐ, ρᵢ)
-
-Returns the coefficients from Table B2 Appendix B in Chen et al 2022
-
-# Arguments
- - `coeffs`: a struct with terminal velocity free parameters
- - `ρₐ`: air density [kg/m³]
- - `ρᵢ`: apparent density of ice particles [kg/m³]
-
-DOI: 10.1016/j.atmosres.2022.106171
-"""
-function Chen2022_vel_coeffs_B2(
-    coeffs::CMP.Chen2022VelTypeSmallIce,
-    ρₐ::FT,
-    ρᵢ::FT,
-) where {FT}
+function Chen2022_vel_coeffs(coeffs::CMP.Chen2022VelTypeSmallIce, ρₐ, ρᵢ)
+    FT = eltype(coeffs)
     (; A, B, C, E, F, G) = coeffs
     # Table B3
     log_ρᵢ = log(ρᵢ)
@@ -267,24 +255,8 @@ function Chen2022_vel_coeffs_B2(
     ciu = ci .* 1000
     return (aiu, bi, ciu)
 end
-
-"""
-    Chen2022_vel_coeffs_B4(coeffs, ρₐ, ρᵢ)
-
-Returns the coefficients from Table B4 Appendix B in Chen et al 2022
-
-# Arguments
- - `coeffs`: a struct with terminal velocity free parameters
- - `ρₐ`: air density [kg/m³]
- - `ρᵢ`: apparent density of ice particles [kg/m³]
-
-DOI: 10.1016/j.atmosres.2022.106171
-"""
-function Chen2022_vel_coeffs_B4(
-    coeffs::CMP.Chen2022VelTypeLargeIce,
-    ρₐ::FT,
-    ρᵢ::FT,
-) where {FT}
+function Chen2022_vel_coeffs(coeffs::CMP.Chen2022VelTypeLargeIce, ρₐ, ρᵢ)
+    FT = eltype(coeffs)
     (; A, B, C, E, F, G, H) = coeffs
     # Table B5
     log_ρᵢ = log(ρᵢ)
@@ -306,17 +278,16 @@ function Chen2022_vel_coeffs_B4(
 end
 
 """
-    Chen2022_monodisperse_pdf(a, b, c, D)
+    Chen2022_monodisperse_pdf(a, b, c)
 
- - a, b, c, - free parameters defined in Chen etl al 2022
- - D - droplet diameter
+# Arguments
+ - `a`, `b`, `c`: free parameters defined in [Chen2022](@cite)
 
-Returns the addends of the bulk fall speed of rain or ice particles
-following Chen et al 2022 DOI: 10.1016/j.atmosres.2022.106171 in [m/s].
-Assuming monodisperse droplet distribution.
+# Returns
+ - `pdf(D)`: The monodisperse particle distribution function as a function of diameter, `D`, in [m/s].
 """
-function Chen2022_monodisperse_pdf(a, b, c, D)
-    return a * D^b * exp(-c * D)
+function Chen2022_monodisperse_pdf(a, b, c)
+    return pdf(D) = a * D^b * exp(-c * D)
 end
 
 """
@@ -337,31 +308,31 @@ function Chen2022_exponential_pdf(a::FT, b::FT, c::FT, λ_inv::FT, k::Int) where
 end
 
 """
-    liquid_particle_terminal_velocity(velocity_params, ρₐ)
+    particle_terminal_velocity(velocity_params, ρₐ)
+    particle_terminal_velocity(velocity_params, ρₐ, ρᵢ)
 
-Compute the terminal velocity of a liquid particle as a function of its size 
-    (maximum dimension, `D`) using the Chen 2022 parametrization.
+Return a function `v_term(D)` that computes the particle terminal velocity
 
 # Arguments
 - `velocity_params`: a struct with terminal velocity parameters from Chen 2022
 - `ρₐ`: air density [kg/m³]
+- `ρᵢ`: apparent density of ice particles [kg/m³],
+    only used for [`CMP.Chen2022VelTypeSmallIce`](@ref) and [`CMP.Chen2022VelTypeLargeIce`](@ref)
 
 # Returns
-- The terminal velocity of a liquid particle as a function of its size (maximum dimension)
-    following Chen 2022 velocity parametrization.
+- `v_term(D)`: The terminal velocity of a particle as a function of its size (diameter, `D`)
     
 Needed for numerical integrals in the P3 scheme.
 
 !!! note
     We use the same terminal velocity parametrization for cloud and rain water.
 """
-function liquid_particle_terminal_velocity(velocity_params::CMP.Chen2022VelTypeRain, ρₐ)
-    (ai, bi, ci) = Chen2022_vel_coeffs_B1(velocity_params, ρₐ)
-    v_term(D) = sum(@. sum(ai * D^bi * exp(-ci * D)))
+function particle_terminal_velocity(velocity_params::CMP.TerminalVelocityType, ρs...)
+    (ai, bi, ci) = Chen2022_vel_coeffs(velocity_params, ρs...)
+    v_terms = Chen2022_monodisperse_pdf.(ai, bi, ci)  # tuple of functions
+    v_term(D) = sum(@. D |> v_terms)
     return v_term
 end
-liquid_particle_terminal_velocity(velocity_params::CMP.Chen2022VelType, ρₐ) =
-    liquid_particle_terminal_velocity(velocity_params.rain, ρₐ)
 
 
 """

--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -190,7 +190,7 @@ function terminal_velocity(
     fall_w = FT(0)
     if q > FT(0)
         # coefficients from Table B1 from Chen et. al. 2022
-        aiu, bi, ciu = CO.Chen2022_vel_coeffs_B1(vel, ρₐ)
+        aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρₐ)
         # size distribution parameter
         λ_inv::FT = lambda_inverse(pdf, mass, q, ρₐ)
         # eq 20 from Chen et al 2022
@@ -214,8 +214,7 @@ function terminal_velocity(
     # from D=125um to D=625um using B2 and D=625um to inf using B4.
     if q > FT(0)
         # coefficients from Table B4 from Chen et. al. 2022
-        aiu, bi, ciu = CO.Chen2022_vel_coeffs_B4(vel, ρₐ, ρᵢ)
-        #aiu, bi, ciu = CO.Chen2022_vel_coeffs_B2(vel, ρₐ, ρᵢ)
+        aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρₐ, ρᵢ)
         # size distribution parameter
         λ_inv::FT = lambda_inverse(pdf, mass, q, ρₐ)
 
@@ -242,7 +241,7 @@ function terminal_velocity(
     # see comments above about B2 vs B4 coefficients
     if q > FT(0)
         # coefficients from Table B4 from Chen et. al. 2022
-        aiu, bi, ciu = CO.Chen2022_vel_coeffs_B4(vel, ρₐ, ρᵢ)
+        aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρₐ, ρᵢ)
         # size distribution parameter
         λ_inv::FT = lambda_inverse(pdf, mass, q, ρₐ)
         # Compute the mass weighted average aspect ratio ϕ_av

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -632,7 +632,7 @@ function rain_terminal_velocity(
     q_rai, ρ, N_rai,
 ) where {FT}
     # coefficients from Table B1 from Chen et. al. 2022
-    aiu, bi, ciu = CO.Chen2022_vel_coeffs_B1(vel, ρ)
+    aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρ)
     # size distribution parameter
     (; Dr_mean) = pdf_rain_parameters(pdf_r, q_rai, ρ, N_rai)
 

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -591,29 +591,6 @@ function rain_self_collection_and_breakup(
 end
 
 """
-    rain_particle_terminal_velocity(Chen2022, ρₐ)
-
-Compute the terminal velocity of an individual rain drop as a function of its size
-(maximum dimension) following Chen 2022 velocity parametrization.
-Needed for numerical integrals in the P3 scheme.
-
-# Arguments
- - `Chen2022`: terminal velocity parameters from Chen 2022, [`CMP.Chen2022VelTypeRain`](@ref)
- - `ρₐ`: air density
-
-# Returns
- - The terminal velocity of an individual rain drop as a function
-    of its size (maximum dimension) following Chen 2022 velocity parametrization.
-    Needed for numerical integrals in the P3 scheme.
- """
-function rain_particle_terminal_velocity(Chen2022::CMP.Chen2022VelTypeRain, ρₐ)
-    (ai, bi, ci) = CO.Chen2022_vel_coeffs_B1(Chen2022, ρₐ)
-
-    v(D) = sum(@. sum(ai * D^bi * exp(-ci * D)))
-    return v
-end
-
-"""
     rain_terminal_velocity(SB2006, vel, q_rai, ρ, N_rai)
 
 Compute the raindrops terminal velocity.

--- a/src/MicrophysicsNonEq.jl
+++ b/src/MicrophysicsNonEq.jl
@@ -151,7 +151,7 @@ function terminal_velocity(
         # for D > 100mm. We should look for a different parameterization
         # that is more suited for cloud droplets. For now I'm just multiplying
         # by an arbitrary correction factor.
-        aiu, bi, ciu = CO.Chen2022_vel_coeffs_B1(vel, ρₐ)
+        v_term = CO.particle_terminal_velocity(vel, ρₐ)
         # The 1M scheme does not assume any cloud droplet size distribution.
         # TODO - For now I compute a mean volume radius assuming a fixed value
         # for the total number concentration of droplets.
@@ -159,8 +159,7 @@ function terminal_velocity(
         D = cbrt(ρₐ * q / N / ρw)
         corr = FT(0.1)
         # assuming ϕ = 1 (spherical)
-        fall_w = sum(CO.Chen2022_monodisperse_pdf.(aiu, bi, ciu, D))
-        fall_w = max(FT(0), corr * fall_w)
+        fall_w = max(FT(0), corr * v_term(D))
     end
     return fall_w
 end
@@ -172,14 +171,12 @@ function terminal_velocity(
 ) where {FT}
     fall_w = FT(0)
     if q > FT(0)
-        # Coefficients from Table B2 from Chen et. al. 2022
-        aiu, bi, ciu = CO.Chen2022_vel_coeffs_B2(vel, ρₐ, ρᵢ)
+        v_term = CO.particle_terminal_velocity(vel, ρₐ, ρᵢ)
         # See the comment for liquid droplets above
         N = FT(500 * 1e6)
         D = cbrt(ρₐ * q / N / ρᵢ)
         # assuming ϕ = 1 (spherical)
-        fall_w = sum(CO.Chen2022_monodisperse_pdf.(aiu, bi, ciu, D))
-        fall_w = max(FT(0), fall_w)
+        fall_w = max(FT(0), v_term(D))
     end
     return fall_w
 end

--- a/src/P3_terminal_velocity.jl
+++ b/src/P3_terminal_velocity.jl
@@ -21,14 +21,13 @@ function ice_particle_terminal_velocity(
 )
     function v_term(D::FT) where {FT}
         (; small_ice, large_ice) = velocity_params
+        D_cutoff = small_ice.cutoff # Diameter cutoff between small and large ice regimes
         ρᵢ = FT(916.7) # ρᵢ = p3_density(p3, D, F_rim, th) # TODO: tmp
+        v_term_small = CO.particle_terminal_velocity(small_ice, ρₐ, ρᵢ)
+        v_term_large = CO.particle_terminal_velocity(large_ice, ρₐ, ρᵢ)
         ϕ_factor = use_aspect_ratio ? cbrt(ϕᵢ(state, D)) : FT(1)
-        (ai, bi, ci) = if D <= small_ice.cutoff
-            CO.Chen2022_vel_coeffs_B2(small_ice, ρₐ, ρᵢ)
-        else
-            CO.Chen2022_vel_coeffs_B4(large_ice, ρₐ, ρᵢ)
-        end
-        ϕ_factor * sum(@. sum(ai * D^bi * exp(-ci * D)))
+        vₜ = D <= D_cutoff ? v_term_small(D) : v_term_large(D)
+        return ϕ_factor * vₜ
     end
     return v_term
 end

--- a/src/parameters/TerminalVelocity.jl
+++ b/src/parameters/TerminalVelocity.jl
@@ -142,7 +142,7 @@ See Table B3 for parameter definitions. DOI: 10.1016/j.atmosres.2022.106171
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-Base.@kwdef struct Chen2022VelTypeSmallIce{FT, N, M} <: ParametersType{FT}
+Base.@kwdef struct Chen2022VelTypeSmallIce{FT, N, M} <: TerminalVelocityType{FT}
     A::NTuple{N, FT}
     B::NTuple{N, FT}
     C::NTuple{M, FT}
@@ -180,7 +180,7 @@ See Table B4 for parameter definitions. DOI: 10.1016/j.atmosres.2022.106171
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-Base.@kwdef struct Chen2022VelTypeLargeIce{FT, N} <: ParametersType{FT}
+Base.@kwdef struct Chen2022VelTypeLargeIce{FT, N} <: TerminalVelocityType{FT}
     A::NTuple{N, FT}
     B::NTuple{N, FT}
     C::NTuple{N, FT}
@@ -221,7 +221,7 @@ DOI: 10.1016/j.atmosres.2022.106171
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-Base.@kwdef struct Chen2022VelTypeRain{FT, N} <: ParametersType{FT}
+Base.@kwdef struct Chen2022VelTypeRain{FT, N} <: TerminalVelocityType{FT}
     ρ0::FT
     a::NTuple{N, FT}
     a3_pow::FT
@@ -259,7 +259,7 @@ DOI: 10.1016/j.atmosres.2022.106171
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct Chen2022VelType{FT, R, SI, LI} <: TerminalVelocityType{FT}
+struct Chen2022VelType{FT, R, SI, LI}
     rain::R
     small_ice::SI
     large_ice::LI

--- a/test/common_functions_tests.jl
+++ b/test/common_functions_tests.jl
@@ -155,7 +155,7 @@ function test_Chen_coefficients(FT)
     ice = CMP.CloudIce(FT)
 
     TT.@testset "Chen terminal velocity rain (B1)" begin
-        aiu, bi, ciu = CO.Chen2022_vel_coeffs_B1(Ch2022.rain, ρ)
+        aiu, bi, ciu = CO.Chen2022_vel_coeffs(Ch2022.rain, ρ)
 
         TT.@test all(
             isapprox.(
@@ -181,7 +181,7 @@ function test_Chen_coefficients(FT)
     end
 
     TT.@testset "Chen terminal velocity small ice (B2)" begin
-        aiu, bi, ciu = CO.Chen2022_vel_coeffs_B2(Ch2022.small_ice, ρ, ice.ρᵢ)
+        aiu, bi, ciu = CO.Chen2022_vel_coeffs(Ch2022.small_ice, ρ, ice.ρᵢ)
 
         TT.@test all(
             isapprox.(aiu, [312.9777159510928, -316.5335670126842], rtol = tol),
@@ -193,7 +193,7 @@ function test_Chen_coefficients(FT)
     end
 
     TT.@testset "Chen terminal velocity large ice (B4)" begin
-        aiu, bi, ciu = CO.Chen2022_vel_coeffs_B4(Ch2022.large_ice, ρ, snow.ρᵢ)
+        aiu, bi, ciu = CO.Chen2022_vel_coeffs(Ch2022.large_ice, ρ, snow.ρᵢ)
 
         TT.@test all(
             isapprox.(aiu, [51.86069839334009, -1.394567234046072], rtol = tol),

--- a/test/p3_tests.jl
+++ b/test/p3_tests.jl
@@ -237,7 +237,7 @@ function test_particle_terminal_velocities(FT)
     @testset "Smoke tests for cloud/rain particle terminal vel from Chen 2022" begin
         Ds = range(FT(1e-6), stop = FT(1e-5), length = 5)  # TODO: Add tests for larger sizes
         expected = [0.002508, 0.009156, 0.01632, 0.02377, 0.03144]
-        v_term = CO.liquid_particle_terminal_velocity(Chen2022.rain, ρ_a)
+        v_term = CO.particle_terminal_velocity(Chen2022.rain, ρ_a)
         for i in axes(Ds, 1)
             vel = v_term(Ds[i])
             @test vel >= 0

--- a/test/p3_tests.jl
+++ b/test/p3_tests.jl
@@ -2,6 +2,7 @@ using Test: @testset, @test, @test_throws, @test_broken
 import CloudMicrophysics.P3Scheme as P3
 import CloudMicrophysics.Parameters as CMP
 import CloudMicrophysics.Microphysics2M as CM2
+import CloudMicrophysics.Common as CO
 import Thermodynamics as TD
 import ClimaParams as CP
 
@@ -236,9 +237,9 @@ function test_particle_terminal_velocities(FT)
     @testset "Smoke tests for cloud/rain particle terminal vel from Chen 2022" begin
         Ds = range(FT(1e-6), stop = FT(1e-5), length = 5)  # TODO: Add tests for larger sizes
         expected = [0.002508, 0.009156, 0.01632, 0.02377, 0.03144]
-        vel_func = CM2.rain_particle_terminal_velocity(Chen2022.rain, ρ_a)
+        v_term = CO.liquid_particle_terminal_velocity(Chen2022.rain, ρ_a)
         for i in axes(Ds, 1)
-            vel = vel_func(Ds[i])
+            vel = v_term(Ds[i])
             @test vel >= 0
             @test vel ≈ expected[i] rtol = 1e-3
         end


### PR DESCRIPTION
- Renamed `rain_particle_terminal_velocity` to `liquid_particle_terminal_velocity` since it is currently used for both cloud and rain.
- and moved it to Common to reflect it's broader applicability.