### PR TITLE
Update non-equilibrium microphysics API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.23.00"
+version = "0.24.00"
 
 [deps]
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"

--- a/parcel/ParcelTendencies.jl
+++ b/parcel/ParcelTendencies.jl
@@ -236,15 +236,12 @@ end
 function condensation(params::NonEqCondParams_simple, PSD, state, ρ_air)
 
     FT = eltype(state)
-    (; Sₗ, T, qₗ, qᵥ, qᵢ) = state
+    (; Sₗ, qₗ, qᵥ) = state
     (; tps, liquid) = params
 
     q_sat_liq = max(Sₗ * qᵥ - qᵥ, 0)
-    q_sat = TD.PhasePartition(FT(0), q_sat_liq, FT(0))
 
-    q = TD.PhasePartition(qᵥ + qₗ + qᵢ, qₗ, qᵢ)
-
-    new_q = MNE.conv_q_vap_to_q_liq_ice(liquid, q_sat, q)
+    new_q = MNE.conv_q_vap_to_q_liq_ice(liquid, q_sat_liq, qₗ)
 
     return new_q
 end
@@ -257,7 +254,7 @@ function condensation(params::NonEqCondParams, PSD, state, ρ_air)
 
     q = TD.PhasePartition(qᵥ + qₗ + qᵢ, qₗ, qᵢ)
 
