### PR TITLE
add supporting P3 collisions sub-parameterizations

### DIFF
--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -141,6 +141,19 @@ DOI = {10.5194/acp-22-65-2022}
   pages= {561--582}
 }
 
+
+@article{CoberList1993,
+	title = {Measurements of the Heat and Mass Transfer Parameters Characterizing Conical Graupel Growth},
+	volume = {50},
+	doi = {10.1175/1520-0469(1993)050<1591:MOTHAM>2.0.CO;2},
+	pages = {1591--1609},
+	number = {11},
+	journal = {Journal of the Atmospheric Sciences},
+	author = {Cober, Stewart G. and List, Roland},
+  year = {1993},
+}
+
+
 @article{Desai2019,
   title = {Aerosol-Mediated Glaciation of Mixed-Phase Clouds: Steady-State Laboratory Measurements},
   author = {Desai, Neel and Chandrakar, KK and Kinney, G and Cantrell, W and Shaw, RA},
@@ -548,6 +561,19 @@ pages  = {6519-6554},
 publisher  = {The Royal Society of Chemistry},
 doi  = {10.1039/C2CS35200A}
 }
+
+
+@article{Musil1970,
+	title = {Computer Modeling of Hailstone Growth in Feeder Clouds},
+	volume = {27},
+	doi = {10.1175/1520-0469(1970)027<0474:CMOHGI>2.0.CO;2},
+	pages = {474--482},
+	number = {3},
+	journal = {Journal of the Atmospheric Sciences},
+	author = {Musil, Dennis J.},
+	year = {1970},
+}
+
 
 @article{Ogura1971,
   title = {Numerical simulation of the life cycle of a thunderstorm cell},

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -109,6 +109,7 @@ CMP.SlopeLaw
 CMP.SlopePowerLaw{Float64}
 CMP.SlopeConstant{Float64}
 CMP.VentilationFactor
+CMP.LocalRimeDensity
 ```
 
 ## Obtain particle state
@@ -167,8 +168,25 @@ P3Scheme.D_m
 P3Scheme.ice_particle_terminal_velocity
 P3Scheme.ice_terminal_velocity_number_weighted
 P3Scheme.ice_terminal_velocity_mass_weighted
+```
+
+### Processes
+
+#### Heterogeneous ice nucleation
+```@docs
 P3Scheme.het_ice_nucleation
+```
+
+#### Ice melting
+```@docs
 P3Scheme.ice_melt
+```
+
+#### Collisions with liquid droplets
+Supporting methods:
+```@docs
+P3Scheme.compute_max_freeze_rate
+P3Scheme.compute_local_rime_density
 ```
 
 ### Supporting integral methods

--- a/docs/src/plots/P3Melting.jl
+++ b/docs/src/plots/P3Melting.jl
@@ -33,26 +33,26 @@ Fᵣ1 = FT(0.8)
 ρᵣ1 = FT(800)
 state = P3.get_state(params; F_rim = Fᵣ1, ρ_rim = ρᵣ1, L_ice = Lᵢ, N_ice = Nᵢ)
 logλ = P3.get_distribution_logλ(state)
-dLdt1 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dLdt for ΔT in ΔT_range]
-dNdt1 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dNdt for ΔT in ΔT_range]
+dLdt1 = [P3.ice_melt(vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt, state, logλ).dLdt for ΔT in ΔT_range]
+dNdt1 = [P3.ice_melt(vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt, state, logλ).dNdt for ΔT in ΔT_range]
 
 Fᵣ2 = FT(0.2)
 state = P3.get_state(params; F_rim = Fᵣ2, ρ_rim = ρᵣ1, L_ice = Lᵢ, N_ice = Nᵢ)
 logλ = P3.get_distribution_logλ(state)
-dLdt2 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dLdt for ΔT in ΔT_range]
-dNdt2 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dNdt for ΔT in ΔT_range]
+dLdt2 = [P3.ice_melt(vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt, state, logλ).dLdt for ΔT in ΔT_range]
+dNdt2 = [P3.ice_melt(vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt, state, logλ).dNdt for ΔT in ΔT_range]
 
 ρᵣ2 = FT(200)
 state = P3.get_state(params; F_rim = Fᵣ2, ρ_rim = ρᵣ2, L_ice = Lᵢ, N_ice = Nᵢ)
 logλ = P3.get_distribution_logλ(state)
