### PR TITLE
rft: Move `size_distribution` to `DistributionTools`

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -55,7 +55,8 @@ Microphysics2M.log_pdf_cloud_parameters_mass
 
 ### Size distributions
 ```@docs
-Microphysics2M.size_distribution
+Microphysics2M.size_distribution(::CMP.RainParticlePDF_SB2006, _, _, _)
+Microphysics2M.size_distribution(::CMP.CloudParticlePDF_SB2006, _, _, _)
 Microphysics2M.size_distribution_value
 Microphysics2M.get_size_distribution_bounds
 ```
@@ -152,12 +153,11 @@ P3Scheme.get_distribution_logλ
 
 ```@docs
 P3Scheme.logN′ice
-P3Scheme.N′ice
+P3Scheme.size_distribution(::P3Scheme.P3State, _)
 P3Scheme.loggamma_inc_moment
 P3Scheme.loggamma_moment
 P3Scheme.logmass_gamma_moment
 P3Scheme.logLdivN
-
 ```
 
 ### Derived integral quantities

--- a/docs/src/plots/P3SlopeParameterizations.jl
+++ b/docs/src/plots/P3SlopeParameterizations.jl
@@ -81,7 +81,7 @@ function make_multiple_solutions_plot()
     )
     Makie.vlines!(P3.get_D_th(params) * m_to_mm, color = (:gray, 0.5))
     for logλ in logλs_calc
-        N′ = P3.N′ice(state, logλ)
+        N′ = P3.size_distribution(state, logλ)
         Makie.lines!(Ds_mm, N′.(Ds) / m_to_cm^4)
         # Makie.lines!(Ds_mm, cumsum(N′.(Ds) .* Ds / m_to_cm^3))  # CUMULATIVE DISTRIBUTION
     end

--- a/src/DistributionTools.jl
+++ b/src/DistributionTools.jl
@@ -14,6 +14,18 @@ import SpecialFunctions as SF
 import LogExpFunctions as LEF
 
 """
+    size_distribution(args...; kwargs...)
+
+Compute the size distribution at diameter `D` given relevant arguments
+
+Note: This is a function stub. Implementations are provided by the various
+    models in the `CloudMicrophysics` package.
+"""
+function size_distribution(args...; kwargs...)
+    throw(ArgumentError("No size distribution implementation exists for the provided arguments"))
+end
+
+"""
     generalized_gamma_quantile(ν, μ, B, Y)
 
 Calculate the quantile (inverse cumulative distribution function) for a 

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -19,6 +19,8 @@ import ..Common as CO
 import ..Parameters as CMP
 import ..DistributionTools as DT
 
+import ..DistributionTools: size_distribution
+
 export autoconversion,
     accretion,
     liquid_self_collection,
@@ -229,9 +231,9 @@ end
 size_distribution_mass(pdf, q_c, ρₐ, N_c) = exp ∘ log_size_distribution_mass(pdf, q_c, ρₐ, N_c)
 
 """
-    size_distribution(pdf, q, ρₐ, N)
+    size_distribution(pdf::CMP.RainParticlePDF_SB2006, q, ρₐ, N)
 
-Return a function in diameter `D` that computes the size distribution value for rain particles.
+Return `n(D)`, a function that computes the size distribution for rain particles at diameter `D`
 
 # Arguments
 - `pdf`: Rain size distribution parameters, [`CMP.RainParticlePDF_SB2006`](@ref)
@@ -239,15 +241,15 @@ Return a function in diameter `D` that computes the size distribution value for 
 - `ρₐ`: Density of air [kg/m³]
 - `N`: Rain water number concentration [1/m³]
 """
-function size_distribution(pdf::CMP.RainParticlePDF_SB2006, q, ρₐ, N)
+function DT.size_distribution(pdf::CMP.RainParticlePDF_SB2006, q, ρₐ, N)
     (; N₀r, Dr_mean) = pdf_rain_parameters(pdf, q, ρₐ, N)
-    return rain_psd(D) = N₀r * exp(-D / Dr_mean)
+    return n(D) = N₀r * exp(-D / Dr_mean)
 end
 
 """
     size_distribution(pdf::CMP.CloudParticlePDF_SB2006, q, ρₐ, N)
 
-Return a function in diameter `D` that computes the size distribution value for cloud particles.
+Return `n(D)`, a function that computes the size distribution for cloud particles at diameter `D`
 
 The size distribution is given by:
 
