### PR TITLE
rft: remove P3Distribution struct

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -119,7 +119,6 @@ P3Scheme.get_state
 
 ```@docs
 P3Scheme.get_thresholds_ρ_g
-P3Scheme.threshold_tuple
 P3Scheme.get_ρ_d
 P3Scheme.get_ρ_g
 P3Scheme.get_D_th
@@ -142,21 +141,21 @@ P3Scheme.ϕᵢ
 ## Distribution parameters
 
 ```@docs
-P3Scheme.P3Distribution
-P3Scheme.get_distribution_parameters
+P3Scheme.get_μ
+P3Scheme.get_logN₀
+P3Scheme.get_distribution_logλ
 ```
 
 ### Distribution relationships
 
 ```@docs
-P3Scheme.log_N′ice
+P3Scheme.logN′ice
 P3Scheme.N′ice
-P3Scheme.get_μ
-P3Scheme.log_integrate_moment_psd
-P3Scheme.log_L_div_N₀
-P3Scheme.log_N_div_N₀
-P3Scheme.log_L_div_N
-P3Scheme.get_log_N₀
+P3Scheme.loggamma_inc_moment
+P3Scheme.loggamma_moment
+P3Scheme.logmass_gamma_moment
+P3Scheme.logLdivN
+
 ```
 
 ### Derived integral quantities

--- a/docs/src/plots/P3AspectRatioPlot.jl
+++ b/docs/src/plots/P3AspectRatioPlot.jl
@@ -53,7 +53,7 @@ function p3_relations_plot()
 	F_rims = [0.0, 0.5, 0.8]
 	for (i, F_rim) in enumerate(F_rims)
 		color = cl[i]
-		state = P3.get_state(params; F_rim, ρ_rim = ρ_rim₀)
+		state = P3.get_state(params; F_rim, ρ_rim = ρ_rim₀, L_ice = FT(0), N_ice = FT(0))
 		lines_and_vlines!(ax1L, state, color)
 	end
 
@@ -62,7 +62,7 @@ function p3_relations_plot()
 	ρ_rims = [200.0, 400.0, 800.0]
 	for (i, ρ_rim) in enumerate(ρ_rims)
 		color = cl[i]
-		state = P3.get_state(params; F_rim = F_rim₀, ρ_rim)
+		state = P3.get_state(params; F_rim = F_rim₀, ρ_rim, L_ice = FT(0), N_ice = FT(0))
 		lines_and_vlines!(ax1R, state, color)
 	end
 

--- a/docs/src/plots/P3Melting.jl
+++ b/docs/src/plots/P3Melting.jl
@@ -32,28 +32,28 @@ max_dNdt = [Nᵢ / dt for ΔT in ΔT_range]
 ρₐ1 = FT(1.2)
 Fᵣ1 = FT(0.8)
 ρᵣ1 = FT(800)
-state = P3.get_state(params; F_rim = Fᵣ1, ρ_rim = ρᵣ1)
-dist = P3.get_distribution_parameters(state; L = Lᵢ, N = Nᵢ)
-dLdt1 = [P3.ice_melt(dist, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dLdt for ΔT in ΔT_range]
-dNdt1 = [P3.ice_melt(dist, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dNdt for ΔT in ΔT_range]
+state = P3.get_state(params; F_rim = Fᵣ1, ρ_rim = ρᵣ1, L_ice = Lᵢ, N_ice = Nᵢ)
+logλ = P3.get_distribution_logλ(state)
+dLdt1 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dLdt for ΔT in ΔT_range]
+dNdt1 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dNdt for ΔT in ΔT_range]
 
 Fᵣ2 = FT(0.2)
-state = P3.get_state(params; F_rim = Fᵣ2, ρ_rim = ρᵣ1)
-dist = P3.get_distribution_parameters(state; L = Lᵢ, N = Nᵢ)
-dLdt2 = [P3.ice_melt(dist, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dLdt for ΔT in ΔT_range]
-dNdt2 = [P3.ice_melt(dist, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dNdt for ΔT in ΔT_range]
+state = P3.get_state(params; F_rim = Fᵣ2, ρ_rim = ρᵣ1, L_ice = Lᵢ, N_ice = Nᵢ)
+logλ = P3.get_distribution_logλ(state)
+dLdt2 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dLdt for ΔT in ΔT_range]
+dNdt2 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dNdt for ΔT in ΔT_range]
 
 ρᵣ2 = FT(200)
-state = P3.get_state(params; F_rim = Fᵣ2, ρ_rim = ρᵣ2)
-dist = P3.get_distribution_parameters(state; L = Lᵢ, N = Nᵢ)
-dLdt3 = [P3.ice_melt(dist, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dLdt for ΔT in ΔT_range]
-dNdt3 = [P3.ice_melt(dist, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dNdt for ΔT in ΔT_range]
+state = P3.get_state(params; F_rim = Fᵣ2, ρ_rim = ρᵣ2, L_ice = Lᵢ, N_ice = Nᵢ)
+logλ = P3.get_distribution_logλ(state)
+dLdt3 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dLdt for ΔT in ΔT_range]
+dNdt3 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dNdt for ΔT in ΔT_range]
 
 ρₐ2 = FT(0.5)
-state = P3.get_state(params; F_rim = Fᵣ2, ρ_rim = ρᵣ2)
-dist = P3.get_distribution_parameters(state; L = Lᵢ, N = Nᵢ)
-dLdt4 = [P3.ice_melt(dist, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ2, dt).dLdt for ΔT in ΔT_range]
-dNdt4 = [P3.ice_melt(dist, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ2, dt).dNdt for ΔT in ΔT_range]
+state = P3.get_state(params; F_rim = Fᵣ2, ρ_rim = ρᵣ2, L_ice = Lᵢ, N_ice = Nᵢ)
+logλ = P3.get_distribution_logλ(state)
+dLdt4 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ2, dt).dLdt for ΔT in ΔT_range]
+dNdt4 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ2, dt).dNdt for ΔT in ΔT_range]
 
 # plotting
 fig = Makie.Figure(size = (1500, 500), fontsize=22, linewidth=3)

--- a/docs/src/plots/P3SchemePlots.jl
+++ b/docs/src/plots/P3SchemePlots.jl
@@ -62,7 +62,7 @@ function p3_relations_plot()
 	F_rims = [0.0, 0.5, 0.8]
 	for (i, F_rim) in enumerate(F_rims)
 		color = cl[i]
-		state = P3.get_state(params; F_rim, ρ_rim = ρ_rim₀)
+		state = P3.get_state(params; F_rim, ρ_rim = ρ_rim₀, L_ice = FT(0), N_ice = FT(0))
 		lines_and_vlines!((ax1L, ax2L, ax3L), state, color)
 	end
 
@@ -71,7 +71,7 @@ function p3_relations_plot()
 	ρ_rims = [200.0, 400.0, 800.0]
 	for (i, ρ_rim) in enumerate(ρ_rims)
 		color = cl[i]
-		state = P3.get_state(params; F_rim = F_rim₀, ρ_rim)
+		state = P3.get_state(params; F_rim = F_rim₀, ρ_rim, L_ice = FT(0), N_ice = FT(0))
 		lines_and_vlines!((ax1R, ax2R, ax3R), state, color)
 	end
 

--- a/docs/src/plots/P3TerminalVelocityPlots.jl
+++ b/docs/src/plots/P3TerminalVelocityPlots.jl
@@ -30,11 +30,11 @@ function get_values(
         for j in 1:y_resolution
             F_rim = F_rims[i]
             ρ_rim = ρ_rims[j]
-            state = P3.get_state(params; F_rim, ρ_rim)
-            dist = P3.get_distribution_parameters(state; L, N)
-            V_m[i, j] = P3.ice_terminal_velocity_mass_weighted(dist, Chen2022, ρ_a; use_aspect_ratio = false)
-            V_m_ϕ[i, j] = P3.ice_terminal_velocity_mass_weighted(dist, Chen2022, ρ_a; use_aspect_ratio = true)
-            D_m[i, j] = P3.D_m(dist)
+            state = P3.get_state(params; F_rim, ρ_rim, L_ice = L, N_ice = N)
+            logλ = P3.get_distribution_logλ(state)
+            V_m[i, j] = P3.ice_terminal_velocity_mass_weighted(state, logλ, Chen2022, ρ_a; use_aspect_ratio = false)
+            V_m_ϕ[i, j] = P3.ice_terminal_velocity_mass_weighted(state, logλ, Chen2022, ρ_a; use_aspect_ratio = true)
+            D_m[i, j] = P3.D_m(state, logλ)
             D_m_regimes[i, j] = D_m[i, j]
             ϕᵢ[i, j] = P3.ϕᵢ(state, D_m[i, j])
 

--- a/docs/src/plots/P3Thresholds.jl
+++ b/docs/src/plots/P3Thresholds.jl
@@ -11,7 +11,7 @@ params = CMP.ParametersP3(FT)
 F_rims = FT.(0.0:0.01:0.9)
 ρ_rims = FT.(200.0:10.0:900.0)
 
-get_state2(F_rim, ρ_rim) = P3.get_state(params; F_rim, ρ_rim)
+get_state2(F_rim, ρ_rim) = P3.get_state(params; F_rim, ρ_rim, L_ice = FT(0), N_ice = FT(0))
 
 states = get_state2.(F_rims, ρ_rims')
 

--- a/src/P3_integral_properties.jl
+++ b/src/P3_integral_properties.jl
@@ -1,4 +1,3 @@
-import CloudMicrophysics.DistributionTools as DT
 
 """
     ∫fdD(f, dist; [p = 1e-6], kwargs...)
@@ -44,23 +43,23 @@ julia> import CloudMicrophysics.Parameters as CMP,
 
 julia> params = CMP.ParametersP3(Float64);
 
-julia> state = P3.get_state(params; F_rim = 0.0, ρ_rim = 400.0);
+julia> state = P3.get_state(params; F_rim = 0.0, ρ_rim = 400.0, L_ice = 0.002, N_ice = 1000.0);
 
-julia> dist = P3.get_distribution_parameters(state; L = 0.002, N = 1000.0);
+julia> logλ = P3.get_distribution_logλ(state);
 
-julia> f(D) = D^3 * P3.N′ice(dist, D);  # Define a function to integrate
+julia> f(D) = D^3 * P3.N′ice(state, logλ)(D);  # Define a function to integrate
 
-julia> P3.∫fdD(f, dist; p = 0.01)  # Integrate the function
-0.0008519464332296548
+julia> P3.∫fdD(f, state, logλ; p = 0.01)  # Integrate the function
+0.0008519464332296608
 
-julia> P3.∫fdD(dist; p = 0.01) do D  # Integrate with a `do`-block
-           P3.ice_mass(state, D) * P3.N′ice(dist, D)
+julia> P3.∫fdD(state, logλ; p = 0.01) do D  # Integrate with a `do`-block
+           P3.ice_mass(state, D) * P3.N′ice(state, logλ)(D)
        end
-0.0017027833723511623
+0.0017027833723511712
 ```
 """
-function ∫fdD(f, dist; p = 1e-6, moment_order = 0, kwargs...)
-    return ∫fdD_error(f, dist; p, moment_order, kwargs...)[1]
+function ∫fdD(f, state::P3State, logλ; p = 1e-6, moment_order = 0, kwargs...)
+    return ∫fdD_error(f, state, logλ; p, moment_order, kwargs...)[1]
 end
 
 """
