### PR TITLE
fix: 2M microphysics type instability

### DIFF
--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -200,11 +200,12 @@ where
  - `(logN₀c, λc, νcD, μcD)`: Parameters of the generalized gamma distribution in terms of diameter
 """
 function pdf_cloud_parameters(pdf_c, q, ρₐ, N)
+    FT = eltype(pdf_c)
     logAc, logBc = log_pdf_cloud_parameters_mass(pdf_c, q, ρₐ, N)
     (; νc, μc, ρw) = pdf_c
     k_m = ρw * π / 6
     # Convert from mass-based to diameter-based distribution
-    logN₀c = logAc + log(3) + (νc + 1) * log(k_m)
+    logN₀c = logAc + log(FT(3)) + (νc + 1) * log(k_m)
     λc = exp(logBc) * k_m^μc
     return (; logN₀c, λc, νcD = 3νc + 2, μcD = 3μc)
 end

--- a/test/microphysics2M_tests.jl
+++ b/test/microphysics2M_tests.jl
@@ -518,6 +518,7 @@ function test_microphysics2M(FT)
             # distribution parameters for rain
             (; N₀r, Dr_mean) = CM2.pdf_rain_parameters(pdf_r, qᵣ, ρₐ, Nᵣ)
             (; Ar, Br) = CM2.pdf_rain_parameters_mass(pdf_r, qᵣ, ρₐ, Nᵣ)
+            TT.@test all(x -> x isa FT, (N₀r, Dr_mean, Ar, Br))
 
             # mass of liquid droplet as a function of its diameter
             k_m = π * ρw / 6
@@ -603,6 +604,7 @@ function test_microphysics2M(FT)
         (; logN₀c, λc, νcD, μcD) = CM2.pdf_cloud_parameters(pdf_c, qₗ, ρₐ, Nₗ)
 
         logAc, logBc = CM2.log_pdf_cloud_parameters_mass(pdf_c, qₗ, ρₐ, Nₗ)
+        TT.@test all(x -> x isa FT, (Ac, Bc, logN₀c, λc, νcD, μcD, logAc, logBc))
 
         # mass of liquid droplet as a function of its diameter
         k_m = π * ρw / 6


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
fixes a type instability in the 2-moment scheme.
adds test to check type of 2M parameters.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
