### PR TITLE
Add Julia v1.11 to CI

### DIFF
--- a/.github/workflows/CodeCov.yml
+++ b/.github/workflows/CodeCov.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Julia
       uses: julia-actions/setup-julia@latest
       with:
-        version: '1.10'
+        version: '1.11'
 
     - name: Test with coverage
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - '1.10'
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
+        version: ['1.10', '1.11']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        exclude:
+          - os: windows-latest
+            version: '1.11'
+        include:
+          - os: windows-2022
+            version: '1.11'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/cache@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.10'
+          version: '1.11'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/docs/src/IceNucleationParcel0D.md
+++ b/docs/src/IceNucleationParcel0D.md
@@ -463,8 +463,17 @@ and `stochastic` (solid lines) parameterization options. We show results for two
 ```
 ![](frostenberg_immersion_freezing.svg)
 
-Below, we show how the non-equilibrium formulation is able to represent the Wegener-Bergeron-Findeisen (WBF) regime in the parcel model. These plots show the liquid supersaturation percent, ice supersaturation percent, temperature, specific humidity `q_{vap}`, specific content of liquid `q_{liq}`, and specific content of ice `q_{ice}` over time. When the supersaturation is negative evaporation/sublimation occurs and when it is positive condensation/deposition occurs. Because the water vapor pressure in the parcel is greater than the saturation water vapor pressure of liquid but larger than that of ice, liquid evaporates while ice grows.
+Below, we show how the non-equilibrium formulation is able to represent the
+Wegener-Bergeron-Findeisen (WBF) regime in the parcel model.
+These plots show the liquid supersaturation, ice supersaturation,
+temperature, specific humidity `q_{vap}`, specific content of liquid `q_{liq}`,
+and specific content of ice `q_{ice}` over time.
+When the supersaturation is negative evaporation/sublimation occurs,
+and when it is positive condensation/deposition occurs.
+In the example below, the water vapor pressure is smaller than the saturation water vapor pressure of liquid
+but larger than that of ice, and as a result liquid water evaporates while ice grows.
 
 ```@example
   include("../../parcel/Example_NonEq.jl")
 ```
+![](noneq_parcel.svg)

--- a/parcel/Example_NonEq.jl
+++ b/parcel/Example_NonEq.jl
@@ -2,7 +2,6 @@ import OrdinaryDiffEq as ODE
 import CairoMakie as MK
 import Thermodynamics as TD
 import CloudMicrophysics as CM
-import CloudMicrophysics.CloudDiagnostics as CD
 import CloudMicrophysics.Parameters as CMP
 import ClimaParams as CP
 
@@ -10,10 +9,19 @@ FT = Float64
 
 include(joinpath(pkgdir(CM), "parcel", "Parcel.jl"))
 
-
 # choosing a value for the ice relaxation timescale
 τ = FT(10)
 @info("using τ value ", τ)
+override_file = Dict(
+    "condensation_evaporation_timescale" =>
+        Dict("value" => τ, "type" => "float"),
+    "sublimation_deposition_timescale" =>
+        Dict("value" => τ, "type" => "float"),
+)
+override_toml_dict = CP.create_toml_dict(FT; override_file)
+liquid = CMP.CloudLiquid(override_toml_dict)
+ice = CMP.CloudIce(override_toml_dict)
+@info("relaxations:", liquid.τ_relax, ice.τ_relax)
 
 # Get free parameters
 tps = TD.Parameters.ThermodynamicsParameters(FT)
@@ -28,7 +36,8 @@ R_d = TD.Parameters.R_d(tps)
 Nₐ = FT(0)
 Nₗ = FT(200 * 1e6)
 Nᵢ = FT(1e6)
-r₀ = FT(8e-6)
+r₀ₗ = FT(1e-6)
+r₀ᵢ = FT(8e-6)
 p₀ = FT(800 * 1e2)
 T₀ = FT(243)
 ln_INPC = FT(0)
@@ -37,39 +46,17 @@ Sₗ = FT(1)
 e = Sₗ * e_sat
 md_v = (p₀ - e) / R_d / T₀
 mv_v = e / R_v / T₀
-ml_v = Nₗ * 4 / 3 * FT(π) * ρₗ * r₀^3
-mi_v = Nᵢ * 4 / 3 * FT(π) * ρᵢ * r₀^3
+ml_v = Nₗ * 4 / 3 * FT(π) * ρₗ * r₀ₗ^3
+mi_v = Nᵢ * 4 / 3 * FT(π) * ρᵢ * r₀ᵢ^3
 qᵥ = mv_v / (md_v + mv_v + ml_v + mi_v)
 qₗ = ml_v / (md_v + mv_v + ml_v + mi_v)
 qᵢ = mi_v / (md_v + mv_v + ml_v + mi_v)
-
-override_file = Dict(
-    "condensation_evaporation_timescale" =>
-        Dict("value" => τ, "type" => "float"),
-)
-
-liquid_toml_dict = CP.create_toml_dict(FT; override_file)
-liquid = CMP.CloudLiquid(liquid_toml_dict)
-
-override_file = Dict(
-    "sublimation_deposition_timescale" =>
-        Dict("value" => τ, "type" => "float"),
-)
-
-ice_toml_dict = CP.create_toml_dict(FT; override_file)
-
-ice = CMP.CloudIce(ice_toml_dict)
-@info("relaxations:", liquid.τ_relax, ice.τ_relax)
-
 IC = [Sₗ, p₀, T₀, qᵥ, qₗ, qᵢ, Nₐ, Nₗ, Nᵢ, ln_INPC]
-simple = false
 
 # Simulation parameters passed into ODE solver
-w = FT(1)                                 # updraft speed
-const_dt = FT(0.001)                         # model timestep
-t_max = FT(20)#FT(const_dt*1)
-size_distribution_list = ["Monodisperse"]
-
+w = FT(1)                     # updraft speed
+const_dt = FT(0.001)          # model timestep
+t_max = FT(20)
 condensation_growth = "NonEq_Condensation"
 deposition_growth = "NonEq_Deposition"
 
@@ -82,44 +69,24 @@ ax4 = MK.Axis(fig[1, 2], ylabel = "Ice Supersaturation [%]")
 ax5 = MK.Axis(fig[2, 2], ylabel = "q_vap [g/kg]")
 ax6 = MK.Axis(fig[3, 2], xlabel = "Time [s]", ylabel = "q_ice [g/kg]")
 
-for DSD in size_distribution_list
-    local params = parcel_params{FT}(
-        liq_size_distribution = DSD,
-        condensation_growth = condensation_growth,
-        deposition_growth = deposition_growth,
-        const_dt = const_dt,
-        w = w,
-        liquid = liquid,
-        ice = ice,
-    )
+params = parcel_params{FT}(
+    condensation_growth = condensation_growth,
+    deposition_growth = deposition_growth,
+    const_dt = const_dt,
+    w = w,
+    liquid = liquid,
+    ice = ice,
+)
 
-    # solve ODE
-    local sol = run_parcel(IC, FT(0), t_max, params)
+# solve ODE
+sol = run_parcel(IC, FT(0), t_max, params)
 
-    # Plot results
-    MK.lines!(ax1, sol.t, (sol[1, :] .- 1) * 100.0)
-    MK.lines!(ax2, sol.t, sol[3, :])
-    MK.lines!(ax3, sol.t, sol[5, :] * 1e3)
-    MK.lines!(ax4, sol.t, (S_i.(tps, sol[3, :], sol[1, :]) .- 1) * 100.0)
-    MK.lines!(ax5, sol.t, sol[4, :] * 1e3)
-    MK.lines!(ax6, sol.t, sol[6, :] * 1e3)
-
-
-    sol_Nₗ = sol[8, :]
-    sol_Nᵢ = sol[9, :]
-    sol_T = sol[3, :]
-    sol_p = sol[2, :]
-    sol_qᵥ = sol[4, :]
-    sol_qₗ = sol[5, :]
-    sol_qᵢ = sol[6, :]
-
-    q = TD.PhasePartition.(sol_qᵥ + sol_qₗ + sol_qᵢ, sol_qₗ, sol_qᵢ)
-
-    local q = TD.PhasePartition.(sol_qᵥ + sol_qₗ + sol_qᵢ, sol_qₗ, sol_qᵢ)
-    local ts = TD.PhaseNonEquil_pTq.(tps, sol_p, sol_T, q)
-    local ρₐ = TD.air_density.(tps, ts)
-
-end
+# Plot results
+MK.lines!(ax1, sol.t, (sol[1, :] .- 1) * 100.0)
+MK.lines!(ax2, sol.t, sol[3, :])
+MK.lines!(ax3, sol.t, sol[5, :] * 1e3)
+MK.lines!(ax4, sol.t, (S_i.(tps, sol[3, :], sol[1, :]) .- 1) * 100.0)
+MK.lines!(ax5, sol.t, sol[4, :] * 1e3)
+MK.lines!(ax6, sol.t, sol[6, :] * 1e3)
 
 MK.save("noneq_parcel.svg", fig)
-nothing

--- a/parcel/ParcelModel.jl
+++ b/parcel/ParcelModel.jl
@@ -72,7 +72,6 @@ function parcel_model(dY, Y, p, t)
         ln_INPC = Y[10],   # needed only in stochastic Frostenberg
         t = t,
     )
-
     # Constants
     Rᵥ = TD.Parameters.R_v(tps)
     grav = TD.Parameters.grav(tps)
@@ -111,7 +110,6 @@ function parcel_model(dY, Y, p, t)
     dqᵢ_dt_dep = dNᵢ_dt_dep * 4 / 3 * FT(π) * r_nuc^3 * ρᵢ / ρ_air
 
     # Heterogeneous ice nucleation
-    #@info(imm_params)
     dln_INPC_imm = INPC_model(imm_params, state)
     dNᵢ_dt_imm = immersion_freezing(imm_params, PSD_liq, state)
     dqᵢ_dt_imm = dNᵢ_dt_imm * PSD_liq.V * ρᵢ / ρ_air
@@ -211,7 +209,6 @@ The parcel parameters struct comes with default values that can be overwritten:
  - γ - inverse timescale for the stochastic process in Frostenberg_stochastic parametrization of immerison freezing
 """
 function run_parcel(IC, t_0, t_end, pp)
-
     FT = eltype(IC)
 
     info = "\nSize distribution (liq): $(pp.liq_size_distribution)\n"
@@ -337,7 +334,6 @@ function run_parcel(IC, t_0, t_end, pp)
         r_nuc = pp.r_nuc,
         w = pp.w,
     )
-
     problem = ODE.ODEProblem(parcel_model, IC, (FT(t_0), FT(t_end)), p)
     return ODE.solve(
         problem,


### PR DESCRIPTION
This PR updates our non-buildkite CI (gihub-CI, docs and code-coverage) to Julia v.1.11. 

Also fixes: https://github.com/CliMA/CloudMicrophysics.jl/issues/572

I have no idea why - but what fixed the segfault locally for me was to replace 

```
    return ifelse(
        cond_rate > FT(0),
        min(cond_rate, limit(qᵥ, dt, 1)),
        -min(abs(cond_rate), limit(qₗ, dt, 1)),
    )
```
by

```
    cond_limit = min(cond_rate, limit(qᵥ, dt, 1))
    evap_limit = min(abs(cond_rate), limit(qₗ, dt, 1))
    ret = ifelse(cond_rate > FT(0), cond_limit, -1 * evap_limit)
    return ret
```

Lets see if that also works in the cloud