@@ -260,7 +262,7 @@ The size distribution is given by:
  - `N`: Cloud water number concentration [1/m³]
 
 """
-function size_distribution(pdf::CMP.CloudParticlePDF_SB2006, q, ρₐ, N)
+function DT.size_distribution(pdf::CMP.CloudParticlePDF_SB2006, q, ρₐ, N)
     (; logN₀c, λc, νcD, μcD) = pdf_cloud_parameters(pdf, q, ρₐ, N)
     return n(D) = exp(logN₀c + νcD * log(D) - λc * D^μcD)
 end

--- a/src/P3_integral_properties.jl
+++ b/src/P3_integral_properties.jl
@@ -28,8 +28,8 @@ This method calls [`∫fdD_error`](@ref), which returns both the value of the in
 - `value`: The value of the integral
 
 !!! note "Integral accuracy"
-    To achieve highest accuracy, which can be challenging when integrating the
-    [`N′ice`](@ref) function, it is recommended to increase the `order` of the 
+    To achieve highest accuracy, which can be challenging when integrating over 
+    the size distribution, it is recommended to increase the `order` of the 
     quadrature rule and set `rtol = 0`. Experimentally, `order = 44` has been found
     to be sufficient for most cases. 
 
@@ -47,13 +47,13 @@ julia> state = P3.get_state(params; F_rim = 0.0, ρ_rim = 400.0, L_ice = 0.002, 
 
 julia> logλ = P3.get_distribution_logλ(state);
 
-julia> f(D) = D^3 * P3.N′ice(state, logλ)(D);  # Define a function to integrate
+julia> f(D) = D^3 * P3.size_distribution(state, logλ)(D);  # Define a function to integrate
 
 julia> P3.∫fdD(f, state, logλ; p = 0.01)  # Integrate the function
 0.0008519464332296608
 
 julia> P3.∫fdD(state, logλ; p = 0.01) do D  # Integrate with a `do`-block
-           P3.ice_mass(state, D) * P3.N′ice(state, logλ)(D)
+           P3.ice_mass(state, D) * P3.size_distribution(state, logλ)(D)
        end
 0.0017027833723511712
 ```

--- a/src/P3_processes.jl
+++ b/src/P3_processes.jl
@@ -81,7 +81,7 @@ function ice_melt(
 
     v_term = ice_particle_terminal_velocity(state, Chen2022, ρₐ)
     F_v = CO.ventilation_factor(vent, aps, v_term)
-    N′ = N′ice(state, logλ)
+    N′ = size_distribution(state, logλ)
 
     # Integrate
     fac = 4 * K_therm / L_f * (Tₐ - T_freeze)

--- a/src/P3_size_distribution.jl
+++ b/src/P3_size_distribution.jl
@@ -1,3 +1,4 @@
+import CloudMicrophysics.DistributionTools: size_distribution
 
 """
     logN′ice(state, logλ)
@@ -14,12 +15,15 @@ function logN′ice(state::P3State, logλ)
 end
 
 """
-    N′ice(dist, D)
+    size_distribution(state::P3State, logλ)
 
-Compute the ice particle number concentration at diameter `D` given the distribution `dist`
+Return `n(D)`, a function that computes the size distribution for ice particles at diameter `D`
+
+# Arguments
+- `state`: The [`P3State`](@ref)
+- `logλ`: The log of the slope parameter [log(1/m)]
 """
-N′ice(state::P3State, logλ) = exp ∘ logN′ice(state, logλ)
-
+DT.size_distribution(state::P3State, logλ) = exp ∘ logN′ice(state, logλ)
 
 ### ------------------------------------------------ ###
 ### ----- Obtaining P3 distribution parameters ----- ###

--- a/src/P3_terminal_velocity.jl
+++ b/src/P3_terminal_velocity.jl
@@ -58,10 +58,10 @@ function ice_terminal_velocity_number_weighted(
     end
 
     v_term = ice_particle_terminal_velocity(state, velocity_params, ρₐ; use_aspect_ratio)
-    N′ = N′ice(state, logλ)
+    n = DT.size_distribution(state, logλ)
 
-    # ∫N(D) v(D) dD
-    number_weighted_integrand(D) = N′(D) * v_term(D)
+    # ∫n(D) v(D) dD
+    number_weighted_integrand(D) = n(D) * v_term(D)
 
     return ∫fdD(number_weighted_integrand, state, logλ; ∫kwargs...) / N_ice
 end
@@ -94,10 +94,10 @@ function ice_terminal_velocity_mass_weighted(
     end
 
     v_term = ice_particle_terminal_velocity(state, velocity_params, ρₐ; use_aspect_ratio)
-    N′ = N′ice(state, logλ)  # Number concentration at diameter D
+    n = DT.size_distribution(state, logλ)  # Number concentration at diameter D
 
-    # ∫N(D) m(D) v(D) dD
-    mass_weighted_integrand(D) = N′(D) * v_term(D) * ice_mass(state, D)
+    # ∫n(D) m(D) v(D) dD
+    mass_weighted_integrand(D) = n(D) * v_term(D) * ice_mass(state, D)
 
 
     return ∫fdD(mass_weighted_integrand, state, logλ; ∫kwargs...) / L_ice

--- a/test/p3_tests.jl
+++ b/test/p3_tests.jl
@@ -442,7 +442,7 @@ function test_numerical_integrals(FT)
             # increase the `order` of the quadrature rule, and set `rtol=0`.
             # The `rtol` settings essentially forces max evaluations of the method.
             # Note 2: For F_rim=0, L=0.002, even higher order quadrature rules are needed.
-            N′ = P3.N′ice(state, logλ)
+            N′ = P3.size_distribution(state, logλ)
             N_estim = P3.∫fdD(state, logλ) do D
                 N′(D)
             end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This is a tiny step towards creating a consistent API for all parameterizations that make use of an assumed size distribution. Here, I create a `size_distribution` function stub in `DistributionTools.jl`, which throws an informative error by default. Then, in `Microphysics2M.jl` and `P3_size_distribution`, the methods `DT.size_distribution(psd, ...)` dispatches over the `psd` type.