@@ -75,16 +74,16 @@ Integrate the function `f` over the size distribution `dist`
 # Notes
 See [`∫fdD`](@ref), which only returns the value of the integral and not the error, for details.
 """
-function ∫fdD_error(f, dist; p, moment_order = 0, accurate = false, kwargs...)
+function ∫fdD_error(f, state::P3State, logλ; p, moment_order = 0, accurate = false, kwargs...)
     # Get integration bounds
-    bnds = integral_bounds(dist; p, moment_order)
+    bnds = integral_bounds(state, logλ; p, moment_order)
     # Use a more accurate quadrature rule if requested
     accurate && (kwargs = (; rtol = 0, order = 44, kwargs...))
     return QGK.quadgk(f, bnds...; kwargs...)
 end
 
 """
-    integral_bounds(dist::P3Distribution; p, moment_order = 0)
+    integral_bounds(state::P3State, logλ; p, moment_order = 0)
 
 Compute the integration bounds for the P3 size distribution,
 
@@ -96,7 +95,8 @@ Compute the integration bounds for the P3 size distribution,
  are determined by this function.
 
 # Arguments
-- `dist`: The distribution object, passed to [`threshold_tuple`](@ref) to set the integration limits.
+- `state`: [`P3State`](@ref) object
+- `logλ`: The log of the slope parameter [log(1/m)]
 - `p`: The integration bounds are set to the `p`-th and `1-p`-th quantiles of the size distribution.
 - `moment_order`: For integrands proportional to moments of the size distribution, 
     `moment_order` can be used to indicate the order of the moment. 