-dLdt3 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dLdt for ΔT in ΔT_range]
-dNdt3 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt).dNdt for ΔT in ΔT_range]
+dLdt3 = [P3.ice_melt(vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt, state, logλ).dLdt for ΔT in ΔT_range]
+dNdt3 = [P3.ice_melt(vel, aps, tps, params.T_freeze .+ ΔT, ρₐ1, dt, state, logλ).dNdt for ΔT in ΔT_range]
 
 ρₐ2 = FT(0.5)
 state = P3.get_state(params; F_rim = Fᵣ2, ρ_rim = ρᵣ2, L_ice = Lᵢ, N_ice = Nᵢ)
 logλ = P3.get_distribution_logλ(state)
-dLdt4 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ2, dt).dLdt for ΔT in ΔT_range]
-dNdt4 = [P3.ice_melt(state, logλ, vel, aps, tps, params.T_freeze .+ ΔT, ρₐ2, dt).dNdt for ΔT in ΔT_range]
+dLdt4 = [P3.ice_melt(vel, aps, tps, params.T_freeze .+ ΔT, ρₐ2, dt, state, logλ).dLdt for ΔT in ΔT_range]
+dNdt4 = [P3.ice_melt(vel, aps, tps, params.T_freeze .+ ΔT, ρₐ2, dt, state, logλ).dNdt for ΔT in ΔT_range]
 
 # plotting
 fig = Makie.Figure(size = (1500, 500), fontsize=22, linewidth=3)

