### PR TITLE
Sketching a future with different thermo modules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.24.2"
+version = "0.25.0"
 
 [deps]
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -241,7 +241,8 @@ CloudDiagnostics.effective_radius_2M
 
 ```@docs
 Common
-Common.G_func
+Common.G_func_liquid
+Common.G_func_ice
 Common.logistic_function
 Common.logistic_function_integral
 Common.H2SO4_soln_saturation_vapor_pressure

--- a/docs/src/plots/ARGplots.jl
+++ b/docs/src/plots/ARGplots.jl
@@ -1,23 +1,18 @@
-import Plots
+import Plots as PL
 
-import CloudMicrophysics
-import ClimaParams
-import Thermodynamics
-
-const PL = Plots
-const AM = CloudMicrophysics.AerosolModel
-const AA = CloudMicrophysics.AerosolActivation
-const CP = ClimaParams
-const CMP = CloudMicrophysics.Parameters
-const TD = Thermodynamics
+import CloudMicrophysics as CM
+import CloudMicrophysics.AerosolModel as AM
+import CloudMicrophysics.AerosolActivation as AA
+import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 
 FT = Float64
 
-tps = Thermodynamics.Parameters.ThermodynamicsParameters(FT)
+tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 aip = CMP.AirProperties(FT)
 ap = CMP.AerosolActivationParameters(FT)
 
-include("plots/ARGdata.jl")
+include(joinpath(pkgdir(CM), "docs", "src", "plots", "ARGdata.jl"))
 
 # Atmospheric conditions
 T = 294.0         # air temperature
@@ -27,9 +22,8 @@ p = 1000.0 * 1e2   # air pressure
 # moist R_m and cp_m in aerosol activation module.
 # We are assuming here saturated conditions and no liquid water or ice.
 # This is consistent with the assumptions of the aerosol activation scheme.
-p_vs = TD.saturation_vapor_pressure(tps, T, TD.Liquid())
-q_vs = 1 / (1 - TD.Parameters.molmass_ratio(tps) * (p_vs - p) / p_vs)
-q = TD.PhasePartition(q_vs, 0.0, 0.0)
+p_vs = TDI.saturation_vapor_pressure_over_liquid(tps, T)
+q_vs = 1 / (1 - 1 / TDI.Rd_over_Rv(tps) * (p_vs - p) / p_vs)
 
 # Sulfate
 sulfate = CMP.Sulfate(FT)
@@ -162,10 +156,10 @@ function make_ARG_figX(X)
                 end
                 AD = AM.AerosolDistribution((paper_mode_1, paper_mode_2))
                 act_frac1[it] =
-                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q)[1] /
+                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q_vs, FT(0), FT(0))[1] /
                     N_1
                 act_frac2[it] =
-                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q)[2] /
+                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q_vs, FT(0), FT(0))[2] /
                     N2i
                 global it += 1
             end
@@ -215,10 +209,10 @@ function make_ARG_figX(X)
                 end
                 AD = AM.AerosolDistribution((paper_mode_1, paper_mode_2))
                 act_frac1[it] =
-                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q)[1] /
+                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q_vs, FT(0), FT(0))[1] /
                     N_1
                 act_frac2[it] =
-                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q)[2] /
+                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q_vs, FT(0), FT(0))[2] /
                     N2i
                 global it += 1
             end
@@ -270,10 +264,10 @@ function make_ARG_figX(X)
                 end
                 AD = AM.AerosolDistribution((paper_mode_1, paper_mode_2))
                 act_frac1[it] =
-                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q)[1] /
+                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q_vs, FT(0), FT(0))[1] /
                     N_1
                 act_frac2[it] =
-                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q)[2] /
+                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q_vs, FT(0), FT(0))[2] /
                     N_2
                 global it += 1
             end
@@ -322,10 +316,10 @@ function make_ARG_figX(X)
                 end
                 AD = AM.AerosolDistribution((paper_mode_1, paper_mode_2))
                 act_frac1[it] =
-                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q)[1] /
+                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q_vs, FT(0), FT(0))[1] /
                     N_1
                 act_frac2[it] =
-                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q)[2] /
+                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, w, q_vs, FT(0), FT(0))[2] /
                     N_2
                 global it += 1
             end
@@ -376,10 +370,10 @@ function make_ARG_figX(X)
 
             for wi in w
                 act_frac1[it] =
-                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, wi, q)[1] /
+                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, wi, q_vs, FT(0), FT(0))[1] /
                     N_1
                 act_frac2[it] =
-                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, wi, q)[2] /
+                    AA.N_activated_per_mode(ap, AD, aip, tps, T, p, wi, q_vs, FT(0), FT(0))[2] /
                     N_2
                 global it += 1
             end

--- a/docs/src/plots/Baumgartner2022_fig5.jl
+++ b/docs/src/plots/Baumgartner2022_fig5.jl
@@ -2,14 +2,14 @@ import RootSolvers as RS
 import CairoMakie as MK
 
 import CloudMicrophysics as CM
-import Thermodynamics as TD
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import ClimaParams as CP
 
 const CMO = CM.Common
 const CMP = CM.Parameters
 
 FT = Float64
-tps = TD.Parameters.ThermodynamicsParameters(FT)
+tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 H2SO4_prs = CMP.H2SO4SolutionParameters(FT)
 
 # Baumgartner at al 2022 Figure 5
@@ -21,9 +21,9 @@ BG2022_fig5_aw = [0.7930, 0.8129, 0.8416, 0.8679, 0.89781, 0.928486, 0.95039]
 
 T_range = range(190, stop = 234, length = 100)
 # sat vap pressure over pure liq water using TD package
-p_sat_liq = [TD.saturation_vapor_pressure(tps, T, TD.Liquid()) for T in T_range]
+p_sat_liq = [TDI.saturation_vapor_pressure_over_liquid(tps, T) for T in T_range]
 # sat vap pressure over ice using TD package
-p_sat_ice = [TD.saturation_vapor_pressure(tps, T, TD.Ice()) for T in T_range]
+p_sat_ice = [TDI.saturation_vapor_pressure_over_ice(tps, T) for T in T_range]
 a_w_ice = p_sat_ice ./ p_sat_liq
 
 radius = 1.0e-4                             # cm

--- a/docs/src/plots/HomFreezingPlots.jl
+++ b/docs/src/plots/HomFreezingPlots.jl
@@ -1,15 +1,15 @@
 import CairoMakie as MK
 
-import Thermodynamics as TD
 import CloudMicrophysics as CM
 import ClimaParams as CP
 
 const CMO = CM.Common
 const CMI = CM.HomIceNucleation
 const CMP = CM.Parameters
+const TDI = CM.ThermodynamicsInterface
 
 FT = Float64
-const tps = TD.Parameters.ThermodynamicsParameters(FT)
+const tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 const H2SO4_prs = CMP.H2SO4SolutionParameters(FT)
 const ip = CMP.IceNucleationParameters(FT)
 

--- a/docs/src/plots/KnopfAlpert2013_fig1.jl
+++ b/docs/src/plots/KnopfAlpert2013_fig1.jl
@@ -1,13 +1,12 @@
 import Plots as PL
 
-import Thermodynamics as TD
-import CloudMicrophysics as CM
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import CloudMicrophysics.Common as CO
 import CloudMicrophysics.HetIceNucleation as IN
 import CloudMicrophysics.Parameters as CMP
 
 FT = Float64
-const tps = TD.Parameters.ThermodynamicsParameters(FT)
+const tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 const H2SO4_prs = CMP.H2SO4SolutionParameters(FT)
 const kaolinite = CMP.Kaolinite(FT) # dust type
 

--- a/docs/src/plots/KnopfAlpert2013_fig5.jl
+++ b/docs/src/plots/KnopfAlpert2013_fig5.jl
@@ -1,14 +1,14 @@
 import CairoMakie as MK
 
 import ClimaParams
-import Thermodynamics as TD
 import CloudMicrophysics as CM
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import CloudMicrophysics.Common as CMO
 import CloudMicrophysics.HetIceNucleation as CMI
 import CloudMicrophysics.Parameters as CMP
 
 FT = Float64
-tps = TD.Parameters.ThermodynamicsParameters(FT)
+tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 H2SO4_prs = CMP.H2SO4SolutionParameters(FT)
 illite = CMP.Illite(FT)    # dust type
 
@@ -41,7 +41,7 @@ T_dew = FT(228.0)               # dew point temperature
 x_sulph = FT(0)                 # sulphuric acid concentration in droplets
 a_sol = [                       # water activity of solution droplet at equilibrium
     CMO.H2SO4_soln_saturation_vapor_pressure(H2SO4_prs, x_sulph, T_dew) /
-    TD.saturation_vapor_pressure(tps, T, TD.Liquid()) for T in T_range
+    TDI.saturation_vapor_pressure_over_liquid(tps, T) for T in T_range
 ]
 # water activity of ice
 a_ice = [CMO.a_w_ice(tps, T) for T in T_range]

--- a/docs/src/plots/MarshallPalmer_distribution.jl
+++ b/docs/src/plots/MarshallPalmer_distribution.jl
@@ -2,13 +2,9 @@ import CairoMakie as MK
 
 import SpecialFunctions as SF
 
-import Thermodynamics as TD
-import CloudMicrophysics as CM
 import ClimaParams as CP
 
-import Thermodynamics.Parameters as TDP
 import CloudMicrophysics.Parameters as CMP
-import CloudMicrophysics.Common as CO
 import CloudMicrophysics.Microphysics1M as CM1
 
 FT = Float64

--- a/docs/src/plots/Microphysics2M_plots.jl
+++ b/docs/src/plots/Microphysics2M_plots.jl
@@ -2,7 +2,6 @@ using CairoMakie
 CairoMakie.activate!(type = "svg")
 
 import ClimaParams
-import Thermodynamics as TD
 import CloudMicrophysics
 import CloudMicrophysics.Microphysics1M as CM1
 import CloudMicrophysics.Microphysics2M as CM2
@@ -10,7 +9,6 @@ import CloudMicrophysics.Parameters as CMP
 
 FT = Float64
 
-const tps = TD.Parameters.ThermodynamicsParameters(FT)
 const aps = CMP.AirProperties(FT)
 
 const KK2000 = CMP.KK2000(FT)

--- a/docs/src/plots/P3ImmersionFreezing.jl
+++ b/docs/src/plots/P3ImmersionFreezing.jl
@@ -1,25 +1,25 @@
 import CairoMakie as PL
 PL.activate!(type = "svg")
 
-import Thermodynamics as TD
 import CloudMicrophysics.Parameters as CMP
 import CloudMicrophysics.P3Scheme as P3
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 
 FT = Float64
 
 # thermodynamics parameters
-tps = TD.Parameters.ThermodynamicsParameters(FT)
+tps = TDI.PS(FT)
 
 # helper functions
 function RH2qₜ(T, RH)
-    eᵥ_sat = TD.saturation_vapor_pressure(tps, T, TD.Liquid())
+    eᵥ_sat = TDI.saturation_vapor_pressure_over_liquid(tps, T)
     eᵥ = RH * eᵥ_sat
     qᵥ = 1 / (1 - tps.molmass_dryair / tps.molmass_water * (eᵥ - p) / eᵥ)
     qₜ = qᵥ + qₗ + qᵢ
     return qₜ
 end
 function p2ρ(T, RH)
-    return TD.air_density(tps, T, p, TD.PhasePartition(RH2qₜ(T, RH), qₗ, qᵢ))
+    return TDI.air_density(tps, T, p, RH2qₜ(T, RH), qₗ, qᵢ)
 end
 
 # ambient conditions
@@ -47,18 +47,18 @@ max_dLdt_T1 = [qₗ* p2ρ(T1, RH) / dt for RH in RH_range]
 max_dLdt_T2 = [qₗ* p2ρ(T2, RH) / dt for RH in RH_range]
 max_dNdt =    [Nₗ              / dt for RH in RH_range]
 
-dLdt_dd_T1 = [P3.het_ice_nucleation(dd, tps, TD.PhasePartition(RH2qₜ(T1, RH), qₗ, qᵢ), Nₗ, RH, T1, p2ρ(T1, RH), dt).dLdt for RH in RH_range]
-dNdt_dd_T1 = [P3.het_ice_nucleation(dd, tps, TD.PhasePartition(RH2qₜ(T1, RH), qₗ, qᵢ), Nₗ, RH, T1, p2ρ(T1, RH), dt).dNdt for RH in RH_range]
+dLdt_dd_T1 = [P3.het_ice_nucleation(dd, tps, qₗ, Nₗ, RH, T1, p2ρ(T1, RH), dt).dLdt for RH in RH_range]
+dNdt_dd_T1 = [P3.het_ice_nucleation(dd, tps, qₗ, Nₗ, RH, T1, p2ρ(T1, RH), dt).dNdt for RH in RH_range]
 
-dLdt_il_T1 = [P3.het_ice_nucleation(il, tps, TD.PhasePartition(RH2qₜ(T1, RH), qₗ, qᵢ), Nₗ, RH, T1, p2ρ(T1, RH), dt).dLdt for RH in RH_range]
-dNdt_il_T1 = [P3.het_ice_nucleation(il, tps, TD.PhasePartition(RH2qₜ(T1, RH), qₗ, qᵢ), Nₗ, RH, T1, p2ρ(T1, RH), dt).dNdt for RH in RH_range]
+dLdt_il_T1 = [P3.het_ice_nucleation(il, tps, qₗ, Nₗ, RH, T1, p2ρ(T1, RH), dt).dLdt for RH in RH_range]
+dNdt_il_T1 = [P3.het_ice_nucleation(il, tps, qₗ, Nₗ, RH, T1, p2ρ(T1, RH), dt).dNdt for RH in RH_range]
 
 
-dLdt_dd_T2 = [P3.het_ice_nucleation(dd, tps, TD.PhasePartition(RH2qₜ(T2, RH), qₗ, qᵢ), Nₗ, RH, T2, p2ρ(T2, RH), dt).dLdt for RH in RH_range]
-dNdt_dd_T2 = [P3.het_ice_nucleation(dd, tps, TD.PhasePartition(RH2qₜ(T2, RH), qₗ, qᵢ), Nₗ, RH, T2, p2ρ(T2, RH), dt).dNdt for RH in RH_range]
+dLdt_dd_T2 = [P3.het_ice_nucleation(dd, tps, qₗ, Nₗ, RH, T2, p2ρ(T2, RH), dt).dLdt for RH in RH_range]
+dNdt_dd_T2 = [P3.het_ice_nucleation(dd, tps, qₗ, Nₗ, RH, T2, p2ρ(T2, RH), dt).dNdt for RH in RH_range]
 
-dLdt_il_T2 = [P3.het_ice_nucleation(il, tps, TD.PhasePartition(RH2qₜ(T2, RH), qₗ, qᵢ), Nₗ, RH, T2, p2ρ(T2, RH), dt).dLdt for RH in RH_range]
-dNdt_il_T2 = [P3.het_ice_nucleation(il, tps, TD.PhasePartition(RH2qₜ(T2, RH), qₗ, qᵢ), Nₗ, RH, T2, p2ρ(T2, RH), dt).dNdt for RH in RH_range]
+dLdt_il_T2 = [P3.het_ice_nucleation(il, tps, qₗ, Nₗ, RH, T2, p2ρ(T2, RH), dt).dLdt for RH in RH_range]
+dNdt_il_T2 = [P3.het_ice_nucleation(il, tps, qₗ, Nₗ, RH, T2, p2ρ(T2, RH), dt).dNdt for RH in RH_range]
 
 # plotting
 fig = PL.Figure(size = (1500, 500), fontsize=22, linewidth=3)

--- a/docs/src/plots/P3Melting.jl
+++ b/docs/src/plots/P3Melting.jl
@@ -1,17 +1,16 @@
 import CairoMakie: CairoMakie, Makie
 CairoMakie.activate!(type = "svg")
 
-import Thermodynamics as TD
 import CloudMicrophysics.Parameters as CMP
 import CloudMicrophysics.P3Scheme as P3
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 FT = Float64
 
 # parameters
-tps = TD.Parameters.ThermodynamicsParameters(FT)
 params = CMP.ParametersP3(FT; slope_law = :constant)
 vel = CMP.Chen2022VelType(FT)
 aps = CMP.AirProperties(FT)
-tps = TD.Parameters.ThermodynamicsParameters(FT)
+tps = TDI.PS(FT)
 
 # model time step (for limiting)
 dt = FT(1)

--- a/docs/src/plots/T_vs_wateractivity.jl
+++ b/docs/src/plots/T_vs_wateractivity.jl
@@ -1,14 +1,14 @@
 import CairoMakie as MK
 
-import Thermodynamics as TD
 import CloudMicrophysics as CM
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import ClimaParams as CP
 
 const CMO = CM.Common
 const CMP = CM.Parameters
 
 FT = Float64
-tps = TD.Parameters.ThermodynamicsParameters(FT)
+tps = TDI.PS(FT)
 H2SO4_prs = CMP.H2SO4SolutionParameters(FT)
 
 T_range = range(190, stop = 234, length = 100)
@@ -16,8 +16,8 @@ x = FT(0.1)
 #! format: off
 p_sol_1 = [CMO.H2SO4_soln_saturation_vapor_pressure(H2SO4_prs, x, T) for T in T_range]     # p_sol for concentration x
 p_sol_0 = [CMO.H2SO4_soln_saturation_vapor_pressure(H2SO4_prs, 0.0, T) for T in T_range]   # sat vap pressure over pure liq water using p_sol eqn
-p_sat_liq = [TD.saturation_vapor_pressure(tps, T, TD.Liquid()) for T in T_range]  # sat vap pressure over pure liq water using TD package
-p_sat_ice = [TD.saturation_vapor_pressure(tps, T, TD.Ice()) for T in T_range]     # sat vap pressure over ice using TD package
+p_sat_liq = [TDI.saturation_vapor_pressure_over_liquid(tps, T) for T in T_range]  # sat vap pressure over pure liq water using TD package
+p_sat_ice = [TDI.saturation_vapor_pressure_over_ice(tps, T) for T in T_range]     # sat vap pressure over ice using TD package
 
 a_w = p_sol_1 ./ p_sat_liq                 # a_w current parameterization
 a_w_alternate = p_sol_1 ./ p_sol_0         # a_w if sat vapor pressure over pure liq water was calculated with p_sol eqn

--- a/docs/src/plots/activity_based_deposition.jl
+++ b/docs/src/plots/activity_based_deposition.jl
@@ -1,13 +1,13 @@
 import Plots as PL
 
-import Thermodynamics as TD
 import CloudMicrophysics as CM
 import CloudMicrophysics.Common as CO
 import CloudMicrophysics.HetIceNucleation as IN
 import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 
 FT = Float32
-const tps = TD.Parameters.ThermodynamicsParameters(FT)
+const tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 const feldspar = CMP.Feldspar(FT)
 const ferrihydrite = CMP.Ferrihydrite(FT)
 const kaolinite = CMP.Kaolinite(FT)

--- a/ext/Common.jl
+++ b/ext/Common.jl
@@ -5,7 +5,7 @@ using StatsBase
 
 import CloudMicrophysics.AerosolModel as AM
 import CloudMicrophysics.AerosolActivation as AA
-import Thermodynamics.Parameters as TDP
+import CloudMicrophysics.ThermodynamicsInterface.TD.Parameters as TDP
 
 function get_num_modes(df::DataFrame)
     i = 1
@@ -108,13 +108,12 @@ function get_ARG_act_frac(
             ) for i in 1:num_modes
         )...,
     )
-    pv0 = TD.saturation_vapor_pressure(tps, FT(T), TD.Liquid())
-    vapor_mix_ratio = pv0 / TD.Parameters.molmass_ratio(tps) / (p - pv0)
+    pv0 = TDI.saturation_vapor_pressure_over_liquid(tps, FT(T))
+    vapor_mix_ratio = pv0 * TDI.Rd_over_Rv(tps) / (p - pv0)
     q_vap = vapor_mix_ratio / (vapor_mix_ratio + 1)
-    q = TD.PhasePartition(FT(q_vap), FT(0), FT(0))
 
     return collect(
-        AA.N_activated_per_mode(ap, ad, aip, tps, FT(T), FT(p), FT(w), q),
+        AA.N_activated_per_mode(ap, ad, aip, tps, FT(T), FT(p), FT(w), FT(q_vap), FT(0), FT(0)),
     ) ./ mode_Ns
 end
 

--- a/ext/EmulatorModelsExt.jl
+++ b/ext/EmulatorModelsExt.jl
@@ -3,15 +3,16 @@ module EmulatorModelsExt
 import MLJ
 import DataFrames as DF
 
-import Thermodynamics as TD
-import Thermodynamics.Parameters as TDP
 import ClimaParams as CP
 import CloudMicrophysics.AerosolActivation as AA
 import CloudMicrophysics.AerosolModel as AM
 import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.ThermodynamicsInterface as TDI
+
+const TDP = TDI.TD.Parameters
 
 """
-    N_activated_per_mode(machine, ap, ad, aip, tps, T, p, w, q)
+    N_activated_per_mode(machine, ap, ad, aip, tps, T, p, w, qₜ, qₗ, qᵢ)
 
   - `machine` - ML model
   - `ap`  - a struct with aerosol activation parameters
@@ -21,7 +22,9 @@ import CloudMicrophysics.Parameters as CMP
   - `T`   - air temperature
   - `p`   - air pressure
   - `w`   - vertical velocity
-  - `q`   - phase partition
+  - `qₜ`  - total water specific content
+  - `qₗ`  - liquid water specific content
+  - `qᵢ`  - ice specific content
 
 Returns the number of activated aerosol particles
 in each aerosol size distribution mode by using a trained emulator.
@@ -35,7 +38,9 @@ function AA.N_activated_per_mode(
     T::FT,
     p::FT,
     w::FT,
-    q::TD.PhasePartition{FT},
+    qₜ::FT,
+    qₗ::FT,
+    qᵢ::FT,
 ) where {FT <: Real}
     hygro = AA.mean_hygroscopicity_parameter(ap, ad)
     return ntuple(Val(AM.n_modes(ad))) do i
@@ -62,7 +67,7 @@ function AA.N_activated_per_mode(
 end
 
 """
-    total_N_activated(machine, ap, ad, aip, tps, T, p, w, q)
+    total_N_activated(machine, ap, ad, aip, tps, T, p, w, qₜ, qₗ, qᵢ)
 
   - `machine` - ML model
   - `ap` - a struct with aerosol activation parameters
@@ -72,7 +77,9 @@ end
   - `T` - air temperature
   - `p` - air pressure
   - `w` - vertical velocity
-  - `q` - phase partition
+  - `qₜ`  - total water specific content
+  - `qₗ`  - liquid water specific content
+  - `qᵢ`  - ice specific content
 
 Returns the total number of activated aerosol particles by using a trained emulator.
 """
@@ -85,9 +92,11 @@ function AA.total_N_activated(
     T::FT,
     p::FT,
     w::FT,
-    q::TD.PhasePartition{FT},
+    qₜ::FT,
+    qₗ::FT,
+    qᵢ::FT,
 ) where {FT}
-    return sum(AA.N_activated_per_mode(machine, ap, ad, aip, tps, T, p, w, q))
+    return sum(AA.N_activated_per_mode(machine, ap, ad, aip, tps, T, p, w, qₜ, qₗ, qᵢ))
 end
 
 """

--- a/parcel/Example_AerosolActivation.jl
+++ b/parcel/Example_AerosolActivation.jl
@@ -1,15 +1,17 @@
 import OrdinaryDiffEq as ODE
 import CairoMakie as MK
-import Thermodynamics as TD
-import CloudMicrophysics as CM
+
 import ClimaParams as CP
+import CloudMicrophysics as CM
+import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 
 # definition of the ODE problem for parcel model
 include(joinpath(pkgdir(CM), "parcel", "Parcel.jl"))
 FT = Float32
 
 # Get free parameters
-tps = TD.Parameters.ThermodynamicsParameters(FT)
+tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 wps = CMP.WaterProperties(FT)
 
 # Initial conditions
@@ -22,10 +24,8 @@ ln_INPC = FT(0)
 
 # Constants
 ρₗ = wps.ρw
-R_v = TD.Parameters.R_v(tps)
-R_d = TD.Parameters.R_d(tps)
-ϵₘ = R_d / R_v
-eₛ = TD.saturation_vapor_pressure(tps, T₀, TD.Liquid())
+ϵₘ = TDI.Rd_over_Rv(tps)
+eₛ = TDI.saturation_vapor_pressure_over_liquid(tps, T₀)
 qᵥ = ϵₘ / (ϵₘ - 1 + 1 / cᵥ₀)
 # Compute qₗ assuming that initially droplets are lognormally distributed
 # with N(r₀, σ). We are not keeping that size distribution assumption

--- a/parcel/Example_Deposition_Nucleation.jl
+++ b/parcel/Example_Deposition_Nucleation.jl
@@ -1,15 +1,16 @@
 import OrdinaryDiffEq as ODE
 import CairoMakie as MK
-import Thermodynamics as TD
-import CloudMicrophysics as CM
+
 import ClimaParams as CP
+import CloudMicrophysics as CM
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 
 # definition of the ODE problem for parcel model
 include(joinpath(pkgdir(CM), "parcel", "Parcel.jl"))
 FT = Float32
 
 # get free parameters
-tps = TD.Parameters.ThermodynamicsParameters(FT)
+tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 
 # Initial conditions
 Nₐ = FT(2000 * 1e3)
@@ -20,15 +21,14 @@ T₀ = FT(230)
 qᵥ = FT(3.3e-4)
 qₗ = FT(0)
 qᵢ = FT(0)
+qₜ = qᵥ + qₗ + qᵢ
 ln_INPC = FT(0)
 
 # Moisture dependent initial conditions
-q = TD.PhasePartition(qᵥ + qₗ + qᵢ, qₗ, qᵢ)
-ts = TD.PhaseNonEquil_pTq(tps, p₀, T₀, q)
-ρₐ = TD.air_density(tps, ts)
-Rₐ = TD.gas_constant_air(tps, q)
-Rᵥ = TD.Parameters.R_v(tps)
-eₛ = TD.saturation_vapor_pressure(tps, T₀, TD.Liquid())
+ρₐ = TDI.air_density(tps, T₀, p₀, qₜ, qₗ, qᵢ)
+Rₐ = TDI.Rₘ(tps, qₜ, qₗ, qᵢ)
+Rᵥ = TDI.Rᵥ(tps)
+eₛ = TDI.saturation_vapor_pressure_over_liquid(tps, T₀)
 e = eᵥ(qᵥ, p₀, Rₐ, Rᵥ)
 
 Sₗ = FT(e / eₛ)

--- a/parcel/Example_Immersion_Freezing.jl
+++ b/parcel/Example_Immersion_Freezing.jl
@@ -1,15 +1,15 @@
-
 import OrdinaryDiffEq as ODE
 import CairoMakie as MK
-import Thermodynamics as TD
+
 import CloudMicrophysics as CM
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import ClimaParams as CP
 
 # definition of the ODE problem for parcel model
 include(joinpath(pkgdir(CM), "parcel", "Parcel.jl"))
 FT = Float32
 # get free parameters
-tps = TD.Parameters.ThermodynamicsParameters(FT)
+tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 wps = CMP.WaterProperties(FT)
 
 # Initial conditions
@@ -23,13 +23,13 @@ T₀ = FT(251)
 qᵥ = FT(8.1e-4)
 qₗ = Nₗ * 4 / 3 * FT(π) * r₀^3 * ρₗ / FT(1.2) # 1.2 should be ρₐ
 qᵢ = FT(0)
+qₜ = qᵥ + qₗ + qᵢ
 ln_INPC = FT(0)
 
 # Moisture dependent initial conditions
-q = TD.PhasePartition.(qᵥ + qₗ + qᵢ, qₗ, qᵢ)
-R_v = TD.Parameters.R_v(tps)
-Rₐ = TD.gas_constant_air(tps, q)
-eₛ = TD.saturation_vapor_pressure(tps, T₀, TD.Liquid())
+R_v = TDI.Rᵥ(tps)
+Rₐ = TDI.Rₘ(tps, qₜ, qₗ, qᵢ)
+eₛ = TDI.saturation_vapor_pressure_over_liquid(tps, T₀)
 e = eᵥ(qᵥ, p₀, Rₐ, R_v)
 Sₗ = FT(e / eₛ)
 IC = [Sₗ, p₀, T₀, qᵥ, qₗ, qᵢ, Nₐ, Nₗ, Nᵢ, ln_INPC]

--- a/parcel/Example_Jensen_et_al_2022.jl
+++ b/parcel/Example_Jensen_et_al_2022.jl
@@ -1,17 +1,18 @@
 import OrdinaryDiffEq as ODE
 import CairoMakie as MK
-import Thermodynamics as TD
-import CloudMicrophysics as CM
-import ClimaParams as CP
 import Distributions as DS
+
+import ClimaParams as CP
+import CloudMicrophysics as CM
 import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 
 # definition of the ODE problem for parcel model
 include(joinpath(pkgdir(CM), "parcel", "Parcel.jl"))
 FT = Float32
 
 # Get free parameters
-tps = TD.Parameters.ThermodynamicsParameters(FT)
+tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 wps = CMP.WaterProperties(FT)
 
 # Initial conditions
@@ -25,10 +26,8 @@ ln_INPC = FT(0)
 
 # Constants
 ρₗ = wps.ρw
-R_v = TD.Parameters.R_v(tps)
-R_d = TD.Parameters.R_d(tps)
-ϵₘ = R_d / R_v
-eₛ = TD.saturation_vapor_pressure(tps, T₀, TD.Liquid())
+ϵₘ = TDI.Rd_over_Rv(tps)
+eₛ = TDI.saturation_vapor_pressure_over_liquid(tps, T₀)
 qᵥ = ϵₘ / (ϵₘ - 1 + 1 / cᵥ₀)
 # Compute qₗ assuming that initially droplets are lognormally distributed
 # with N(r₀, σ). We are not keeping that size distribution assumption

--- a/parcel/Example_NonEq.jl
+++ b/parcel/Example_NonEq.jl
@@ -1,8 +1,9 @@
 import OrdinaryDiffEq as ODE
 import CairoMakie as MK
-import Thermodynamics as TD
+
 import CloudMicrophysics as CM
 import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import ClimaParams as CP
 
 FT = Float64
@@ -24,13 +25,13 @@ ice = CMP.CloudIce(override_toml_dict)
 @info("relaxations:", liquid.τ_relax, ice.τ_relax)
 
 # Get free parameters
-tps = TD.Parameters.ThermodynamicsParameters(FT)
+tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 wps = CMP.WaterProperties(FT)
 # Constants
 ρₗ = wps.ρw
 ρᵢ = wps.ρi
-R_v = TD.Parameters.R_v(tps)
-R_d = TD.Parameters.R_d(tps)
+R_v = TDI.Rᵥ(tps)
+R_d = TDI.Rd(tps)
 
 # Initial conditions
 Nₐ = FT(0)
@@ -41,7 +42,7 @@ r₀ᵢ = FT(8e-6)
 p₀ = FT(800 * 1e2)
 T₀ = FT(243)
 ln_INPC = FT(0)
-e_sat = TD.saturation_vapor_pressure(tps, T₀, TD.Liquid())
+e_sat = TDI.saturation_vapor_pressure_over_liquid(tps, T₀)
 Sₗ = FT(1)
 e = Sₗ * e_sat
 md_v = (p₀ - e) / R_d / T₀

--- a/parcel/Example_Tully_et_al_2023.jl
+++ b/parcel/Example_Tully_et_al_2023.jl
@@ -1,8 +1,8 @@
 import OrdinaryDiffEq as ODE
 import CairoMakie as MK
 
-import Thermodynamics as TD
 import CloudMicrophysics as CM
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import ClimaParams as CP
 
 # definition of the ODE problem for parcel model
@@ -12,10 +12,9 @@ include(joinpath(pkgdir(CM), "parcel", "Parcel.jl"))
     Wrapper for initial condition
 """
 function get_initial_condition(tps, p_air, T, qᵥ, qₗ, qᵢ, Nₐ, Nₗ, Nᵢ, ln_INPC)
-    q = TD.PhasePartition(qᵥ + qₗ + qᵢ, qₗ, qᵢ)
-    R_a = TD.gas_constant_air(tps, q)
-    R_v = TD.Parameters.R_v(tps)
-    e_sl = TD.saturation_vapor_pressure(tps, T, TD.Liquid())
+    R_a = TDI.Rₘ(tps, qᵥ + qₗ + qᵢ, qₗ, qᵢ)
+    R_v = TDI.Rᵥ(tps)
+    e_sl = TDI.saturation_vapor_pressure_over_liquid(tps, T)
     e = eᵥ(qᵥ, p_air, R_a, R_v)
     Sₗ = e / e_sl
 
@@ -33,7 +32,7 @@ end
 function Tully_et_al_2023(FT)
 
     # get free parameters
-    tps = TD.Parameters.ThermodynamicsParameters(FT)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
     # Initial conditions for 1st period
     N_aerosol = FT(2000 * 1e3)
     N_droplets = FT(0)

--- a/parcel/ParcelCommon.jl
+++ b/parcel/ParcelCommon.jl
@@ -2,8 +2,8 @@ import Interpolations as Intp
 
 # Saturation ratio over ice
 ξ(tps, T) =
-    TD.saturation_vapor_pressure(tps, T, TD.Liquid()) /
-    TD.saturation_vapor_pressure(tps, T, TD.Ice())
+    TDI.saturation_vapor_pressure_over_liquid(tps, T) /
+    TDI.saturation_vapor_pressure_over_ice(tps, T)
 
 # Vapour partial pressure
 eᵥ(qᵥ, p_air, R_air, Rᵥ) = qᵥ * p_air * Rᵥ / R_air

--- a/parcel/ParcelParameters.jl
+++ b/parcel/ParcelParameters.jl
@@ -1,5 +1,5 @@
 import CloudMicrophysics.Parameters as CMP
-import Thermodynamics.Parameters as TDP
+import CloudMicrophysics.ThermodynamicsInterface.TD.Parameters as TDP
 
 struct Empty{FT} <: CMP.ParametersType{FT} end
 

--- a/src/CloudMicrophysics.jl
+++ b/src/CloudMicrophysics.jl
@@ -10,6 +10,7 @@ export accretion
 function conv_q_liq_to_q_rai end
 function accretion end
 
+include("ThermodynamicsInterface.jl")
 include("Common.jl")
 include("DistributionTools.jl")
 include("Microphysics0M.jl")

--- a/src/DistributionTools.jl
+++ b/src/DistributionTools.jl
@@ -28,7 +28,7 @@ end
 """
     generalized_gamma_quantile(ν, μ, B, Y)
 
-Calculate the quantile (inverse cumulative distribution function) for a 
+Calculate the quantile (inverse cumulative distribution function) for a
     generalized gamma distribution parameterized in the form:
 
     g(x) = A ⋅ x^ν ⋅ exp(-B ⋅ x^μ)
@@ -86,7 +86,7 @@ Calculate the nth physical moment of a generalized gamma distribution parameteri
 
     Mⁿ = ∫ x^n ⋅ g(x) dx
        = N ⋅ B^(-n/μ) ⋅ Γ((ν+1+n)/μ) / Γ((ν+1)/μ)
- 
+
 # Arguments
  - `ν, μ, B`: The PDF parameters
  - `N`: The total number concentration of particles
@@ -164,7 +164,7 @@ Calculate the nth moment of an exponential distribution parameterized in the for
 
     Mⁿ = ∫ x^n ⋅ n(x) dx
        = N ⋅ n! ⋅ D_mean^n
- 
+
  where N₀ = N / D_mean.
 
 # Arguments

--- a/src/IceNucleation.jl
+++ b/src/IceNucleation.jl
@@ -4,7 +4,6 @@ Parameterization for heterogenous ice nucleation.
 module HetIceNucleation
 
 import ..Parameters as CMP
-import Thermodynamics as TD
 
 export dust_activated_number_fraction
 export MohlerDepositionRate
@@ -231,7 +230,6 @@ Parameterization for homogeneous ice nucleation
 module HomIceNucleation
 
 import ..Parameters as CMP
-import Thermodynamics as TD
 
 export homogeneous_J_cubic
 export homogeneous_J_linear

--- a/src/Microphysics0M.jl
+++ b/src/Microphysics0M.jl
@@ -9,8 +9,11 @@ terminal velocity.
 """
 module Microphysics0M
 
-import Thermodynamics as TD
 import CloudMicrophysics.Parameters as CMP
+
+# Only needed for the wrapper for calling remove_precipitation with
+# TD.PhasePartition as an argument. Can be dropped if we drop this pattern.
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 
 export remove_precipitation
 
@@ -19,7 +22,7 @@ export remove_precipitation
     remove_precipitation(params_0M, q; q_vap_sat)
 
  - `params_0M` - a struct with 0-moment parameters
- - `q` - current Thermodynamics.PhasePartition or `q_liq` and `q_ice` specific contents
+ - `q` - `q_liq` and `q_ice` specific contents
  - `q_vap_sat` - specific humidity at saturation
 
 Returns the `q_tot` tendency due to the removal of precipitation.
@@ -35,20 +38,18 @@ remove_precipitation(
     q_ice,
 ) = -max(0, (q_liq + q_ice - qc_0)) / τ_precip
 remove_precipitation(
-    params::CMP.Parameters0M,
-    q::TD.PhasePartition,
-) = remove_precipitation(params, q.liq, q.ice)
-
-remove_precipitation(
     (; τ_precip, S_0)::CMP.Parameters0M,
     q_liq,
     q_ice,
     q_vap_sat,
 ) = -max(0, (q_liq + q_ice - S_0 * q_vap_sat)) / τ_precip
-remove_precipitation(
-    params::CMP.Parameters0M,
-    q::TD.PhasePartition,
-    q_vap_sat,
-) = remove_precipitation(params, q.liq, q.ice, q_vap_sat)
+
+###
+### Wrappers for calling with TD.PhasePartition
+###
+remove_precipitation(params::CMP.Parameters0M, q::TDI.TD.PhasePartition) =
+    remove_precipitation(params, q.liq, q.ice)
+remove_precipitation(params::CMP.Parameters0M, q::TDI.TD.PhasePartition, q_vap_sat) =
+    remove_precipitation(params, q.liq, q.ice, q_vap_sat)
 
 end #module Microphysics0M.jl

--- a/src/P3.jl
+++ b/src/P3.jl
@@ -13,14 +13,13 @@ import RootSolvers as RS
 import LogExpFunctions
 
 import ClimaParams as CP
+
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import CloudMicrophysics.Parameters as CMP
 import CloudMicrophysics.Common as CO
 import CloudMicrophysics.DistributionTools as DT
 import CloudMicrophysics.HetIceNucleation as CM_HetIce
 import CloudMicrophysics.Microphysics2M as CM2
-
-import Thermodynamics as TD
-import Thermodynamics.Parameters as TDP
 
 include("P3_particle_properties.jl")
 include("P3_size_distribution.jl")

--- a/src/P3_particle_properties.jl
+++ b/src/P3_particle_properties.jl
@@ -4,7 +4,7 @@
 
 State of the P3 scheme.
 
-This struct bundles the P3 parameterizations `params`, the provided rime state (`F_rim`, `ρ_rim`), 
+This struct bundles the P3 parameterizations `params`, the provided rime state (`F_rim`, `ρ_rim`),
     and the derived threshold variables (`D_th`, `D_gr`, `D_cr`, `ρ_g`).
 
 To obtain a `P3State` object, use the [`get_state`](@ref) function.
@@ -43,13 +43,13 @@ Create a [`P3State`](@ref) from [`CMP.ParametersP3`](@ref) and rime state parame
 # Examples
 
  ```jldoctest