@@ -106,37 +106,32 @@ Compute the integration bounds for the P3 size distribution,
 # Returns
 - `bnds`: The integration bounds (a `Tuple`), for use in [`QGK.quadgk`].
 """
-function integral_bounds(dist::P3Distribution; p, moment_order = 0)
-    FT = eltype(dist)
+function integral_bounds(state::P3State{FT}, logλ; p, moment_order = 0) where {FT}
     # Get mass thresholds
-    thresholds = threshold_tuple(dist.state)
-    @assert thresholds[1] > 0 "The lower integration threshold (D_th) must be greater than 0"
+    (; D_th, D_gr, D_cr) = get_thresholds_ρ_g(state)
     # Get bounds from quantiles
-    (; log_λ) = dist
-    μ = get_μ(dist) + moment_order
-    D_min = DT.generalized_gamma_quantile(μ, FT(1), exp(log_λ), FT(p))
-    D_max = DT.generalized_gamma_quantile(μ, FT(1), exp(log_λ), FT(1 - p))
+    k = get_μ(state, logλ) + moment_order
+    D_min = DT.generalized_gamma_quantile(k, FT(1), exp(logλ), FT(p))
+    D_max = DT.generalized_gamma_quantile(k, FT(1), exp(logλ), FT(1 - p))
 
     # Only integrate up to the maximum diameter, `D_max`, including intermediate thresholds
     # If `F_rim` is very close to 1, `D_cr` may be greater than `D_max`, in which case it is disregarded.
-    bnds = (D_min, filter(<(D_max), thresholds)..., D_max)
+    bnds = (D_min, filter(<(D_max), (D_th, D_gr, D_cr))..., D_max)
     return bnds
 end
 
 """
-    D_m(dist::P3Distribution)
+    D_m(state::P3State, logλ)
 
 Compute the mass weighted mean particle size [m]
 
 # Parameters
- - `dist`: [`P3Distribution`](@ref) object
+ - `state`: [`P3State`](@ref) object
+ - `logλ`: The log of the slope parameter [log(1/m)]
 """
-function D_m(dist::P3Distribution{FT}) where {FT}
-    (; state, log_λ, log_N₀, L) = dist
-    L < eps(FT) && return FT(0)
-    log∫DmN′dD = log∫DⁿmN′dD(state, log_λ; n = 1)
-
-    return exp(log∫DmN′dD + log_N₀) / L
-    # TODO: Implement `F_liq`-weighted average
-    # return weighted_average(F_liq, exp(log∫DmN′dD_liqfrac + log_N₀), exp(log∫DmN′dD + log_N₀) / L
+function D_m(state, logλ)
+    μ = get_μ(state, logλ)
+    mass_weighted_moment = logmass_gamma_moment(state, μ, logλ; n = 1)
+    log_N₀ = get_logN₀(state.N_ice, μ, logλ)
+    return exp(log_N₀ + mass_weighted_moment) / state.L_ice
 end

--- a/src/P3_size_distribution.jl
+++ b/src/P3_size_distribution.jl
@@ -1,68 +1,16 @@
 
-### --------------------------------- ###
-### ----- P3Distribution STRUCT ----- ###
-### --------------------------------- ###
-
 """
-    P3Distribution{FT}
+    logN′ice(state, logλ)
 
