### PR TITLE
fix: limiting behavior of 2M and P3 PSDs

### DIFF
--- a/src/P3_size_distribution.jl
+++ b/src/P3_size_distribution.jl
@@ -225,6 +225,7 @@ where `m(D)` is the mass of a particle at diameter `D` (see [`ice_mass`](@ref)).
 function get_distribution_logλ(
     state::P3State{FT}; logλ_min = log(1e1), logλ_max = log(1e7),
 ) where {FT}
+    (iszero(state.N_ice) || iszero(state.L_ice)) && return log(zero(FT))
     target_log_LdN = log(state.L_ice) - log(state.N_ice)
 
     shape_problem(logλ) = logLdivN(state, logλ) - target_log_LdN

--- a/test/microphysics2M_tests.jl
+++ b/test/microphysics2M_tests.jl
@@ -143,6 +143,34 @@ function test_microphysics2M(FT)
     end
 
     # 2M_microphysics - Seifert and Beheng 2006 double moment scheme tests
+    TT.@testset "Seifert and Beheng 2006 - PDF parameters limiting behavior" begin
+        N = 0.0
+        q = 0.0
+        ρₐ = 1.2
+        # limited rain drop size distribution
+        params = CM2.pdf_rain_parameters(SB2006.pdf_r, q, ρₐ, N)
+        TT.@test all(iszero, params)
+        n = CM2.size_distribution(SB2006.pdf_r, q, ρₐ, N)
+        TT.@test all(iszero, (n(0), n(0.1), n(Inf)))
+        bnds = CM2.get_size_distribution_bounds(SB2006.pdf_r, q, ρₐ, N)
+        TT.@test all(iszero, bnds)
+        # not limited rain drop size distribution
+        params = CM2.pdf_rain_parameters(SB2006_no_limiters.pdf_r, q, ρₐ, N)
+        TT.@test all(iszero, params)
+        n = CM2.size_distribution(SB2006_no_limiters.pdf_r, q, ρₐ, N)
+        TT.@test all(iszero, (n(0), n(0.1), n(Inf)))
+        bnds = CM2.get_size_distribution_bounds(SB2006_no_limiters.pdf_r, q, ρₐ, N)
+        TT.@test all(iszero, bnds)
+        # cloud drop size distribution
+        logA, logB = CM2.log_pdf_cloud_parameters_mass(SB2006.pdf_c, q, ρₐ, N)
+        TT.@test logA == -Inf
+        TT.@test logB == Inf
+        A, B = CM2.pdf_cloud_parameters_mass(SB2006.pdf_c, q, ρₐ, N)
+        TT.@test A == 0
+        TT.@test B == Inf
+        n = CM2.size_distribution(SB2006.pdf_c, q, ρₐ, N)
+        TT.@test all(iszero, (n(0), n(0.1), n(Inf)))
+    end
     TT.@testset "limiting lambda_r and x_r - Seifert and Beheng 2006" begin
         #setup
         q_rai = [FT(0), FT(1e-3), FT(1e-4), FT(1e-2)]

--- a/test/p3_tests.jl
+++ b/test/p3_tests.jl
@@ -178,6 +178,11 @@ function test_shape_solver(FT)
         params = CMP.ParametersP3(FT; slope_law)
 
         @testset "Shape parameters - nonlinear solver" begin
+            # -- First, test limiting behavior: `N_ice = L_ice = 0` --
+            state = P3.get_state(params; F_rim = FT(0.5), ρ_rim = FT(500), L_ice = FT(0), N_ice = FT(0))
+            logλ = P3.get_distribution_logλ(state)
+            @test logλ == -Inf
+            # --
 
             # initialize test values:
             ep = 1 #1e4 * eps(FT)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

Some reasonable limits for distributions. Needed in particular for the cases when there's no particles and no mass, because then the ratio `L/N` is undefined.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