--- a/docs/src/plots/P3TerminalVelocityPlots.jl
+++ b/docs/src/plots/P3TerminalVelocityPlots.jl
@@ -32,8 +32,8 @@ function get_values(
             ρ_rim = ρ_rims[j]
             state = P3.get_state(params; F_rim, ρ_rim, L_ice = L, N_ice = N)
             logλ = P3.get_distribution_logλ(state)
-            V_m[i, j] = P3.ice_terminal_velocity_mass_weighted(state, logλ, Chen2022, ρ_a; use_aspect_ratio = false)
-            V_m_ϕ[i, j] = P3.ice_terminal_velocity_mass_weighted(state, logλ, Chen2022, ρ_a; use_aspect_ratio = true)
+            V_m[i, j] = P3.ice_terminal_velocity_mass_weighted(Chen2022, ρ_a, state, logλ; use_aspect_ratio = false)
+            V_m_ϕ[i, j] = P3.ice_terminal_velocity_mass_weighted(Chen2022, ρ_a, state, logλ; use_aspect_ratio = true)
             D_m[i, j] = P3.D_m(state, logλ)
             D_m_regimes[i, j] = D_m[i, j]
             ϕᵢ[i, j] = P3.ϕᵢ(state, D_m[i, j])

--- a/src/Common.jl
+++ b/src/Common.jl
@@ -383,14 +383,15 @@ The ventilation factor parameterizes the increase in the mass and heat exchange 
 # Returns
 - `F_v(D)`: The ventilation factor as a function of diameter, `D`
 
-See e.g. [SeifertBeheng2006](@cite) Eq. (24) for the definition of the ventilation factor.
+See e.g. [SeifertBeheng2006](@cite) Eq. (24), or [`CMP.VentilationFactor`](@ref),
+for the definition of the ventilation factor.
 """
 function ventilation_factor(vent, aps, v_term)
-    (; vent_a, vent_b) = vent
+    (; aᵥ, bᵥ) = vent
     (; ν_air, D_vapor) = aps
     N_sc = ν_air / D_vapor           # Schmidt number
     N_Re(D) = D * v_term(D) / ν_air  # Reynolds number
-    F_v(D) = vent_a + vent_b * ∛(N_sc) * √(N_Re(D))  # Ventilation factor
+    F_v(D) = aᵥ + bᵥ * ∛(N_sc) * √(N_Re(D))  # Ventilation factor
     return F_v
 end
 

--- a/src/P3_processes.jl
+++ b/src/P3_processes.jl
@@ -47,17 +47,17 @@ function het_ice_nucleation(
 end
 
 """
-    ice_melt(state, logλ, Chen2022, aps, tps, Tₐ, ρₐ, dt; ∫kwargs...)
+    ice_melt(velocity_params::CMP.Chen2022VelType, aps, tps, Tₐ, ρₐ, dt, state, logλ; ∫kwargs...)
 
 # Arguments
- - `state`: a [`P3State`](@ref) object
- - `logλ`: the log of the slope parameter [log(1/m)]
- - `Chen2022`: struct containing Chen 2022 velocity parameters
- - `aps`: air properties
+ - `velocity_params`: [`CMP.Chen2022VelType`](@ref)
+ - `aps`: [`CMP.AirProperties`](@ref)
  - `tps`: thermodynamics parameters
  - `Tₐ`: temperature (K)
  - `ρₐ`: air density
  - `dt`: model time step (for limiting the tendnecy)
+ - `state`: a [`P3State`](@ref) object
+ - `logλ`: the log of the slope parameter [log(1/m)]
 
 # Keyword arguments
  - `∫kwargs`: Named tuple of keyword arguments passed to [`∫fdD`](@ref)
@@ -65,9 +65,7 @@ end
 Returns the melting rate of ice (QIMLT in Morrison and Mildbrandt (2015)).
 """
 function ice_melt(
-    state::P3State, logλ, Chen2022::CMP.Chen2022VelType,
-    aps::CMP.AirProperties, tps::TDI.PS,
-    Tₐ, ρₐ, dt;
+    velocity_params::CMP.Chen2022VelType, aps::CMP.AirProperties, tps::TDI.PS, Tₐ, ρₐ, dt, state::P3State, logλ;
     ∫kwargs = (;),
 )
     # Note: process not dependent on `F_liq`
@@ -79,7 +77,7 @@ function ice_melt(
     (; L_ice, N_ice) = state
     (; T_freeze, vent) = state.params
 
-    v_term = ice_particle_terminal_velocity(state, Chen2022, ρₐ)
+    v_term = ice_particle_terminal_velocity(velocity_params, ρₐ, state)
     F_v = CO.ventilation_factor(vent, aps, v_term)
     N′ = size_distribution(state, logλ)
 
@@ -98,4 +96,106 @@ function ice_melt(
     dNdt = min(dNdt, N_ice / dt)  # TODO: Apply limiters in CA.jl
     dLdt = min(dLdt, L_ice / dt)
     return (; dNdt, dLdt)
+end
+
+"""
+    compute_max_freeze_rate(aps, tps, velocity_params, ρₐ, Tₐ, state)
+
+Returns a function `max_freeze_rate(Dᵢ)` that returns the maximum possible freezing rate [kg/s] 
+    for an ice particle of diameter `Dᵢ` [m]. Evaluates to `0` if `T ≥ T_freeze`.
+
+# Arguments
+- `aps`: [`CMP.AirProperties`](@ref) 
+- `tps`: `TDP.ThermodynamicsParameters`
+- `velocity_params`: velocity parameterization, e.g. [`CMP.Chen2022VelType`](@ref)
+- `ρₐ`: air density [kg/m³]
+- `Tₐ`: air temperature [K]
+- `state`: [`P3State`](@ref)
+
+This rate represents the thermodynamic upper limit to collisional freezing, 
+which occurs when the heat transfer from the ice particle to the environment is 
+balanced by the latent heat of fusion.
+
+From Eq (A7) in Musil (1970), [Musil1970](@cite).
+"""
+function compute_max_freeze_rate(aps, tps, velocity_params, ρₐ, Tₐ, state)
+    (; D_vapor, K_therm) = aps
+    cp_l = TDI.TD.Parameters.cp_l(tps)
+    T_frz = TDI.TD.Parameters.T_freeze(tps)
+    Lᵥ = TDI.Lᵥ(tps, Tₐ)
+    L_f = TDI.Lf(tps, Tₐ)
+    Tₛ = T_frz  # the surface of the ice particle is assumed to be at the freezing temperature
+    ΔT = Tₛ - Tₐ  # temperature difference between the surface of the ice particle and the air
+    Δρᵥ_sat =
+        ρₐ * (  # saturation vapor density difference between the surface of the ice particle and the air
+            TDI.p2q(tps, Tₛ, ρₐ, TDI.saturation_vapor_pressure_over_ice(tps, Tₛ)) -
+            TDI.p2q(tps, Tₐ, ρₐ, TDI.saturation_vapor_pressure_over_ice(tps, Tₐ))
+        )
+    v_term = ice_particle_terminal_velocity(velocity_params, ρₐ, state)
+    F_v = CO.ventilation_factor(state.params.vent, aps, v_term)
+    function max_freeze_rate(Dᵢ)
+        Tₐ ≥ T_frz && return zero(Dᵢ)  # No collisional freezing above the freezing temperature
+        return 2 * (π * Dᵢ) * F_v(Dᵢ) * (K_therm * ΔT + Lᵥ * D_vapor * Δρᵥ_sat) / (L_f - cp_l * ΔT)
+    end
+    return max_freeze_rate
+end
+
+"""
+    compute_local_rime_density(velocity_params, ρₐ, T, state)
+
+Provides a function `ρ′_rim(Dᵢ, Dₗ)` that computes the local rime density [kg/m³] 
+    for a given ice particle diameter `Dᵢ` [m] and liquid particle diameter `Dₗ` [m].
+
+# Arguments
+- `velocity_params`: velocity parameterization, e.g. [`CMP.Chen2022VelType`](@ref)
+- `ρₐ`: air density [kg/m³]
+- `T`: temperature [K]
+- `state`: [`P3State`](@ref)
+
+# Returns
+A function that computes the local rime density [kg/m³] using the equation:
+
+```math
+ρ'_{rim} = a + b R_i + c R_i^2
+```
+where
+```math
+R_i = \\frac{ 10^6 ⋅ D_{liq} ⋅ |v_{liq} - v_{ice}| }{ 2 T_{sfc} }
+```
+and ``T_{sfc}`` is the surface temperature [°C], ``D_{liq}`` is the liquid particle
+diameter [m], ``v_{liq/ice}`` is the particle terminal velocity [m/s].
+So the units of ``R_i`` are [m² s⁻¹ °C⁻¹]. The units of ``ρ'_{rim}`` are [kg/m³].
+
+We assume for simplicity that ``T_{sfc}`` equals ``T``, the ambient air temperature.
+For real graupel, ``T_{sfc}`` is slightly higher than ``T`` due to latent heat release 
+of freezing liquid particles onto the ice particle. Morrison & Milbrandt (2013) 
+found little sensitivity to "realistic" increases in ``T_{sfc}``.
+
+See also [`LocalRimeDensity`](@ref CloudMicrophysics.Parameters.LocalRimeDensity).
+
+# Extended help
+
+ Implementation follows Cober and List (1993), Eq. 16 and 17.
+ See also the P3 fortran code, `microphy_p3.f90`, Line 3315-3323,
+ which extends the range of the calculation to ``R_i ≤ 12``, the upper limit of which
+ then equals the solid bulk ice density, ``ρ_ice = 916.7 kg/m^3``.
+
+ Note that Morrison & Milbrandt (2015) [MorrisonMilbrandt2015](@cite) only uses this 
+ parameterization for collisions with cloud droplets.
+ For rain drops, they use a value near the solid bulk ice density, ``ρ^* = 900 kg/m^3``.
+ We do not consider this distinction, and use this parameterization for all liquid particles.
+"""
+function compute_local_rime_density(velocity_params, ρₐ, T, state)
+    (; T_freeze, ρ_rim_local) = state.params
+    T°C = T - T_freeze  # Convert to °C
+    μm = 1_000_000  # Note: m to μm factor, c.f. units of rₘ in Eq. 16 in Cober and List (1993)
+
+    v_ice = ice_particle_terminal_velocity(velocity_params, ρₐ, state)
+    v_liq = CO.particle_terminal_velocity(velocity_params.rain, ρₐ)
+    function ρ′_rim(Dᵢ, Dₗ)
+        v_term = abs(v_ice(Dᵢ) - v_liq(Dₗ))
+        Rᵢ = (Dₗ * μm * v_term) / (2 * T°C)  # Eq. 16 in Cober and List (1993). Note: no `-` due to absolute value in v_term
+        return ρ_rim_local(Rᵢ)
+    end
+    return ρ′_rim
 end

--- a/src/P3_terminal_velocity.jl
+++ b/src/P3_terminal_velocity.jl
@@ -1,6 +1,7 @@
 
 """
-    ice_particle_terminal_velocity(state, velocity_params, ρₐ; [use_aspect_ratio])
+    ice_particle_terminal_velocity(velocity_params, ρₐ, state::P3State; [use_aspect_ratio])
+    ice_particle_terminal_velocity(velocity_params, ρₐ, params::CMP.ParametersP3, F_rim, ρ_rim; [use_aspect_ratio])
 
 Returns the terminal velocity of a single ice particle as a function of its size 
     (maximum dimension, `D`) using the Chen 2022 parametrization.
@@ -15,7 +16,7 @@ Returns the terminal velocity of a single ice particle as a function of its size
     of particle aspect ratio on its terminal velocity (default: `true`)
 """
 function ice_particle_terminal_velocity(
-    state::P3State, velocity_params::CMP.Chen2022VelType, ρₐ; use_aspect_ratio = true,
+    velocity_params::CMP.Chen2022VelType, ρₐ, state_components...; use_aspect_ratio = true,
 )
     function v_term(D::FT) where {FT}
         (; small_ice, large_ice) = velocity_params
@@ -23,23 +24,26 @@ function ice_particle_terminal_velocity(
         ρᵢ = FT(916.7) # ρᵢ = p3_density(p3, D, F_rim, th) # TODO: tmp
         v_term_small = CO.particle_terminal_velocity(small_ice, ρₐ, ρᵢ)
         v_term_large = CO.particle_terminal_velocity(large_ice, ρₐ, ρᵢ)
-        ϕ_factor = use_aspect_ratio ? cbrt(ϕᵢ(state, D)) : FT(1)
+        # `state_components...` is either `state` or `(params, F_rim, ρ_rim)`
+        ϕ_factor = use_aspect_ratio ? cbrt(ϕᵢ(state_components..., D)) : FT(1)
         vₜ = D <= D_cutoff ? v_term_small(D) : v_term_large(D)
         return ϕ_factor * vₜ
     end
     return v_term
 end
-
 """
-    ice_terminal_velocity_number_weighted(state, logλ velocity_params, ρₐ; [use_aspect_ratio], [∫kwargs...])
+    ice_terminal_velocity_number_weighted(
+        velocity_params::CMP.Chen2022VelType, ρₐ, state::P3State, logλ;
+        [use_aspect_ratio], [∫kwargs...],
+    )
 
 Return the terminal velocity of the number-weighted mean ice particle size.
 
 # Arguments
-- `state`: A [`P3State`](@ref)
-- `logλ`: The log of the slope parameter [log(1/m)]
 - `velocity_params`: A [`CMP.Chen2022VelType`](@ref) with terminal velocity parameters
 - `ρₐ`: Air density [kg/m³]
+- `state`: A [`P3State`](@ref)
+- `logλ`: The log of the slope parameter [log(1/m)]
 
 # Keyword arguments
  - `use_aspect_ratio`: Bool flag set to `true` if we want to consider the effects
@@ -49,7 +53,7 @@ Return the terminal velocity of the number-weighted mean ice particle size.
 See also [`ice_terminal_velocity_mass_weighted`](@ref)
 """
 function ice_terminal_velocity_number_weighted(
-    state::P3State, logλ, velocity_params::CMP.Chen2022VelType, ρₐ;
+    velocity_params::CMP.Chen2022VelType, ρₐ, state::P3State, logλ;
     use_aspect_ratio = true, ∫kwargs...,
 )
     (; N_ice, L_ice) = state
@@ -57,7 +61,7 @@ function ice_terminal_velocity_number_weighted(
         return zero(N_ice)
     end
 
-    v_term = ice_particle_terminal_velocity(state, velocity_params, ρₐ; use_aspect_ratio)
+    v_term = ice_particle_terminal_velocity(velocity_params, ρₐ, state; use_aspect_ratio)
     n = DT.size_distribution(state, logλ)
 
     # ∫n(D) v(D) dD
@@ -67,15 +71,15 @@ function ice_terminal_velocity_number_weighted(
 end
 
 """
-    ice_terminal_velocity_mass_weighted(state, logλ, velocity_params, ρₐ; [use_aspect_ratio], [∫kwargs...])
+    ice_terminal_velocity_mass_weighted(velocity_params::CMP.Chen2022VelType, ρₐ, state::P3State, logλ; [use_aspect_ratio], [∫kwargs...])
 
 Return the terminal velocity of the mass-weighted mean ice particle size.
 
 # Arguments
-- `state`: A [`P3State`](@ref)
-- `logλ`: The log of the slope parameter [log(1/m)]
 - `velocity_params`: A [`CMP.Chen2022VelType`](@ref) with terminal velocity parameters
 - `ρₐ`: Air density [kg/m³]
+- `state`: A [`P3State`](@ref)
+- `logλ`: The log of the slope parameter [log(1/m)]
 
 # Keyword arguments
  - `use_aspect_ratio`: Bool flag set to `true` if we want to consider the effects
@@ -85,7 +89,7 @@ Return the terminal velocity of the mass-weighted mean ice particle size.
 See also [`ice_terminal_velocity_number_weighted`](@ref)
 """
 function ice_terminal_velocity_mass_weighted(
-    state::P3State, logλ, velocity_params::CMP.Chen2022VelType, ρₐ;
+    velocity_params::CMP.Chen2022VelType, ρₐ, state::P3State, logλ;
     use_aspect_ratio = true, ∫kwargs...,
 )
     (; N_ice, L_ice) = state
@@ -93,7 +97,7 @@ function ice_terminal_velocity_mass_weighted(
         return zero(L_ice)
     end
 
-    v_term = ice_particle_terminal_velocity(state, velocity_params, ρₐ; use_aspect_ratio)
+    v_term = ice_particle_terminal_velocity(velocity_params, ρₐ, state; use_aspect_ratio)
     n = DT.size_distribution(state, logλ)  # Number concentration at diameter D
 
     # ∫n(D) m(D) v(D) dD

--- a/test/p3_tests.jl
+++ b/test/p3_tests.jl
@@ -244,7 +244,7 @@ function test_particle_terminal_velocities(FT)
         # Allow for a D falling into every regime of the P3 Scheme
         Ds = range(FT(0.5e-4), stop = FT(4.5e-4), length = 5)
         expected = [0.08109, 0.4115, 0.7912, 1.1550, 1.4871]
-        v_term = P3.ice_particle_terminal_velocity(state, Chen2022, ρ_a; use_aspect_ratio)
+        v_term = P3.ice_particle_terminal_velocity(Chen2022, ρ_a, state; use_aspect_ratio)
         for i in axes(Ds, 1)
             D = Ds[i]
             vel = v_term(D)
@@ -256,7 +256,7 @@ function test_particle_terminal_velocities(FT)
         # Allow for a D falling into every regime of the P3 Scheme
         Ds = range(FT(0.5e-4), stop = FT(4.5e-4), length = 5)
         expected = [0.08109, 0.4115, 0.79121, 1.155, 1.487]
-        v_term = P3.ice_particle_terminal_velocity(state, Chen2022, ρ_a; use_aspect_ratio)
+        v_term = P3.ice_particle_terminal_velocity(Chen2022, ρ_a, state; use_aspect_ratio)
         for i in axes(Ds, 1)
             D = Ds[i]
             vel = v_term(D)
@@ -274,7 +274,7 @@ function test_particle_terminal_velocities(FT)
         # Allow for a D falling into every regime of the P3 Scheme
         Ds = range(FT(0.5e-4), stop = FT(4.5e-4), length = 5)
         expected = [0.13192, 0.50457, 0.90753, 1.3015, 1.6757]
-        v_term = P3.ice_particle_terminal_velocity(state, Chen2022, ρ_a; use_aspect_ratio)
+        v_term = P3.ice_particle_terminal_velocity(Chen2022, ρ_a, state; use_aspect_ratio)
         for i in axes(Ds, 1)
             D = Ds[i]
             vel = v_term(D)
@@ -285,7 +285,7 @@ function test_particle_terminal_velocities(FT)
         # Allow for a D falling into every regime of the P3 Scheme
         Ds = range(FT(0.5e-4), stop = FT(4.5e-4), length = 5)
         expected = [0.13191, 0.50457, 0.90753, 1.301499, 1.67569]
-        v_term = P3.ice_particle_terminal_velocity(state, Chen2022, ρ_a; use_aspect_ratio)
+        v_term = P3.ice_particle_terminal_velocity(Chen2022, ρ_a, state; use_aspect_ratio)
         for i in axes(Ds, 1)
             D = Ds[i]
             vel = v_term(D)
@@ -311,15 +311,15 @@ function test_bulk_terminal_velocities(FT)
 
         state₀ = P3.get_state(params; F_rim = FT(0.5), ρ_rim, L_ice = FT(0), N_ice)
         logλ = P3.get_distribution_logλ(state₀)
-        vel_n₀ = P3.ice_terminal_velocity_number_weighted(state₀, logλ, Chen2022, ρ_a)
-        vel_m₀ = P3.ice_terminal_velocity_mass_weighted(state₀, logλ, Chen2022, ρ_a)
+        vel_n₀ = P3.ice_terminal_velocity_number_weighted(Chen2022, ρ_a, state₀, logλ)
+        vel_m₀ = P3.ice_terminal_velocity_mass_weighted(Chen2022, ρ_a, state₀, logλ)
         @test iszero(vel_n₀)
         @test iszero(vel_m₀)
 
         state₀ = P3.get_state(params; F_rim = FT(0.5), ρ_rim, L_ice, N_ice = FT(0))
         logλ = P3.get_distribution_logλ(state₀)
-        vel_n₀ = P3.ice_terminal_velocity_number_weighted(state₀, logλ, Chen2022, ρ_a)
-        vel_m₀ = P3.ice_terminal_velocity_mass_weighted(state₀, logλ, Chen2022, ρ_a)
+        vel_n₀ = P3.ice_terminal_velocity_number_weighted(Chen2022, ρ_a, state₀, logλ)
+        vel_m₀ = P3.ice_terminal_velocity_mass_weighted(Chen2022, ρ_a, state₀, logλ)
         @test iszero(vel_n₀)
         @test iszero(vel_m₀)
 
@@ -337,7 +337,7 @@ function test_bulk_terminal_velocities(FT)
         for (k, F_rim) in enumerate(F_rims)
             state = P3.get_state(params; F_rim, ρ_rim, L_ice, N_ice)
             logλ = P3.get_distribution_logλ(state)
-            args = (state, logλ, Chen2022, ρ_a)
+            args = (Chen2022, ρ_a, state, logλ)
             accurate = true
             vel_n = P3.ice_terminal_velocity_number_weighted(args...; use_aspect_ratio = false, accurate)
             vel_m = P3.ice_terminal_velocity_mass_weighted(args...; use_aspect_ratio = false, accurate)
@@ -447,10 +447,10 @@ function test_numerical_integrals(FT)
             @test N_ice ≈ N_estim rtol = 1e-5
 
             # Bulk velocity comparison
-            vel_N = P3.ice_terminal_velocity_number_weighted(state, logλ, Chen2022, ρ_a; use_aspect_ratio, p)
-            vel_m = P3.ice_terminal_velocity_mass_weighted(state, logλ, Chen2022, ρ_a; use_aspect_ratio, p)
+            vel_N = P3.ice_terminal_velocity_number_weighted(Chen2022, ρ_a, state, logλ; use_aspect_ratio, p)
+            vel_m = P3.ice_terminal_velocity_mass_weighted(Chen2022, ρ_a, state, logλ; use_aspect_ratio, p)
 
-            v_term = P3.ice_particle_terminal_velocity(state, Chen2022, ρ_a; use_aspect_ratio)
+            v_term = P3.ice_particle_terminal_velocity(Chen2022, ρ_a, state; use_aspect_ratio)
             g(D) = v_term(D) * N′(D)
             vel_N_estim = P3.∫fdD(g, state, logλ; p) / N_ice
             vel_m_estim = P3.∫fdD(state, logλ; p) do D
@@ -527,13 +527,13 @@ function test_p3_melting(FT)
 
         T_cold = FT(273.15 - 0.01)
 
-        rate = P3.ice_melt(state, logλ, vel, aps, tps, T_cold, ρₐ, dt)
+        rate = P3.ice_melt(vel, aps, tps, T_cold, ρₐ, dt, state, logλ)
 
         @test rate.dNdt == 0
         @test rate.dLdt == 0
 
         T_warm = FT(273.15 + 0.01)
-        rate = P3.ice_melt(state, logλ, vel, aps, tps, T_warm, ρₐ, dt)
+        rate = P3.ice_melt(vel, aps, tps, T_warm, ρₐ, dt, state, logλ)
 
         @test rate.dNdt >= 0
         @test rate.dLdt >= 0
@@ -552,15 +552,69 @@ function test_p3_melting(FT)
         @test rate.dLdt ≈ ref_dLdt
 
         T_vwarm = FT(273.15 + 0.1)
-        rate = P3.ice_melt(state, logλ, vel, aps, tps, T_vwarm, ρₐ, dt)
+        rate = P3.ice_melt(vel, aps, tps, T_vwarm, ρₐ, dt, state, logλ)
 
         @test rate.dNdt == Nᵢ
         @test rate.dLdt == Lᵢ
     end
 end
 
+function test_p3_bulk_liquid_ice_collisions(FT)
+    params = CMP.ParametersP3(FT)
+    vel_params = CMP.Chen2022VelType(FT)
+    aps = CMP.AirProperties(FT)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 
-TT.@testset "P3 tests ($FT)" for FT in (Float64, Float32)
+    (; T_freeze) = params
+
+    ρₐ = FT(1.2)
+    qᵢ = FT(1e-4)
+    Lᵢ = qᵢ * ρₐ
+    Nᵢ = FT(2e5) * ρₐ
+    F_rim = FT(0.8)
+    ρ_rim = FT(800)
+
+    state = P3.get_state(params; F_rim, ρ_rim, L_ice = Lᵢ, N_ice = Nᵢ)
+    logλ = P3.get_distribution_logλ(state)
+    D̄ = exp(-logλ)
+
+    @testset "maximum dry freezing rate" begin
+        # Below freezing, max freeze rate is non-zero (check against reference value)
+        Tₐ = T_freeze - 1 // 10
+        max_rate = P3.compute_max_freeze_rate(aps, tps, vel_params, ρₐ, Tₐ, state)
+        @test max_rate(D̄) ≈ FT(9.35962884896919e-13) rtol = 1e-4
+
+        # At freezing, max freeze rate is zero
+        Tₐ = T_freeze
+        max_rate = P3.compute_max_freeze_rate(aps, tps, vel_params, ρₐ, Tₐ, state)
+        @test iszero(max_rate(D̄))
+
+        # Above freezing, max freeze rate is zero
+        Tₐ = T_freeze + 1 // 10
+        max_rate = P3.compute_max_freeze_rate(aps, tps, vel_params, ρₐ, Tₐ, state)
+        @test iszero(max_rate(D̄))
+    end
+
+    @testset "local rime density" begin
+        Tₐ = T_freeze - 1 // 10
+        ρ′_rim = P3.compute_local_rime_density(vel_params, ρₐ, Tₐ, state)
+        @test ρ′_rim(D̄, D̄) ≈ FT(159.5) rtol = 1e-6
+
+        a, b, c = 51, 114, -11 // 2 # coeffs for Eq. 17 in Cober and List (1993), converted to [kg / m³]
+        ρ′_rim_CL93(Rᵢ) = a + b * Rᵢ + c * Rᵢ^2  # Eq. 17 in Cober and List (1993), in [kg / m³], valid for 1 ≤ Rᵢ ≤ 8
+        ρ_ice = FT(916.7)  # density of solid bulk ice
+
+        ρ_rim_local = params.ρ_rim_local
+
+        @test ρ_rim_local(1) == ρ′_rim_CL93(1)
+        @test ρ_rim_local(8) == ρ′_rim_CL93(8)
+        @test ρ_rim_local(12) == ρ_ice
+    end
+
+end
+
+
+@testset "P3 tests ($FT)" for FT in (Float64, Float32)
     # state creation
     test_p3_state_creation(FT)
 
@@ -576,5 +630,8 @@ TT.@testset "P3 tests ($FT)" for FT in (Float64, Float32)
     # processes
     test_p3_het_freezing(FT)
     test_p3_melting(FT)
+
+    # bulk liquid-ice collisions and related processes
+    test_p3_bulk_liquid_ice_collisions(FT)
 end
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,3 +22,4 @@ TT.@testset "All tests" begin
     include("ventilation_tests.jl")
     include("DistributionTools_tests.jl")
 end
+nothing

--- a/test/ventilation_tests.jl
+++ b/test/ventilation_tests.jl
@@ -17,7 +17,7 @@ function test_ventilation_factor(FT)
         ρₐ = FT(1.2)     # Air density [kg/m³]
         state = P3.get_state(params; F_rim, ρ_rim, L_ice, N_ice)
         vent = state.params.vent
-        v_term = P3.ice_particle_terminal_velocity(state, vel, ρₐ)
+        v_term = P3.ice_particle_terminal_velocity(vel, ρₐ, state)
         vent_factor = CO.ventilation_factor(vent, aps, v_term)
         Ds = range(FT(0.5e-4), stop = FT(4.5e-4), length = 5)
         calc_vents = vent_factor.(Ds)


### PR DESCRIPTION
This P3 implements:
- dry freeze rate from Musil (1970) [[link](https://doi.org/10.1175/1520-0469(1970)027%3C0474:CMOHGI%3E2.0.CO;2)]
- local rime density from Cober and List (1993) [[link](https://doi.org/10.1175/1520-0469(1993)050%3C1591:MOTHAM%3E2.0.CO;2)]

I would find it helpful with a second pair of eyes on the papers to verify my implementation. The docstring and inline comments are quite verbose, so finding your way around the paper is hopefully easy.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
