### PR TITLE
Update 1M interface + working fluid fixes

### DIFF
--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -31,6 +31,14 @@ abstract type AbstractSnowShape end
 struct Oblate <: AbstractSnowShape end
 struct Prolate <: AbstractSnowShape end
 
+# Thermodynamics deps:
+# ---------------------
+# TD.latent_heat_fusion(tps, T)
+# TD.supersaturation(tps, q, ρ, T, TD.Liquid())
+# TD.supersaturation(tps, q, ρ, T, TD.Ice())
+# CO.G_func(aps, tps, T, TD.Liquid())
+# CO.G_func(aps, tps, T, TD.Ice())
+
 """
     Ec(type_1, type_2, ce)
 
@@ -298,12 +306,18 @@ conv_q_ice_to_q_sno_no_supersat(
     max(0, q_ice - q_threshold) / τ
 
 """
-    conv_q_ice_to_q_sno(ice, aps, tps, q, ρ, T)
+    conv_q_ice_to_q_sno(ice, aps, tps, q_tot, q_liq, q_ice, q_rai, q_sno, ρ, T)
+    conv_q_ice_to_q_sno(ice, aps, tps, q, q_rai, q_sno, ρ, T)
 
  - `ice` - a struct with ice parameters
  - `aps` - a struct with air properties
  - `tps` - a struct with thermodynamics parameters
- - `q` - phase partition
+ - `q_tot` - total water specific content
+ - `q_liq` - cloud water specific content
+ - `q_ice` - ice specific content
+ - `q_rai` - rain specific content
+ - `q_sno` - snow specific content
+ - `q` - Thermodynamics.PhasePartition
  - `ρ` - air density
  - `T` - air temperature
 
@@ -314,18 +328,28 @@ function conv_q_ice_to_q_sno(
     (; r_ice_snow, pdf, mass)::CMP.CloudIce{FT},
     aps::CMP.AirProperties{FT},
     tps::TDP.ThermodynamicsParameters{FT},
-    q::TD.PhasePartition{FT},
+    q_tot::FT,
+    q_liq::FT,
+    q_ice::FT,
+    q_rai::FT,
+    q_sno::FT,
     ρ::FT,
     T::FT,
 ) where {FT}
     acnv_rate = FT(0)
-    S = TD.supersaturation(tps, q, ρ, T, TD.Ice())
+    S = TD.supersaturation(
+        tps,
+        TD.PhasePartition(q_tot, q_liq + q_rai, q_ice + q_sno),
+        ρ,
+        T,
+        TD.Ice(),
+    )
 
-    if (q.ice > FT(0) && S > FT(0))
+    if (q_ice > FT(0) && S > FT(0))
         (; me, Δm) = mass
         G = CO.G_func(aps, tps, T, TD.Ice())
         n0 = get_n0(pdf)
-        λ_inv = lambda_inverse(pdf, mass, q.ice, ρ)
+        λ_inv = lambda_inverse(pdf, mass, q_ice, ρ)
 
         acnv_rate =
             4 * FT(π) * S * G * n0 / ρ *