-Distribution of ice particles in size.
-
-# Fields
-$(FIELDS)
+Compute the log of the ice particle number concentration at diameter `D` given the distribution `dist`
 """
-@kwdef struct P3Distribution{FT}
-    "Particle state, see [`P3State`](@ref)"
-    state::P3State{FT}
-
-    # Integral solution parameters
-    "The mass concentration [kg/m³]"
-    L::FT
-    "The number concentration [1/m³]"
-    N::FT
-
-    # Distribution parameters
-    "Logarithm of the slope parameter"
-    log_λ::FT
-    "Logarithm of the intercept parameter"
-    log_N₀::FT
-end
-
-"""
-    get_state(dist::P3Distribution)
-
-Return the particle state from a [`P3Distribution`](@ref) object.
-"""
-get_state(dist::P3Distribution) = dist.state
-
-Base.eltype(::P3Distribution{FT}) where {FT} = FT
-Base.broadcastable(state::P3Distribution) = tuple(state)
-
-"""
-    get_parameters(dist::P3Distribution)
-
-Return the parameters from a [`P3Distribution`](@ref) object.
-"""
-get_parameters(dist::P3Distribution) = get_parameters(get_state(dist))
-
-"""
-    isunrimed(dist::P3Distribution)
-
-Return `true` if the particle state associated with a [`P3Distribution`](@ref) object is unrimed, `false` otherwise.
-"""
-isunrimed(dist::P3Distribution) = isunrimed(get_state(dist))
-
-
-"""
-    log_N′ice(dist, D)
-
-Compute the log of the ice particle number concentration at diameter `D` 
-    given the distribution `dist`
-"""
-function log_N′ice(dist::P3Distribution, D)
-    (; log_N₀, log_λ) = dist
-    μ = get_μ(dist)
-    return log_N₀ + μ * log(D) - exp(log_λ) * D
+function logN′ice(state::P3State, logλ)
+    μ = get_μ(state, logλ)
+    log_N₀ = get_logN₀(state.N_ice, μ, logλ)
+    return function logN′(D)
+        logD = log(D)
+        log_N₀ + μ * logD - exp(logλ + logD)
+    end
 end
 
 """
@@ -70,170 +18,188 @@ end
 
 Compute the ice particle number concentration at diameter `D` given the distribution `dist`
 """
-N′ice(dist::P3Distribution, D) = exp(log_N′ice(dist, D))
+N′ice(state::P3State, logλ) = exp ∘ logN′ice(state, logλ)
 
 
 ### ------------------------------------------------ ###
 ### ----- Obtaining P3 distribution parameters ----- ###
 ### ------------------------------------------------ ###
 
-
 """
-    log_integrate_moment_psd(D₁, D₂, a, b, μ, log_λ)
+    loggamma_inc_moment(D₁, D₂, μ, logλ, [k = 0], [scale = 1])
 
-Computes the log of the integral of the moment of the PSD from `D₁` to `D₂`
+Compute `log(Iᵏ)` where `Iᵏ` is the following integral:
 
-i.e. integral of the form
-    ``∫_{D₁}^{D₂} (aD^b) D^μ e^{-λD} dD``
+    ``I^k = ∫_{D₁}^{D₂} G(D) D^k dD``
+
+ ``G(D) ≡ D^μ e^{-λD}`` is the (unnormalized) gamma kernel, and `k` is an arbitrary exponent.
+
+ If `scale` is provided, `log(scale ⋅ Iᵏ)` is returned.
+
+ With appropriate scaling, we can compute useful quantities like:
+ - the `k`-th moment of the ice PSD,
+    ``M^k = N₀ I^k``
+ - combined power law and moment weighted integrals,
+    ``∫_{D₁}^{D₂} (aD^b) D^n K(D) dD ≡ a I^(b + n)``
+
+# Arguments
+ - `D₁`: The minimum diameter [`m`]
+ - `D₂`: The maximum diameter [`m`]
+ - `μ`: The PSD shape parameter [`-`]
+ - `logλ`: The log of the PSD slope parameter [`log(1/m)`]
+ - `k`: An arbitrary exponent [`-`], default is `0`
+ - `scale`: The scale factor [`-`], default is `1`
+
+# Extended help
+ ## Implementation details
+ We can write `∫_D₁^D₂ G(D) D^k dD`, where `G(D) = D^μ e^{-λD}` as:
+    `∫_D₁^∞ G(D) D^k dD - ∫_D₂^∞ G(D) D^k dD`
+ with the transformation `x = λD`, and `z = μ+k+1`, each term can be written as:
+    `∫_{Dᵢ}^∞ G(D) D^k dD = ∫_{λDᵢ}^∞ x^z e^{-x} dx / λ^z = Γ(z, λDᵢ) / λ^z`
+ where `Γ(z, λDᵢ) = q ⋅ Γ(z)` and `q` is the incomplete gamma function ratio given by
+    `(_, q) = SF.gamma_inc(z, x)`.
+ This means that the integral `∫_{Dᵢ}^∞ G(D) D^k dD` is computed as:
+    `Γ(z) ⋅ q / λ^z`
+ The full integral from `D₁` to `D₂` is then:
+    `Γ(z) ⋅ (q_D₁ - q_D₂) / λ^z`
+ In log-space, this is:
+    `- z log(λ) + logΓ(z) + log(q_D₁ - q_D₂)`
+ 
 """
-function log_integrate_moment_psd(D₁, D₂, a, b, μ, log_λ)
-    b_μ_1 = b + μ + 1
-    (_, q_D₁) = SF.gamma_inc(b_μ_1, exp(log_λ) * D₁)
-    (_, q_D₂) = SF.gamma_inc(b_μ_1, exp(log_λ) * D₂)
-    return log(a) - b_μ_1 * log_λ + SF.loggamma(b_μ_1) + log(abs(q_D₁ - q_D₂))
+function loggamma_inc_moment(D₁, D₂, μ, logλ, k = 0, scale = 1)
+    FT = eltype(logλ)
+    D₁ < D₂ || return log(FT(0))  # return log(0) if D₁ ≥ D₂
+    z = k + μ + 1
+    (_, q_D₁) = SF.gamma_inc(z, exp(logλ) * D₁)
+    (_, q_D₂) = SF.gamma_inc(z, exp(logλ) * D₂)
+    return -z * logλ + SF.loggamma(z) + log(q_D₁ - q_D₂) + log(FT(scale))
 end
 
 """