- julia> import CloudMicrophysics.Parameters as CMP, 
+ julia> import CloudMicrophysics.Parameters as CMP,
                CloudMicrophysics.P3Scheme as P3
- 
+
  julia> FT = Float32;
- 
+
  julia> params = CMP.ParametersP3(FT);
- 
+
  julia> state = P3.get_state(params; F_rim = FT(0.5), ρ_rim = FT(916.7))
  P3State{Float32}
  ├── params = {MassPowerLaw, AreaPowerLaw, SlopePowerLaw, VentilationFactor}
@@ -81,8 +81,8 @@ isunrimed(state::P3State) = iszero(state.F_rim)
     get_ρ_d(mass::MassPowerLaw, F_rim, ρ_rim)
     get_ρ_d(state::P3State)
 
-Exact solution for the density of the unrimed portion of the particle as 
-    function of the rime mass fraction `F_rim`, mass power law parameters `mass`, 
+Exact solution for the density of the unrimed portion of the particle as
+    function of the rime mass fraction `F_rim`, mass power law parameters `mass`,
     and rime density `ρ_rim`.
 
 # Arguments
@@ -96,8 +96,8 @@ Exact solution for the density of the unrimed portion of the particle as
 # Examples
 
 ```jldoctest
-julia> import CloudMicrophysics.Parameters as CMP, 
-              ClimaParams as CP, 
+julia> import CloudMicrophysics.Parameters as CMP,
+              ClimaParams as CP,
               CloudMicrophysics.P3Scheme as P3
 
 julia> FT = Float64;
@@ -146,7 +146,7 @@ get_ρ_g((; params, F_rim, ρ_rim)::P3State) = get_ρ_g(params.mass, F_rim, ρ_r
     _get_threshold(params, ρ)
 
 All thresholds are on the form
-    
+
 ```math
 \\left( \\frac{6α_{va}}{π ρ} \\right)^\\frac{1}{3 - β_{va}}
 ```
@@ -195,7 +195,7 @@ get_D_cr(mass::CMP.MassPowerLaw, F_rim, ρ_g) = _get_threshold(mass, ρ_g * (1 -
     get_thresholds_ρ_g(params::CMP.ParametersP3, F_rim, ρ_rim)
 
 # Returns
-- `(; D_th, D_gr, D_cr, ρ_g)`: The thresholds for the size distribution, 
+- `(; D_th, D_gr, D_cr, ρ_g)`: The thresholds for the size distribution,
     and the density of total (deposition + rime) ice mass for graupel [kg/m³]
 
 
@@ -234,8 +234,8 @@ For example, if the (valid) thresholds are `(D_th, D_gr, D_cr)`, then the segmen
 function get_segments(state::P3State)
     FT = eltype(state)
     (; D_th, D_gr, D_cr) = get_thresholds_ρ_g(state)
-    # For certain high rimed values, D_gr < D_th (cf test/p3_tests.jl): 
-    #   so here we filter away invalid thresholds 
+    # For certain high rimed values, D_gr < D_th (cf test/p3_tests.jl):
+    #   so here we filter away invalid thresholds
     # (this also works correctly for the unrimed case, where D_gr = D_cr = NaN)
     valid_D = filter(≥(D_th), (D_th, D_gr, D_cr))
     segments = tuple.((FT(0), valid_D...), (valid_D..., FT(Inf)))
@@ -246,7 +246,7 @@ end
     weighted_average(f_a, a, b)
 
 Return the weighted average of `a` and `b` with fraction `f_a`,
-    
+
 ```math
 f_a ⋅ a + (1 - f_a) ⋅ b
 ```
@@ -318,8 +318,8 @@ Return the density of a particle at diameter D
  - `D`: maximum particle dimension [m]
 
 # Notes:
- The density of nonspherical particles is assumed to be the particle mass divided 
- by the volume of a sphere with the same D [MorrisonMilbrandt2015](@cite). 
+ The density of nonspherical particles is assumed to be the particle mass divided
+ by the volume of a sphere with the same D [MorrisonMilbrandt2015](@cite).
  Needed for aspect ratio calculation, so we assume zero liquid fraction.
 """
 function ice_density(args_D...)
@@ -348,7 +348,7 @@ end
     ice_area(state::P3State, D)
     ice_area(params::CMP.ParametersP3, F_rim, ρ_rim, D)
 
-Return the cross-sectional area of a particle based on where it falls in the 
+Return the cross-sectional area of a particle based on where it falls in the
     particle-size-based properties regime.
 
 # Arguments
@@ -387,8 +387,8 @@ Returns the aspect ratio (ϕ) for an ice particle
  - `D`: maximum dimension of ice particle [m]
 
 # Notes
- The density of nonspherical particles is assumed to be equal to the particle mass 
- divided by the volume of a spherical particle with the same D_max [MorrisonMilbrandt2015](@cite). 
+ The density of nonspherical particles is assumed to be equal to the particle mass
+ divided by the volume of a spherical particle with the same D_max [MorrisonMilbrandt2015](@cite).
  Assuming zero liquid fraction and oblate shape.
 """
 function ϕᵢ(args_D...)

--- a/src/P3_processes.jl
+++ b/src/P3_processes.jl
@@ -1,9 +1,9 @@
 """
-    het_ice_nucleation(pdf_c, p3, tps, q, N, T, ρₐ, p, aerosol)
+    het_ice_nucleation(pdf_c, p3, tps, q_liq, N, T, ρₐ, p, aerosol)
 
  - aerosol - aerosol parameters (supported types: desert dust, illite, kaolinite)
  - tps - thermodynamics parameters
- - qₚ - phase partition
+ - q_liq - liquid water specific content
  - N_liq - cloud water number concentration
  - RH - relative humidity
  - T - temperature
@@ -15,8 +15,8 @@ hetergoeneous freezing rates from cloud droplets.
 """
 function het_ice_nucleation(
     aerosol::Union{CMP.DesertDust, CMP.Illite, CMP.Kaolinite},
-    tps::TDP.ThermodynamicsParameters{FT},
-    qₚ::TD.PhasePartition{FT},
+    tps::TDI.PS,
+    q_liq::FT,
     N_liq::FT,
     RH::FT,
     T::FT,
@@ -34,14 +34,14 @@ function het_ice_nucleation(
     A_aer = FT(1e-10)
 
     dNdt = J * A_aer * N_liq
-    dLdt = J * A_aer * qₚ.liq * ρₐ
+    dLdt = J * A_aer * q_liq * ρₐ
 
     # nucleation rates are always positive definite...
     dNdt = max(0, dNdt)
     dLdt = max(0, dLdt)
     # ... and dont exceed the available number and mass of water droplets
     dNdt = min(dNdt, N_liq / dt)
-    dLdt = min(dLdt, qₚ.liq * ρₐ / dt)
+    dLdt = min(dLdt, q_liq * ρₐ / dt)
 
     return (; dNdt, dLdt)
 end
@@ -66,7 +66,7 @@ Returns the melting rate of ice (QIMLT in Morrison and Mildbrandt (2015)).
 """
 function ice_melt(
     state::P3State, logλ, Chen2022::CMP.Chen2022VelType,
-    aps::CMP.AirProperties, tps::TDP.ThermodynamicsParameters,
+    aps::CMP.AirProperties, tps::TDI.PS,
     Tₐ, ρₐ, dt;
     ∫kwargs = (;),
 )
@@ -74,7 +74,7 @@ function ice_melt(
     # (we want ice core shape params)
     # Get constants
     (; K_therm) = aps
-    L_f = TD.latent_heat_fusion(tps, Tₐ)
+    L_f = TDI.Lf(tps, Tₐ)
 
     (; L_ice, N_ice) = state
     (; T_freeze, vent) = state.params

--- a/src/ThermodynamicsInterface.jl
+++ b/src/ThermodynamicsInterface.jl
@@ -1,0 +1,69 @@
+module ThermodynamicsInterface
+
+import Thermodynamics as TD
+const PS = TD.Parameters.ThermodynamicsParameters
+const PP = TD.PhasePartition
+
+
+# Constants
+
+grav(tps::PS) = TD.Parameters.grav(tps) # Needed in parcel model
+
+
+# Constants for moist air
+
+Rᵥ(tps::PS) = TD.Parameters.R_v(tps)
+Rd(tps::PS) = TD.Parameters.R_d(tps)
+Rd_over_Rv(tps::PS) = 1 / TD.Parameters.molmass_ratio(tps)
+# Gas constant for mois air
+Rₘ(tps::PS, qₜ, qₗ, qᵢ) = TD.gas_constant_air(tps, PP(qₜ, qₗ, qᵢ)) #TODO - PP
+
+Lᵥ(tps::PS, T) = TD.latent_heat_vapor(tps, T)
+Lₛ(tps::PS, T) = TD.latent_heat_sublim(tps, T)
+Lf(tps::PS, T) = TD.latent_heat_fusion(tps, T)
+
+cpₘ(tps::PS, qₜ, qₗ, qᵢ) = TD.cp_m(tps, qₜ, qₗ, qᵢ)
+
+# Supersaturations
+
+saturation_vapor_pressure_over_liquid(tps::PS, T) =
+    TD.saturation_vapor_pressure(tps, T, TD.Liquid())
+saturation_vapor_pressure_over_ice(tps::PS, T) =
+    TD.saturation_vapor_pressure(tps, T, TD.Ice())
+
+# (only used in tests)
+saturation_vapor_specific_content_over_liquid(tps::PS, T, ρ) =
+    TD.q_vap_saturation_generic(tps, T, ρ, TD.Liquid())
+saturation_vapor_specific_content_over_ice(tps::PS, T, ρ) =
+    TD.q_vap_saturation_generic(tps, T, ρ, TD.Ice())
+
+supersaturation_over_liquid(tps::PS, qₜ, qₗ, qᵢ, ρ, T) =
+    TD.supersaturation(tps, PP(qₜ, qₗ, qᵢ), ρ, T, TD.Liquid()) # TODO - PP
+supersaturation_over_ice(tps::PS, qₜ, qₗ, qᵢ, ρ, T) =
+    TD.supersaturation(tps, PP(qₜ, qₗ, qᵢ), ρ, T, TD.Ice()) # TODO - PP
+
+
+# Utility functions
+
+# Get vapor specific content from total water, total liquid water and total ice
+# water specific contents.
+q_vap(q_tot, q_liq, q_ice) = q_tot - q_liq - q_ice
+# Get vapor specific content from total water, cloud liquid water, cloud ice,
+# rain and snow specific contents.
+q_vap(q_tot, q_liq, q_ice, q_rai, q_sno) = q_tot - q_liq - q_ice - q_rai - q_sno
+
+# Get specific content from partial pressure
+p2q(tps::PS, T, ρ, p) = TD.q_vap_saturation_from_density(tps, T, ρ, p)
+
+
+# Get air density from temperature, pressure and water content
+# (only used in tests)
+air_density(tps::PS, T, p, q_tot, q_liq, q_ice) =
+    TD.air_density(tps, T, p, PP(q_tot, q_liq, q_ice))
+
+# Get a tuple containing total water, cloud liquid water and cloud ice specific
+# contents from TD.PhasePartition and rain and snow specific contents.
+# Assumes that q::PhasePartition = (q_tot, q_cloud_liq + q_rai, q_cloud_ice + q_sno)
+q_(q::PP, q_rai, q_sno) = (q.tot, q.liq - q_rai, q.ice - q_sno)
+
+end

--- a/test/aerosol_activation_emulators.jl
+++ b/test/aerosol_activation_emulators.jl
@@ -15,9 +15,10 @@ EvoTreeRegressor = MLJ.@load EvoTreeRegressor pkg = EvoTrees
 import Test as TT
 
 # Get the CliMA packages
-import CloudMicrophysics as CM
 import ClimaParams as CP
-import Thermodynamics as TD
+
+import CloudMicrophysics as CM
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import CloudMicrophysics.AerosolModel as AM
 import CloudMicrophysics.AerosolActivation as AA
 import CloudMicrophysics.Parameters as CMP
@@ -159,7 +160,7 @@ include(joinpath(pkgdir(CM), "ext", "Common.jl"))
 
 function preprocess_aerosol_data_with_ARG_act_frac_FT32(x::DataFrame)
     aip = CMP.AirProperties(Float32)
-    tps = TD.Parameters.ThermodynamicsParameters(Float32)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(Float32)
     ap = CMP.AerosolActivationParameters(Float32)
     return preprocess_aerosol_data_with_ARG_act_frac(x, ap, aip, tps, Float32)
 end
@@ -290,16 +291,16 @@ function test_emulator(
 )
 
     aip = CMP.AirProperties(FT)
-    tps = TD.Parameters.ThermodynamicsParameters(FT)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
     ap = CMP.AerosolActivationParameters(FT)
 
     # Atmospheric conditions
     T = FT(294)    # air temperature K
     p = FT(1e5)    # air pressure Pa
     w = FT(0.5)    # vertical velocity m/s
-    p_vs = TD.saturation_vapor_pressure(tps, T, TD.Liquid())
-    q_vs = 1 / (1 - TD.Parameters.molmass_ratio(tps) * (p_vs - p) / p_vs)
-    q = TD.PhasePartition(q_vs)
+    p_vs = TDI.saturation_vapor_pressure_over_liquid(tps, T)
+    q_vs = 1 / (1 - 1 / TDI.Rd_over_Rv(tps) * (p_vs - p) / p_vs)
+    q = TDI.TD.PhasePartition(q_vs)
 
     # Aerosol size distribution
     salt = CMP.Seasalt(FT)

--- a/test/common_functions_tests.jl
+++ b/test/common_functions_tests.jl
@@ -1,8 +1,8 @@
 import Test as TT
 
 import ClimaParams
-import Thermodynamics as TD
 import CloudMicrophysics as CM
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import CloudMicrophysics.Common as CO
 import CloudMicrophysics.Parameters as CMP
 
@@ -85,7 +85,7 @@ end
 
 function test_a_w_xT(FT)
 
-    tps = TD.Parameters.ThermodynamicsParameters(FT)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
     H2SO4_prs = CMP.H2SO4SolutionParameters(FT)
 
     TT.@testset "a_w_xT" begin
@@ -111,7 +111,7 @@ end
 
 function test_a_w_eT(FT)
 
-    tps = TD.Parameters.ThermodynamicsParameters(FT)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 
     TT.@testset "a_w_eT" begin
 
@@ -132,7 +132,7 @@ end
 
 function test_a_w_ice(FT)
 
-    tps = TD.Parameters.ThermodynamicsParameters(FT)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 
     TT.@testset "a_w_ice" begin
 

--- a/test/heterogeneous_ice_nucleation_tests.jl
+++ b/test/heterogeneous_ice_nucleation_tests.jl
@@ -1,9 +1,9 @@
 import Test as TT
 
-import Thermodynamics as TD
-import CloudMicrophysics as CM
 import ClimaParams as CP
 
+import CloudMicrophysics as CM
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import CloudMicrophysics.Common as CO
 import CloudMicrophysics.Parameters as CMP
 import CloudMicrophysics.HetIceNucleation as CMI_het
@@ -11,7 +11,7 @@ import CloudMicrophysics.HetIceNucleation as CMI_het
 function test_heterogeneous_ice_nucleation(FT)
 
     # parameters for parameterizations
-    tps = TD.Parameters.ThermodynamicsParameters(FT)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
     H2SO4_prs = CMP.H2SO4SolutionParameters(FT)
     ip = CMP.IceNucleationParameters(FT)
     ip_frostenberg = CMP.Frostenberg2023(FT)

--- a/test/homogeneous_ice_nucleation_tests.jl
+++ b/test/homogeneous_ice_nucleation_tests.jl
@@ -1,16 +1,16 @@
 import Test as TT
 
-import Thermodynamics as TD
-import CloudMicrophysics as CM
 import ClimaParams as CP
 
+import CloudMicrophysics as CM
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import CloudMicrophysics.Common as CO
 import CloudMicrophysics.Parameters as CMP
 import CloudMicrophysics.HomIceNucleation as CMH
 
 function test_homogeneous_J_cubic(FT)
 
-    tps = TD.Parameters.ThermodynamicsParameters(FT)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
     H2SO4_prs = CMP.H2SO4SolutionParameters(FT)
     ip = CMP.IceNucleationParameters(FT)
 
@@ -47,7 +47,7 @@ end
 
 function test_homogeneous_J_linear(FT)
 
-    tps = TD.Parameters.ThermodynamicsParameters(FT)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
     H2SO4_prs = CMP.H2SO4SolutionParameters(FT)
     ip = CMP.IceNucleationParameters(FT)
 

--- a/test/microphysics0M_tests.jl
+++ b/test/microphysics0M_tests.jl
@@ -1,8 +1,8 @@
 import Test as TT
 
 import ClimaParams
-import Thermodynamics as TD
 
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import CloudMicrophysics.Parameters as CMP
 import CloudMicrophysics.Microphysics0M as CM0
 
@@ -18,7 +18,7 @@ function test_microphysics0M(FT)
         frac = [FT(0), FT(0.5), FT(1.0)]
 
         # no rain if no cloud
-        q = TD.PhasePartition(q_tot)
+        q = TDI.TD.PhasePartition(q_tot)
         TT.@test CM0.remove_precipitation(p0m, q) ≈ FT(0)
         TT.@test CM0.remove_precipitation(p0m, FT(0), FT(0)) ≈ FT(0)
         TT.@test CM0.remove_precipitation(p0m, q, q_vap_sat) ≈ FT(0)
@@ -30,7 +30,7 @@ function test_microphysics0M(FT)
             q_liq = qc * lf
             q_ice = (1 - lf) * qc
 
-            q = TD.PhasePartition(q_tot, q_liq, q_ice)
+            q = TDI.TD.PhasePartition(q_tot, q_liq, q_ice)
 
             TT.@test CM0.remove_precipitation(p0m, q) ≈
                      -max(0, q_liq + q_ice - qc_0) / τ_precip
@@ -43,7 +43,7 @@ function test_microphysics0M(FT)
             q_liq = qc * lf
             q_ice = (1 - lf) * qc
 
-            q = TD.PhasePartition(q_tot, q_liq, q_ice)
+            q = TDI.TD.PhasePartition(q_tot, q_liq, q_ice)
 
             TT.@test CM0.remove_precipitation(p0m, q, q_vap_sat) ≈
                      -max(0, q_liq + q_ice - S_0 * q_vap_sat) / τ_precip

--- a/test/microphysics2M_tests.jl
+++ b/test/microphysics2M_tests.jl
@@ -1,9 +1,9 @@
 import Test as TT
 
-import Thermodynamics as TD
-import CloudMicrophysics as CM
 import ClimaParams as CP
 
+import CloudMicrophysics as CM
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import CloudMicrophysics.Parameters as CMP
 import CloudMicrophysics.Common as CMC
 import CloudMicrophysics.Microphysics2M as CM2
@@ -31,7 +31,7 @@ function test_microphysics2M(FT)
 
     # Thermodynamics and air properties parameters
     aps = CMP.AirProperties(FT)
-    tps = TD.Parameters.ThermodynamicsParameters(FT)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 
     # Terminal velocity parameters
     SB2006Vel = CMP.SB2006VelType(FT)
@@ -455,7 +455,10 @@ function test_microphysics2M(FT)
         N_rai = FT(1e4)
         T = FT(288.15)
         q_tot = FT(1e-3)
-        q = TD.PhasePartition(q_tot)
+        q_liq = FT(0)
+        q_ice = FT(0)
+        q_sno = FT(0)
+        q = TDI.TD.PhasePartition(q_tot, q_liq, q_ice)
 
         for SB in [SB2006, SB2006_no_limiters]
 
@@ -463,10 +466,14 @@ function test_microphysics2M(FT)
             (; ν_air, D_vapor) = aps
 
             #action
-            evap = CM2.rain_evaporation(SB, aps, tps, q, q_rai, ρ, N_rai, T)
+            evap = CM2.rain_evaporation(SB, aps, tps, q_tot, q_liq, q_ice, q_rai, ρ, N_rai, T)
 
-            G = CMC.G_func(aps, tps, T, TD.Liquid())
-            S = TD.supersaturation(tps, q, ρ, T, TD.Liquid())
+            @assert CM2.rain_evaporation(SB, aps, tps, q_tot, q_liq, q_ice, q_rai, ρ, N_rai, T) ==
+                    CM2.rain_evaporation(SB, aps, tps, q, q_rai, ρ, N_rai, T)
+
+            G = CMC.G_func_liquid(aps, tps, T)
+            # TODO - update after working fluid change
+            S = TDI.supersaturation_over_liquid(tps, q_tot, q_liq, q_ice, ρ, T)
 
             (; xr_mean) = CM2.pdf_rain_parameters(SB.pdf_r, q_rai, ρ, N_rai)
             Dr = FT(6 / π / 1000.0)^FT(1 / 3) * xr_mean^FT(1 / 3)
@@ -487,16 +494,16 @@ function test_microphysics2M(FT)
             TT.@test evap.evap_rate_0 ≈ evap0 rtol = 1e-4
             TT.@test evap.evap_rate_1 ≈ evap1 rtol = 1e-5
             TT.@test CM2.rain_evaporation(
-                SB, aps, tps, q, q_rai, ρ, FT(0), T,
+                SB, aps, tps, q_tot, q_liq, q_ice, q_rai, ρ, FT(0), T,
             ).evap_rate_0 ≈ 0 atol = eps(FT)
             TT.@test CM2.rain_evaporation(
-                SB, aps, tps, q, FT(0), ρ, N_rai, T,
+                SB, aps, tps, q_tot, q_liq, q_ice, FT(0), ρ, N_rai, T,
             ).evap_rate_1 ≈ 0 atol = eps(FT)
         end
 
         # test limit case: xr = 0 for SB with no limiters
         TT.@test CM2.rain_evaporation(
-            SB2006_no_limiters, aps, tps, q, FT(0), ρ, N_rai, T,
+            SB2006_no_limiters, aps, tps, q_tot, q_liq, q_ice, FT(0), ρ, N_rai, T,
         ).evap_rate_0 ≈ 0 atol = eps(FT)
 
     end

--- a/test/microphysics_noneq_tests.jl
+++ b/test/microphysics_noneq_tests.jl
@@ -1,8 +1,8 @@
 import Test as TT
 
 import ClimaParams
-import Thermodynamics as TD
 
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import CloudMicrophysics.Parameters as CMP
 import CloudMicrophysics.MicrophysicsNonEq as CMNe
 
@@ -10,7 +10,7 @@ function test_microphysics_noneq(FT)
 
     ice = CMP.CloudIce(FT)
     liquid = CMP.CloudLiquid(FT)
-    tps = TD.Parameters.ThermodynamicsParameters(FT)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
     Ch2022 = CMP.Chen2022VelType(FT)
 
     TT.@testset "τ_relax" begin
@@ -49,13 +49,13 @@ function test_microphysics_noneq(FT)
         ρ = FT(0.8)
         T = FT(273 - 10)
 
-        pᵥ_sl = TD.saturation_vapor_pressure(tps, T, TD.Liquid())
-        qᵥ_sl = TD.q_vap_saturation_from_density(tps, T, ρ, pᵥ_sl)
+        pᵥ_sl = TDI.saturation_vapor_pressure_over_liquid(tps, T)
+        qᵥ_sl = TDI.p2q(tps, T, ρ, pᵥ_sl)
 
-        pᵥ_si = TD.saturation_vapor_pressure(tps, T, TD.Ice())
-        qᵥ_si = TD.q_vap_saturation_from_density(tps, T, ρ, pᵥ_si)
+        pᵥ_si = TDI.saturation_vapor_pressure_over_ice(tps, T)
+        qᵥ_si = TDI.p2q(tps, T, ρ, pᵥ_si)
 
-        qₚ(qᵥ) = TD.PhasePartition(FT(qᵥ))
+        qₚ(qᵥ) = TDI.TD.PhasePartition(FT(qᵥ))
 
         #! format: off
         # test sign

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -2,10 +2,10 @@ import Test as TT
 import BenchmarkTools as BT
 import JET
 
-import CloudMicrophysics as CM
 import ClimaParams as CP
-import Thermodynamics as TD
 
+import CloudMicrophysics as CM
+import CloudMicrophysics.ThermodynamicsInterface as TDI
 import CloudMicrophysics.ArtifactCalling as AFC
 import CloudMicrophysics.Common as CO
 import CloudMicrophysics.AerosolModel as AM
@@ -105,14 +105,14 @@ function benchmark_test(FT)
     # air and thermodynamics parameters
     aps = CMP.AirProperties(FT)
     wtr = CMP.WaterProperties(FT)
-    tps = TD.Parameters.ThermodynamicsParameters(FT)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 
     ρ_air = FT(1.2)
     T_air = FT(280)
     q_liq = FT(5e-4)
     q_ice = FT(5e-4)
     q_tot = FT(1e-3)
-    q = TD.PhasePartition(q_tot)
+    q = TDI.TD.PhasePartition(q_tot)
     q_rai = FT(1e-4)
     q_sno = FT(1e-4)
     N_liq = FT(1e8)
@@ -187,7 +187,7 @@ function benchmark_test(FT)
     #    (
     #        kaolinite,
     #        tps,
-    #        TD.PhasePartition(q_tot, q_liq, q_ice),
+    #        TDI.TD.PhasePartition(q_tot, q_liq, q_ice),
     #        N_liq,
     #        RH_2,
     #        T_air_2,
@@ -228,7 +228,7 @@ function benchmark_test(FT)
     bench_press(
         FT,
         AA.total_N_activated,
-        (ap, aer_distr, aps, tps, T_air, p_air, w_air, q),
+        (ap, aer_distr, aps, tps, T_air, p_air, w_air, q_tot, FT(0), FT(0)),
         1300,
     )
 
@@ -273,7 +273,7 @@ function benchmark_test(FT)
     bench_press(
         FT,
         CMN.conv_q_vap_to_q_liq_ice_MM2015,
-        (liquid, tps, TD.PhasePartition(FT(0.00145)), FT(0), FT(0), FT(0.8), FT(263)),
+        (liquid, tps, TDI.TD.PhasePartition(FT(0.00145)), FT(0), FT(0), FT(0.8), FT(263)),
         70,
     )
     bench_press(
@@ -314,7 +314,7 @@ function benchmark_test(FT)
         bench_press(
             @NamedTuple{evap_rate_0::FT, evap_rate_1::FT},
             CM2.rain_evaporation,
-            (sb, aps, tps, q, q_rai, ρ_air, N_rai, T_air),
+            (sb, aps, tps, q_tot, q_liq, q_ice, q_rai, ρ_air, N_rai, T_air),
             2000,
         )
         bench_press(

--- a/test/ventilation_tests.jl
+++ b/test/ventilation_tests.jl
@@ -3,7 +3,6 @@ import CloudMicrophysics.P3Scheme as P3
 import CloudMicrophysics.Common as CO
 import CloudMicrophysics.Parameters as CMP
 import CloudMicrophysics.Microphysics2M as CM2
-import Thermodynamics as TD
 import ClimaParams as CP
 
 function test_ventilation_factor(FT)


### PR DESCRIPTION
This PR creates a ThermodynamicsInterface module.

Hopefully this 
- clarifies the interactions and minimal function set needed between `Thermodynamics.jl` and `CM.jl` (and helps track down all the clipping in thermodynamics that we may want to get rid of).
- clarifies some of the logic of how to compute the microphysics rates and/or air properties depending on the working fluid assumptions

In the future we may make it an extension instead of a module, which would allow us to couple to models with different thermodynamics.

I created wrappers for functions that are currently used in `Atmos` and use `TD.PhasePartition` in the function signature. This will allow me to make the needed changes in `Atmos` without breaking the CI. But once I'm done there, I will remove those wrappers in CM.jl. I did not create wrappers for functions that are not currently used in Atmos.

The thing that is left to do is to write some short entry in the docs that explains the module. But I want to do that after I hear some feedback.