@@ -334,6 +358,27 @@ function conv_q_ice_to_q_sno(
     end
     return acnv_rate
 end
+conv_q_ice_to_q_sno(
+    ice_params::CMP.CloudIce,
+    aps::CMP.AirProperties,
+    tps::TDP.ThermodynamicsParameters,
+    q::TD.PhasePartition, # Assuming q = (q_tot, q_liq + q_rai, q_ice + q_sno)
+    q_rai,
+    q_sno,
+    ρ,
+    T,
+) = conv_q_ice_to_q_sno(
+    ice_params::CMP.CloudIce,
+    aps::CMP.AirProperties,
+    tps::TDP.ThermodynamicsParameters,
+    q.tot,
+    q.liq - q_rai,
+    q.ice - q_sno,
+    q_rai,
+    q_sno,
+    ρ,
+    T,
+)
 
 """
     accretion(cloud, precip, vel, ce, q_clo, q_pre, ρ)
@@ -488,17 +533,19 @@ function accretion_snow_rain(
 end
 
 """
-    evaporation_sublimation(rain, vel, aps, tps, q, q_rai, ρ, T)
-    evaporation_sublimation(snow, vel, aps, tps, q, q_sno, ρ, T)
+    evaporation_sublimation(params, vel, aps, tps, q_tot, q_liq, q_ice, q_rai, q_snow, ρ, T)
+    evaporation_sublimation(params, vel, aps, tps, q, q_rai, q_sno, ρ, T)
 
- - `rain` - a struct with rain parameters
- - `snow` - a struct with snow parameters
+ - `params` - a struct with rain or snow parameters
  - `vel` - a struct with terminal velocity parameters
  - `aps` - a struct with air parameters
  - `tps` - a struct with thermodynamics parameters
- - `q` - phase partition
+ - `q_tot` - total water specific content
+ - `q_liq` - liquid water specific content
+ - `q_ice` - ice specific content
  - `q_rai` - rain specific content
  - `q_sno` - snow specific content
+ - `q` - Thermodynamics.PhasePartition
  - `ρ` - air density
  - `T` - air temperature
 
@@ -509,13 +556,21 @@ function evaporation_sublimation(
     vel::CMP.Blk1MVelTypeRain{FT},
     aps::CMP.AirProperties{FT},
     tps::TDP.ThermodynamicsParameters{FT},
-    q::TD.PhasePartition{FT},
+    q_tot::FT,
+    q_liq::FT,
+    q_ice::FT,
     q_rai::FT,
+    q_sno::FT,
     ρ::FT,
     T::FT,
 ) where {FT}
     evap_subl_rate = FT(0)
-    S = TD.supersaturation(tps, q, ρ, T, TD.Liquid())
+    S = TD.supersaturation(
+        tps,
+        TD.PhasePartition(q_tot, q_liq + q_rai, q_ice + q_sno),
+        ρ,
+        T, TD.Liquid(),
+    )
 
     if (q_rai > FT(0) && S < FT(0))
 
@@ -543,12 +598,39 @@ function evaporation_sublimation(
     # only evaporation is considered for rain
     return min(0, evap_subl_rate)
 end
+evaporation_sublimation(
+    rain_params::CMP.Rain,
+    vel::CMP.Blk1MVelTypeRain,
+    aps::CMP.AirProperties,
+    tps::TDP.ThermodynamicsParameters,
+    q::TD.PhasePartition, # Assuming q = (q_tot, q_liq + q_rai, q_ice + q_sno)
+    q_rai,
+    q_sno,
+    ρ,
+    T,
+) = evaporation_sublimation(
+    rain_params::CMP.Rain,
+    vel::CMP.Blk1MVelTypeRain,
+    aps::CMP.AirProperties,
+    tps::TDP.ThermodynamicsParameters,
+    q.tot,
+    q.liq - q_rai,
+    q.ice - q_sno,
+    q_rai,
+    q_sno,
+    ρ,
+    T,
+)
+
 function evaporation_sublimation(
     (; pdf, mass, vent)::CMP.Snow{FT},
     vel::CMP.Blk1MVelTypeSnow{FT},
     aps::CMP.AirProperties{FT},
     tps::TDP.ThermodynamicsParameters{FT},
-    q::TD.PhasePartition{FT},
+    q_tot::FT,
+    q_liq::FT,
+    q_ice::FT,
+    q_rai::FT,
     q_sno::FT,
     ρ::FT,
     T::FT,
@@ -557,7 +639,13 @@ function evaporation_sublimation(
     if q_sno > FT(0)
         (; ν_air, D_vapor) = aps
 
-        S = TD.supersaturation(tps, q, ρ, T, TD.Ice())
+        S = TD.supersaturation(
+            tps,
+            TD.PhasePartition(q_tot, q_liq + q_rai, q_ice + q_sno),
+            ρ,
+            T,
+            TD.Ice(),
+        )
         G = CO.G_func(aps, tps, T, TD.Ice())
 
         n0 = get_n0(pdf, q_sno, ρ)
@@ -582,6 +670,30 @@ function evaporation_sublimation(
     end
     return evap_subl_rate
 end
+
+evaporation_sublimation(
+    snow_params::CMP.Snow,
+    vel::CMP.Blk1MVelTypeSnow,
+    aps::CMP.AirProperties,
+    tps::TDP.ThermodynamicsParameters,
+    q::TD.PhasePartition, # Assuming q = (q_tot, q_liq + q_rai, q_ice + q_sno)
+    q_rai,
+    q_sno,
+    ρ,
+    T,
+) = evaporation_sublimation(
+    snow_params::CMP.Snow,
+    vel::CMP.Blk1MVelTypeSnow,
+    aps::CMP.AirProperties,
+    tps::TDP.ThermodynamicsParameters,
+    q.tot,
+    q.liq - q_rai,
+    q.ice - q_sno,
+    q_rai,
+    q_sno,
+    ρ,
+    T,
+)
 
 """
     snow_melt(snow, vel, aps, tps, q_sno, ρ, T)


### PR DESCRIPTION
This PR provides wrappers for 1-moment microphysics functions that don't use `Thermodynamics.jl` `PhasePartition` as argument. First step towards simplifying things in `Atmos` limiters 