-    get_μ(dist)
-    get_μ(state, log_λ)
-    get_μ(params, log_λ)
+    loggamma_moment(μ, logλ; [k = 0], [scale = 1])
+
+Compute `log(scale ⋅ ∫_0^∞ G(D) D^k dD)`, 
+ where `G(D) ≡ D^μ e^{-λD}` is the (unnormalized) gamma kernel, 
+ `k` is an arbitrary exponent, and `scale` is a scale factor.
+
+# Arguments
+ - `μ`: The PSD shape parameter [`-`]
+ - `logλ`: The log of the PSD slope parameter [`log(1/m)`]
+
+# Keyword arguments
+- `k`: An arbitrary exponent [`-`], default is `0`
+- `scale`: The scale factor [`-`], default is `1`.
+
+The implementation follows the same logic as [`loggamma_inc_moment`](@ref),
+    but with `D₁ = 0` and `D₂ = ∞`, which implies `q_D₁ = 1` and `q_D₂ = 0`.
+"""
+function loggamma_moment(μ, logλ; k = 0, scale = 1)
+    FT = eltype(μ)
+    z = k + μ + 1
+    return -z * logλ + SF.loggamma(z) + log(FT(scale))
+end
+
+"""
+    get_μ(slope::CMP.SlopeLaw, logλ)
+    get_μ(state::P3State, logλ)
     
 Compute the slope parameter μ
 
 # Arguments
-- `dist`: [`P3Distribution`](@ref) object
-- `state`: [`P3State`](@ref) object
+- `slope`: [`CMP.SlopeLaw`](@ref) object, or
+- `state`: [`P3State`](@ref) object, or
 - `params`: [`CMP.ParametersP3`](@ref) object
-- `log_λ`: The log of the slope parameter [log(1/m)]
+- `logλ`: The log of the slope parameter [log(1/m)]
 """
-get_μ(dist::P3Distribution) = get_μ(get_state(dist), dist.log_λ)
-get_μ(state::P3State, log_λ) = get_μ(get_parameters(state), log_λ)
-get_μ(params::CMP.ParametersP3, log_λ) = get_μ(params.slope, log_λ)
-
-get_μ((; a, b, c, μ_max)::CMP.SlopePowerLaw, log_λ) =
-    clamp(a * exp(log_λ)^b - c, 0, μ_max)
-get_μ((; μ)::CMP.SlopeConstant, _) = μ
+get_μ((; a, b, c, μ_max)::CMP.SlopePowerLaw, logλ) = clamp(a * exp(logλ)^b - c, 0, μ_max)
+get_μ((; μ)::CMP.SlopeConstant, logλ...) = μ
+get_μ((; params)::P3State, logλ) = get_μ(params.slope, logλ)
 
 """
-    log∫DⁿmN′dD(state, log_λ; n = 0)
+    logmass_gamma_moment(state, logλ; [n=0])
 
-Compute `log(∫_0^∞ Dⁿ m(D) N′(D) dD)` given the `state` and `log_λ`.
+Compute `log(∫_0^∞ Dⁿ m(D) N′(D) dD)` given the `state` and `logλ`.
     This is the log of the `n`-th moment of the mass-weighted PSD.
 
 # Arguments