-    cond_rate = MNE.conv_q_vap_to_q_liq_ice_MM2015(liquid, tps, q, ρ_air, T)
+    cond_rate = MNE.conv_q_vap_to_q_liq_ice_MM2015(liquid, tps, q, FT(0), FT(0), ρ_air, T)
 
     # using same limiter as ClimaAtmos for now
     return ifelse(
@@ -289,18 +286,14 @@ end
 
 function deposition(params::NonEqDepParams_simple, PSD, state, ρ_air)
     FT = eltype(state)
-    (; T, Sₗ, qₗ, qᵥ, qᵢ) = state
+    (; T, Sₗ, qᵥ, qᵢ) = state
 
     (; tps, ice) = params
 
     Sᵢ = S_i(tps, T, Sₗ)
     q_sat_ice = max(Sᵢ * qᵥ - qᵥ, 0)
 
-    q_sat = TD.PhasePartition(FT(0), FT(0), q_sat_ice)
-
-    q = TD.PhasePartition(qᵥ + qₗ + qᵢ, qₗ, qᵢ)
-
-    new_q = MNE.conv_q_vap_to_q_liq_ice(ice, q_sat, q)
+    new_q = MNE.conv_q_vap_to_q_liq_ice(ice, q_sat_ice, qᵢ)
 
     return new_q
 end
@@ -313,7 +306,7 @@ function deposition(params::NonEqDepParams, PSD, state, ρ_air)
 
     q = TD.PhasePartition(qᵥ + qₗ + qᵢ, qₗ, qᵢ)
 
-    dep_rate = MNE.conv_q_vap_to_q_liq_ice_MM2015(ice, tps, q, ρ_air, T)
+    dep_rate = MNE.conv_q_vap_to_q_liq_ice_MM2015(ice, tps, q, FT(0), FT(0), ρ_air, T)
 
     # using same limiter as ClimaAtmos for now
     return ifelse(

--- a/test/gpu_tests.jl
+++ b/test/gpu_tests.jl
@@ -120,14 +120,23 @@ end
             liquid,
             tps,
             TD.PhasePartition(qᵥ_sl[i]),
+            FT(0),
+            FT(0),
             ρ[i],
             T[i],
         )
-        output[2, i] = CMN.conv_q_vap_to_q_liq_ice(
-            ice,
-            TD.PhasePartition(FT(0), FT(0), qᵢ_s[i]),
-            TD.PhasePartition(FT(0), FT(0), qᵢ[i]),
+        output[2, i] = CMN.conv_q_vap_to_q_liq_ice_MM2015(
+            liquid,
+            tps,
+            qᵥ_sl[i],
+            FT(0),
+            FT(0),
+            FT(0),
+            FT(0),
+            ρ[i],
+            T[i],
         )
+        output[3, i] = CMN.conv_q_vap_to_q_liq_ice(ice, qᵢ_s[i], qᵢ[i])
     end
 end
 
@@ -840,7 +849,7 @@ function test_gpu(FT)
     end
 
     @testset "non-equilibrium microphysics kernels" begin
-        dims = (2, 1)
+        dims = (3, 1)
         (; output, ndrange) = setup_output(dims, FT)
 
         ρ = ArrayType([FT(0.8)])
@@ -854,7 +863,8 @@ function test_gpu(FT)
 
         # test that nonequilibrium cloud formation is callable and returns a reasonable value
         @test Array(output)[1] ≈ FT(3.763783850665844e-5)
-        @test Array(output)[2] ≈ FT(-1e-4)
+        @test Array(output)[2] ≈ FT(3.763783850665844e-5)
+        @test Array(output)[3] ≈ FT(-1e-4)
     end
 
     @testset "Chen 2022 terminal velocity kernels" begin

--- a/test/microphysics_noneq_tests.jl
+++ b/test/microphysics_noneq_tests.jl
@@ -28,12 +28,7 @@ function test_microphysics_noneq(FT)
 
         for fr in frac
             q_liq = q_liq_sat * fr
-
-            TT.@test CMNe.conv_q_vap_to_q_liq_ice(
-                liquid,
-                TD.PhasePartition(FT(0), q_liq_sat, FT(0)),
-                TD.PhasePartition(FT(0), q_liq, FT(0)),
-            ) ≈ (1 - fr) * q_liq_sat / _τ_cond_evap
+            TT.@test CMNe.conv_q_vap_to_q_liq_ice(liquid, q_liq_sat, q_liq) ≈ (1 - fr) * q_liq_sat / _τ_cond_evap
         end
     end
 
@@ -46,12 +41,7 @@ function test_microphysics_noneq(FT)
 
         for fr in frac
             q_ice = q_ice_sat * fr
-
-            TT.@test CMNe.conv_q_vap_to_q_liq_ice(
-                ice,
-                TD.PhasePartition(FT(0), FT(0), q_ice_sat),
-                TD.PhasePartition(FT(0), FT(0), q_ice),
-            ) ≈ (1 - fr) * q_ice_sat / _τ_cond_evap
+            TT.@test CMNe.conv_q_vap_to_q_liq_ice(ice, q_ice_sat, q_ice) ≈ (1 - fr) * q_ice_sat / _τ_cond_evap
         end
     end
 
@@ -70,21 +60,24 @@ function test_microphysics_noneq(FT)
 
         #! format: off
         # test sign
-        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(liquid, tps, qₚ(FT(0.5 * qᵥ_sl)), ρ, T) < FT(0)
-        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(liquid, tps, qₚ(FT(1.5 * qᵥ_sl)), ρ, T) > FT(0)
-        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(liquid, tps, qₚ(      qᵥ_sl), ρ, T) ≈ FT(0)
+        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(liquid, tps, qₚ(FT(0.5 * qᵥ_sl)), FT(0), FT(0), ρ, T) < FT(0)
+        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(liquid, tps, qₚ(FT(1.5 * qᵥ_sl)), FT(0), FT(0), ρ, T) > FT(0)
+        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(liquid, tps, qₚ(         qᵥ_sl),  FT(0), FT(0), ρ, T) ≈ FT(0)
 
-        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(ice, tps, qₚ(FT(0.5 * qᵥ_si)), ρ, T) < FT(0)
-        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(ice, tps, qₚ(FT(1.5 * qᵥ_si)), ρ, T) > FT(0)
-        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(ice, tps, qₚ(      qᵥ_si), ρ, T) ≈ FT(0)
+        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(ice, tps, qₚ(FT(0.5 * qᵥ_si)), FT(0), FT(0), ρ, T) < FT(0)
+        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(ice, tps, qₚ(FT(1.5 * qᵥ_si)), FT(0), FT(0), ρ, T) > FT(0)
+        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(ice, tps, qₚ(         qᵥ_si),  FT(0), FT(0), ρ, T) ≈ FT(0)
 
         # smoke test for values
-        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(liquid, tps, qₚ(FT(1.2 * qᵥ_sl)), ρ, T) ≈ 3.7631e-5 rtol = 1e-6
-        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(ice,    tps, qₚ(FT(1.2 * qᵥ_si)), ρ, T) ≈ 3.2356777e-5 rtol = 1e-6
+        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(liquid, tps, qₚ(FT(1.2 * qᵥ_sl)), FT(0), FT(0), ρ, T) ≈ 3.7631e-5 rtol = 1e-6
+        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(ice,    tps, qₚ(FT(1.2 * qᵥ_si)), FT(0), FT(0), ρ, T) ≈ 3.2356777e-5 rtol = 1e-6
+
+        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(liquid, tps, FT(1.2 * qᵥ_sl), FT(0), FT(0), FT(0), FT(0), ρ, T) ≈ 3.7631e-5 rtol = 1e-6
+        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(ice,    tps, FT(1.2 * qᵥ_si), FT(0), FT(0), FT(0), FT(0), ρ, T) ≈ 3.2356777e-5 rtol = 1e-6
 
         # ice grows faster than liquid
-        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(liquid, tps, qₚ(FT(1.2 * qᵥ_sl)), ρ, T) <
-                 CMNe.conv_q_vap_to_q_liq_ice_MM2015(ice,    tps, qₚ(FT(1.2 * qᵥ_sl)), ρ, T)
+        TT.@test CMNe.conv_q_vap_to_q_liq_ice_MM2015(liquid, tps, qₚ(FT(1.2 * qᵥ_sl)), FT(0), FT(0), ρ, T) <
+                 CMNe.conv_q_vap_to_q_liq_ice_MM2015(ice,    tps, qₚ(FT(1.2 * qᵥ_sl)), FT(0), FT(0), ρ, T)
 
         #! format: on
     end

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -271,22 +271,20 @@ function benchmark_test(FT)
 
     # non-equilibrium
     bench_press(FT, CMN.τ_relax, (liquid,), 15)
+    bench_press(FT, CMN.conv_q_vap_to_q_liq_ice, (ice, FT(2e-3), FT(1e-3)), 12)
     bench_press(
         FT,
-        CMN.conv_q_vap_to_q_liq_ice,
-        (
-            ice,
-            TD.PhasePartition(FT(0), FT(0), FT(0.002)),
-            TD.PhasePartition(FT(0), FT(0), FT(0.001)),
-        ),
-        12,
+        CMN.conv_q_vap_to_q_liq_ice_MM2015,
+        (liquid, tps, TD.PhasePartition(FT(0.00145)), FT(0), FT(0), FT(0.8), FT(263)),
+        70,
     )
     bench_press(
         FT,
         CMN.conv_q_vap_to_q_liq_ice_MM2015,
-        (liquid, tps, TD.PhasePartition(FT(0.00145)), FT(0.8), FT(263)),
+        (liquid, tps, FT(0.00145), FT(0), FT(0), FT(0), FT(0), FT(0.8), FT(263)),
         70,
     )
+
 
     # 0-moment
     bench_press(FT, CM0.remove_precipitation, (p0m, q), 12)


### PR DESCRIPTION
This PR adds an option to call non-equilibrium cloud formation without using the `TD.PhasePartition`. This is a breaking change for the API.
