### PR TITLE
rft: separate mass & number weighted ice terminal velocity

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -183,7 +183,8 @@ These methods integrate over the particle size distribution.
 ```@docs
 P3Scheme.D_m
 P3Scheme.ice_particle_terminal_velocity
-P3Scheme.ice_terminal_velocity
+P3Scheme.ice_terminal_velocity_number_weighted
+P3Scheme.ice_terminal_velocity_mass_weighted
 P3Scheme.het_ice_nucleation
 P3Scheme.ice_melt
 ```

--- a/docs/src/plots/P3TerminalVelocityPlots.jl
+++ b/docs/src/plots/P3TerminalVelocityPlots.jl
@@ -34,13 +34,8 @@ function get_values(
             ρ_r = ρ_rs[j]
             state = P3.get_state(params; F_rim, ρ_r)
             dist = P3.get_distribution_parameters(state; L, N)
-
-            V_m[i, j] = P3.ice_terminal_velocity(
-                dist, Chen2022, ρ_a; use_aspect_ratio = false,
-            )[2]
-            V_m_ϕ[i, j] =
-                P3.ice_terminal_velocity(dist, Chen2022, ρ_a; use_aspect_ratio = true)[2]
-
+            V_m[i, j] = P3.ice_terminal_velocity_mass_weighted(dist, Chen2022, ρ_a; use_aspect_ratio = false)
+            V_m_ϕ[i, j] = P3.ice_terminal_velocity_mass_weighted(dist, Chen2022, ρ_a; use_aspect_ratio = true)
             D_m[i, j] = P3.D_m(dist)
             D_m_regimes[i, j] = D_m[i, j]
             ϕᵢ[i, j] = P3.ϕᵢ(state, D_m[i, j])


### PR DESCRIPTION
To simplify integration with `ClimaAtmos.jl` / `KiD`, I split `ice_terminal_velocity` into `ice_terminal_velocity_mass_weighted` and `P3Scheme.ice_terminal_velocity_number_weighted`.

In the previous code, these calculations were separate integrals, bundled in the same function.
Since it's a bit awkward to return more than one value at a time to broadcast expressions, I split these so we instead call them one at a time