-- `state::P3State`: [`P3State`](@ref) object
-- `log_λ`: The log of the slope parameter [log(1/m)]
-- `n`: The order of the moment [dimensionless]
-
-# Note:
-- For `n = 0`, this evaluates to `log(L/N₀)`, see [`log_L_div_N₀`](@ref)
-- For `n = 1`, this evaluates to the (unnormalized) mass-weighted mean particle size, see [`D_m`](@ref)
-"""
-function log∫DⁿmN′dD(state::P3State{FT}, log_λ; n = 0) where {FT}
-    @assert n ≥ 0 "The moment order must be non-negative"
-    (; F_rim) = state
-    (; D_th, D_gr, D_cr, ρ_g) = get_thresholds_ρ_g(state)
-    (; ρ_i, mass) = state.params
-    (; α_va, β_va) = mass
-
-    μ = get_μ(state, log_λ)
-    ∞ = FT(Inf)
-    G = log_integrate_moment_psd
-    # G_liqfrac = G(FT(0), FT(Inf), ρ_l * FT(π) / 6, 3 + n, μ, log_λ)  # TODO: Implement liquid fraction (need to do weighted average)
-    G_small_spherical = G(0, D_th, ρ_i * π / 6, 3 + n, μ, log_λ)
-    if isunrimed(state)
-        G_large_unrimed = G(D_th, ∞, α_va, β_va + n, μ, log_λ)
-        return LogExpFunctions.logsumexp((G_small_spherical, G_large_unrimed))
-    else
-        G_dense_nonspherical = G(D_th, D_gr, α_va, β_va + n, μ, log_λ)
-        G_graupel = G(D_gr, D_cr, ρ_g * π / 6, 3 + n, μ, log_λ)
-        G_partially_rimed = G(D_cr, ∞, α_va / (1 - F_rim), β_va + n, μ, log_λ)
-        return LogExpFunctions.logsumexp((
-            G_small_spherical,
-            G_dense_nonspherical,
-            G_graupel,
-            G_partially_rimed,
-        ))
-    end
-end
-
-
-"""
-    log_L_div_N₀(state, log_λ)
-
-Compute `log(L/N₀)` given the `state` and `log_λ`
-"""
-log_L_div_N₀(state::P3State, log_λ) = log∫DⁿmN′dD(state, log_λ; n = 0)
-
-"""
-    log_N_div_N₀(state, log_λ)
-    log_N_div_N₀(slope, log_λ)
-
-Compute `log(N/N₀)` given either the `state` or the `slope` parameterization, and `log_λ`
-
-Note: This function is equivalent to `log_integrate_moment_psd(0, Inf, 1, 0, μ, log_λ)`
-"""
-log_N_div_N₀(state::P3State, log_λ) = log_N_div_N₀(get_parameters(state), log_λ)
-log_N_div_N₀(params::CMP.ParametersP3, log_λ) = log_N_div_N₀(params.slope, log_λ)
-function log_N_div_N₀(slope::CMP.SlopeLaw, log_λ)
-    μ = get_μ(slope, log_λ)
-    return SF.loggamma(μ + 1) - (μ + 1) * log_λ
-end
-
-"""
-    log_L_div_N(state, log_λ)
-
-Compute `log(L/N)` given the `state` (or `params`) and `log_λ`
-
-# Arguments
-- `state::P3State`: [`P3State`](@ref) object, or
-- `params`: [`CMP.ParametersP3`](@ref) object, and
-- `log_λ`: The log of the slope parameter [log(1/m)]
-"""
-log_L_div_N(state::P3State, log_λ) = log_L_div_N₀(state, log_λ) - log_N_div_N₀(state, log_λ)
-
-"""
-    get_log_N₀(state; N, log_λ)
-    get_log_N₀(params; N, log_λ)
-
-Compute `log(N₀)` given the `state`, `N`, and `log_λ`
-
-# Arguments
-- `state::P3State`: [`P3State`](@ref) object, or
-- `params`: [`CMP.ParametersP3`](@ref) object
+- `state`: [`P3State`](@ref) object
+- `μ`: The shape parameter [`-`]
+- `logλ`: The log of the slope parameter [log(1/m)]
 
 # Keyword arguments
-- `N`: The number concentration [1/m³]
-- `log_λ`: The log of the slope parameter [log(1/m)]
+- `n`: The order of the moment, default is `0`
+
+# Note:
+- For `n = 0`, this evaluates to `log(L/N₀)`
+- For `n = 1`, this evaluates to the (unnormalized) mass-weighted mean particle size, see [`D_m`](@ref)
 """
-function get_log_N₀(state::P3State; N, log_λ)
-    get_log_N₀(get_parameters(state); N, log_λ)
-end
-function get_log_N₀(params::CMP.ParametersP3; N, log_λ)
-    μ = get_μ(params, log_λ)
-    return log(N) - SF.loggamma(μ + 1) + (μ + 1) * log_λ
+function logmass_gamma_moment(state::P3State, μ, logλ; n = 0)
+    segments = get_segments(state)
+    return LogExpFunctions.logsumexp(
+        let (D_min, D_max) = segment, (a, b) = ice_mass_coeffs(state, (D_min + D_max) / 2)
+            loggamma_inc_moment(D_min, D_max, μ, logλ, b + n, a)
+        end for segment in segments
+    )
 end
 
 """
-    get_distribution_parameters(state; L, N, [log_λ_min, log_λ_max])
+    logLdivN(state, logλ)
+
+Compute `log(L/N)` given the `state` and `logλ`
+
+# Arguments
+- `state`: [`P3State`](@ref) object
+- `logλ`: The log of the slope parameter [log(1/m)]
+"""
+function logLdivN(state::P3State, logλ)
+    μ = get_μ(state, logλ)
+    logLdivN₀ = logmass_gamma_moment(state, μ, logλ; n = 0)
+    logNdivN₀ = loggamma_moment(μ, logλ; k = 0)
+    return logLdivN₀ - logNdivN₀
+end
+
+"""
+    get_logN₀(N_ice, μ, logλ)
+
+Compute `log(N₀)` given the `state`, `N`, and `logλ`,
+
+        N  = N₀ ∫ G(D) dD
+    log N₀ = log N - log(∫G(D) dD) 
+           = log(N) - log( ∫D^μ e^{-λD} dD )
+           = log(N) - M⁰
+
+# Arguments
+- `N_ice`: The number concentration [1/m³]
+- `μ`: The shape parameter [`-`]
+- `logλ`: The log of the slope parameter [log(1/m)]
+"""
+function get_logN₀(N_ice, μ, logλ)
+    logNdivN₀ = loggamma_moment(μ, logλ; k = 0)
+    logN₀ = log(N_ice) - logNdivN₀
+    return logN₀
+end
+
+"""
+    get_distribution_logλ(params, L_ice, N_ice, F_rim, ρ_rim; [logλ_min, logλ_max])
+    get_distribution_logλ(state; [logλ_min, logλ_max])
 
 Solve for the distribution parameters given the state, and the mass (`L`) and number (`N`) concentrations.
 
 The assumed distribution is of the form
 
 ```math
-N(D) = N₀ D^μ e^{-λD}
+N′(D) = N₀ D^μ e^{-λD}
 ```
-where `N(D)` is the number concentration at diameter `D` and `μ` is the slope parameter.
+where `N′(D)` is the number concentration at diameter `D` and `μ` is the slope parameter.
     The slope parameter is parameterized, e.g. [`CMP.SlopePowerLaw`](@ref) or [`CMP.SlopeConstant`](@ref).
 
-This algorithm solves for `log_λ = log(λ)` and `log_N₀ = log(N₀)` 
-    given `L` and `N` by solving the equations:
+This algorithm solves for `logλ = log(λ)` and `log_N₀ = log(N₀)` 
+    given `L_ice` and `N_ice` by solving the equations:
 
 ```math
 \\begin{align*}
-\\log(L) &= \\log ∫_0^∞ m(D) N(D)\\ \\mathrm{d}D, \\\\
-\\log(N) &= \\log ∫_0^∞ N(D)\\ \\mathrm{d}D, \\\\
+\\log(L) &= \\log ∫_0^∞ m(D) N′(D)\\ \\mathrm{d}D, \\\\
+\\log(N) &= \\log ∫_0^∞ N′(D)\\ \\mathrm{d}D, \\\\
 \\end{align*}
 ```
 where `m(D)` is the mass of a particle at diameter `D` (see [`ice_mass`](@ref)).
@@ -242,107 +208,65 @@ where `m(D)` is the mass of a particle at diameter `D` (see [`ice_mass`](@ref)).
 
 # Arguments
 - `state`: [`P3State`](@ref) object
+- `params`: [`CMP.ParametersP3`](@ref) object
+- `L_ice`: The mass concentration [kg/m³]
+- `N_ice`: The number concentration [1/m³]
+- `F_rim`: The rime mass fraction
+- `ρ_rim`: The rime density
 
 # Keyword arguments
-- `L`: The mass concentration [kg/m³]
-- `N`: The number concentration [1/m³]
-- `search_bound_min`: The minimum value of the search bounds [log(1/m)], default is `log(1e1)`
-- `search_bound_max`: The maximum value of the search bounds [log(1/m)], default is `log(1e7)`
-
-# Returns
-- [`P3Distribution`](@ref) object with the distribution parameters `log_λ` and `log_N₀`
-
-# Examples
-
-```jldoctest
-julia> import CloudMicrophysics.Parameters as CMP,
-              CloudMicrophysics.P3Scheme   as P3
-
-julia> params = CMP.ParametersP3(Float64);
-
-julia> state = P3.get_state(params; F_rim = 0.0, ρ_rim = 400.0);
-
-julia> dist = P3.get_distribution_parameters(state; L = 1e-3, N = 1e3)
-P3Distribution{Float64}
-├── state: is unrimed
-├── log_λ = 5.4897008376530385 [log(1/m)]
-└── log_N₀ = 12.397456116635176 [log(1/m^3)]
-```
+- `logλ_min`: The minimum value of the search bounds [log(1/m)], default is `log(1e1)`
+- `logλ_max`: The maximum value of the search bounds [log(1/m)], default is `log(1e7)`
 """
-function get_distribution_parameters(
-    state::P3State{FT};
-    L,
-    N,
-    log_λ_min = log(1e1),
-    log_λ_max = log(1e7),
+function get_distribution_logλ(
+    state::P3State{FT}; logλ_min = log(1e1), logλ_max = log(1e7),
 ) where {FT}
-    target_log_LdN = log(L) - log(N)
+    target_log_LdN = log(state.L_ice) - log(state.N_ice)
 
-    shape_problem(log_λ) = log_L_div_N(state, log_λ) - target_log_LdN
+    shape_problem(logλ) = logLdivN(state, logλ) - target_log_LdN
 
     # Find slope parameter
     sol = RS.find_zero(
         shape_problem,
-        RS.SecantMethod(FT(log_λ_min), FT(log_λ_max)),
+        RS.SecantMethod(FT(logλ_min), FT(logλ_max)),
         RS.CompactSolution(),
         RS.RelativeSolutionTolerance(eps(FT)),
         50,
     )
-    log_λ = sol.root
-
-    log_N₀ = get_log_N₀(state; N, log_λ)
-
-    return P3Distribution(; state, L, N, log_λ, log_N₀)
+    return sol.root  # logλ
+end
+function get_distribution_logλ(params::CMP.ParametersP3, L_ice, N_ice, F_rim, ρ_rim; kwargs...)
+    state = get_state(params; L_ice, N_ice, F_rim, ρ_rim)
+    return get_distribution_logλ(state; kwargs...)
 end
 
 """
-    get_distribution_parameters_all_solutions(state; L, N)
+    get_distribution_logλ_all_solutions(state; L, N)
 
-Find all solutions for `log_λ` given the `state` ([`P3State`](@ref)), `L`, and `N`.
+Find all solutions for `logλ` given the `state` ([`P3State`](@ref)), `L`, and `N`.
 
 !!! note "Usage"
     This function is experimental, and usually only relevant for the
     [`SlopePowerLaw`](@ref) parameterization, which can have multiple solutions
-    for `log_λ` for a given `log_L` and `log_N`.
+    for `logλ` for a given `log_L` and `log_N`.
 """
-function get_distribution_parameters_all_solutions(
-    state::P3State{FT};
-    L,
-    N,
-) where {FT}
+function get_distribution_logλ_all_solutions(state::P3State)
     # Find bounds by evaluating function incrementally, then apply root finding with bounds above and below zero-point
-    target_log_LdN = log(L) - log(N)
+    target_log_LdN = log(state.L_ice) - log(state.N_ice)
 
-    shape_problem(log_λ) = log_L_div_N(state, log_λ) - target_log_LdN
+    shape_problem(logλ) = logLdivN(state, logλ) - target_log_LdN
 
     Δλ = 0.01
     λs = 10.0 .^ (2.0:Δλ:6.0)
-    λ_bnds = Tuple[]
+    logλ_bnds = Tuple[]
     # Loop over λs and find where shape_problem changes sign
     for i in 1:(length(λs) - 1)
         if shape_problem(log(λs[i])) * shape_problem(log(λs[i + 1])) < 0
-            push!(λ_bnds, (λs[i], λs[i + 1]))
+            push!(logλ_bnds, (log(λs[i]), log(λs[i + 1])))
         end
     end
 
     # Apply root finding with bounds above and below zero-point
-    dists = P3Distribution[]
-    for (λ_min, λ_max) in λ_bnds
-        log_λ_min, log_λ_max = log(λ_min), log(λ_max)
-        dist = get_distribution_parameters(state; L, N, log_λ_min, log_λ_max)
-        push!(dists, dist)
-    end
-    return dists
-end
-
-### ----------------- ###
-### ----- UTILS ----- ###
-### ----------------- ###
-
-function Base.show(io::IO, p3s::P3Distribution{FT}) where {FT}
-    rimed = isunrimed(p3s) ? "unrimed" : "rimed"
-    println(io, "P3Distribution{$FT}")
-    println(io, "├── state: is $rimed")
-    println(io, "├── log_λ = $(p3s.log_λ) [log(1/m)]")
-    println(io, "└── log_N₀ = $(p3s.log_N₀) [log(1/m^3)]")
+    logλs = [get_distribution_logλ(state; logλ_min, logλ_max) for (logλ_min, logλ_max) in logλ_bnds]
+    return logλs
 end

--- a/test/ventilation_tests.jl
+++ b/test/ventilation_tests.jl
@@ -14,9 +14,11 @@ function test_ventilation_factor(FT)
         vel = CMP.Chen2022VelType(FT)
         aps = CMP.AirProperties(FT)
         F_rim = FT(0.5)  # Riming fraction [-]
-        ρ_rim = FT(500)    # Riming density [kg/m³]
+        ρ_rim = FT(500)  # Riming density [kg/m³]
+        L_ice = FT(0.22) # Ice mass concentration [kg/m³] (not used in this test)
+        N_ice = FT(1e6)  # Ice number concentration [1/m³] (not used in this test)
         ρₐ = FT(1.2)     # Air density [kg/m³]
-        state = P3.get_state(params; F_rim, ρ_rim)
+        state = P3.get_state(params; F_rim, ρ_rim, L_ice, N_ice)
         vent = state.params.vent
         v_term = P3.ice_particle_terminal_velocity(state, vel, ρₐ)
         vent_factor = CO.ventilation_factor(vent, aps, v_term)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR makes necessary changes to have P3 sources be compatible with broadcast expressions in `ClimaAtmos.jl`. Notably, I completely remove the `P3Distribution` struct, which was intended to simplify (and reduce errors) in internal calculations. Unfortunately, because this struct bundled the `P3State`, which bundled the `CMP.ParametersP3`, a broadcast expression that would find the P3 distribution parameters would store unnecessarily much data (notably copies of all the P3 parameters).

Further, because `F_rim` in `P3State` is computed from `L_rim / L_ice`, it's a bit odd to store `L_ice` in `P3Distribution` and `F_rim` in `P3State`. Thus, it makes more sense for `L_ice` (and `N_ice`) to live in `P3State` (they are, after all, the prognostic "P3 State" variables). This leaves us with only `log_λ` and `log_N₀` left in `P3Distribution`. Since the latter is computed from the former, it can also be left out. Thus we're left with little reason to have a `P3Distribution` struct at all.

The new setup is thus to store `params`, `L_ice`, `N_ice`, `F_rim`, `ρ_rim` in `P3State`. The `P3State` is only used internally, and should not be included in any "external API". There should be minimal overhead by using this struct instead of separate arguments to internal functions.

For distribution-dependent functions, we now pass `state, logλ` where we previously passed `dist` (`P3Distribution`).


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
P3_particle_properties.jl:
- move `L` and `N` to `P3State` struct (now called `L_ice` and `N_ice`)
- update `get_state` to take `L_ice` and `N_ice` as keyword arguments
- remove `get_parameters`, `threshold_tuple`
- add `get_segments`. used for analytical integration over mass
P3_size_distribution.jl:
- rename `log∫DⁿmN′dD` -> `logmass_gamma_moment`
    - refactored to fetch mass coeffs using `ice_mass_coeffs`
- rename `log_integrate_moment_psd` -> `loggamma_inc_moment`
- rename `log_L_div_N` -> `logLdivN`
- remove `log_L_div_N₀`, `log_N_div_N₀` (see `logLdivN` for calculation)
- remove `P3Distribution` struct
  - implies that these functions now take `state, logλ` as arguments:
    `logN′ice`, `N′ice`, `get_μ`, `logmass_gamma_moment`, `logLdivN`,
    `∫fdD`, `integral_bounds`, `D_m`, `ice_terminal_velocity_number_weighted`,
    `ice_terminal_velocity_mass_weighted`
- remove `get_distribution_parameters` (returned `P3Distribution` struct)
- replaced by `get_distribution_logλ` (now returns `logλ`, Float value)
- similarly, replace `get_distribution_parameters_all_solutions` by
    `get_distribution_logλ_all_solutions` (now returns vector of `logλ` values)
Elsewhere:
- update docs / docs-plots
- update tests

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
