### PR TITLE
fix: remove allocations in P3 scheme

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ RootSolvers = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
+UnrolledUtilities = "0fe1646c-419e-43be-ac14-22321958931b"
 
 [weakdeps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -33,4 +34,5 @@ RootSolvers = "0.3, 0.4, 1"
 SpecialFunctions = "1, 2"
 StaticArrays = "1.9"
 Thermodynamics = "0.12.14, 0.13"
+UnrolledUtilities = "0.1"
 julia = "1.6"

--- a/src/Common.jl
+++ b/src/Common.jl
@@ -4,6 +4,7 @@
 module Common
 
 import SpecialFunctions as SF
+using UnrolledUtilities
 
 import ..Parameters as CMP
 import ..ThermodynamicsInterface as TDI
@@ -337,7 +338,7 @@ Needed for numerical integrals in the P3 scheme.
 function particle_terminal_velocity(velocity_params::CMP.TerminalVelocityType, ρs...)
     (ai, bi, ci) = Chen2022_vel_coeffs(velocity_params, ρs...)
     v_terms = Chen2022_monodisperse_pdf.(ai, bi, ci)  # tuple of functions
-    v_term(D) = sum(@. D |> v_terms)
+    v_term(D) = unrolled_sum(v_term -> v_term(D), v_terms)
     return v_term
 end
 

--- a/src/IceNucleation.jl
+++ b/src/IceNucleation.jl
@@ -150,7 +150,7 @@ function P3_deposition_N_i(ip::CMP.MorrisonMilbrandt2014, T::FT) where {FT}
         max(FT(0), FT(ip.c₁ * exp(ip.c₂ * (T₀ - T_thres)))),
         max(FT(0), FT(ip.c₁ * exp(ip.c₂ * (T₀ - T)))),
     )
-    return Nᵢ * 1e3  # converts L^-1 to m^-3
+    return Nᵢ * 1000  # converts L^-1 to m^-3
 end
 
 """
@@ -176,9 +176,9 @@ function P3_het_N_i(
     Δt::FT,
 ) where {FT}
 
-    a = ip.het_a                # (celcius)^-1
-    B = ip.het_B                # cm^-3 s^-1 for rain water
-    V_l_converted = V_l * 1e6   # converted from m^3 to cm^3
+    a = ip.het_a                     # (celcius)^-1
+    B = ip.het_B                     # cm^-3 s^-1 for rain water
+    V_l_converted = V_l * 1_000_000  # converted from m^3 to cm^3
     Tₛ = ip.T₀ - T
 
     return N_l * (1 - exp(-B * V_l_converted * Δt * exp(a * Tₛ)))

--- a/test/gpu_tests.jl
+++ b/test/gpu_tests.jl
@@ -1246,7 +1246,15 @@ function test_gpu(FT)
         kernel!(output, ip_P3, T, N_l, V_l, Δt; ndrange)
 
         # test if P3_het_N_i is callable and returns reasonable values
-        TT.@test Array(output)[1] ≈ FT(0.0002736160475969029)
+        ref_val = if FT == Float64
+            FT(0.0002736160475969029)
+        else
+            # loss of precision due to
+            # `exp(-B * V_l_converted * Δt * exp(a * Tₛ))` -> 0.9999999 (Float32)
+            # instead of 0.9999998631919762 (Float64).
+            FT(0.00023841858f0)
+        end
+        TT.@test Array(output)[1] ≈ ref_val
 
         dims = (1, 1)
         (; output, ndrange) = setup_output(dims, FT)

--- a/test/p3_tests.jl
+++ b/test/p3_tests.jl
@@ -781,6 +781,14 @@ function test_p3_bulk_liquid_ice_collisions(FT)
         @test BCCOL ≈ 3.7184509f-9
         @test BRCOL ≈ 4.2099646f-7
         @test ∫𝟙_wet_M_col ≈ 1.58113f-5
+
+        ### Test the bulk source function
+        rates = P3.bulk_liquid_ice_collision_sources(
+            params, logλ, Lᵢ, Nᵢ, F_rim, ρ_rim,
+            psd_c, psd_r, L_c, N_c, L_r, N_r,
+            aps, tps, vel_params, ρₐ, T,
+        )
+        @test eltype(rates) == FT  # check type stability
     end
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

This pull request introduces several improvements and refactorings to the P3 microphysics scheme and its related utilities, focusing on code clarity, numerical stability, and performance benchmarking. The most significant changes are grouped below by theme.

### P3 Scheme Refactoring and Utility Improvements

* Added the `get_bounded_thresholds` utility to consistently clamp and sanitize particle size thresholds, and refactored related functions (`integral_bounds`, `get_segments`) to use this for more robust interval handling. This improves the reliability of segment and bounds calculations for particle distributions. [[1]](diffhunk://#diff-235201250cd4f055da80487c6c91e1a9d72731a7cfd6cfdc99cabaf36dea788dR220-R244) [[2]](diffhunk://#diff-63db617954a2e50cf06bb0f5ff018891a0a7a2da1f4f16261c2c6e8d1eeda74cL167-R175)
* Refactored particle property functions (`ice_mass`, `ice_density`, `get_∂mass_∂D_coeffs`, `∂ice_mass_∂D`, `ϕᵢ`) to accept explicit arguments or state objects rather than variadic arguments, improving type stability and readability. [[1]](diffhunk://#diff-235201250cd4f055da80487c6c91e1a9d72731a7cfd6cfdc99cabaf36dea788dL303-R308) [[2]](diffhunk://#diff-235201250cd4f055da80487c6c91e1a9d72731a7cfd6cfdc99cabaf36dea788dL325-R335) [[3]](diffhunk://#diff-235201250cd4f055da80487c6c91e1a9d72731a7cfd6cfdc99cabaf36dea788dL341-R347) [[4]](diffhunk://#diff-235201250cd4f055da80487c6c91e1a9d72731a7cfd6cfdc99cabaf36dea788dL394-R409)

### Numerical Integration and Terminal Velocity

* Improved numerical integration routines by adding input validation (returning zero for invalid bounds) and using `unrolled_sum` for efficient summation in `particle_terminal_velocity`, enhancing both correctness and performance. [[1]](diffhunk://#diff-63db617954a2e50cf06bb0f5ff018891a0a7a2da1f4f16261c2c6e8d1eeda74cL37-R37) [[2]](diffhunk://#diff-63db617954a2e50cf06bb0f5ff018891a0a7a2da1f4f16261c2c6e8d1eeda74cL59-R59) [[3]](diffhunk://#diff-3823607d8c154df76812d06df3339ce4251f8ae8a60e1a9f2f2547122e8ebc54L340-R341) [[4]](diffhunk://#diff-3823607d8c154df76812d06df3339ce4251f8ae8a60e1a9f2f2547122e8ebc54R7)

### Consistency and Readability Updates

* Standardized unit conversion factors in ice nucleation routines for clarity (e.g., using `1000` and `1_000_000` instead of scientific notation). [[1]](diffhunk://#diff-6636c90ace8799ad4bb5048d3240c8d88686a6ac53bea7d01569b609aced7b1bL153-R153) [[2]](diffhunk://#diff-6636c90ace8799ad4bb5048d3240c8d88686a6ac53bea7d01569b609aced7b1bL181-R181)
* Various code style improvements in test and benchmark files, including argument formatting and variable naming for clarity and maintainability. [[1]](diffhunk://#diff-1cd7759d8aae59d02dddf1a45ea5762a9734eefbd759f0c81289107b59326097L28-R28) [[2]](diffhunk://#diff-1cd7759d8aae59d02dddf1a45ea5762a9734eefbd759f0c81289107b59326097L58-R58) [[3]](diffhunk://#diff-1cd7759d8aae59d02dddf1a45ea5762a9734eefbd759f0c81289107b59326097L76-R75) [[4]](diffhunk://#diff-1cd7759d8aae59d02dddf1a45ea5762a9734eefbd759f0c81289107b59326097L122-R112) [[5]](diffhunk://#diff-1cd7759d8aae59d02dddf1a45ea5762a9734eefbd759f0c81289107b59326097L141-R127) [[6]](diffhunk://#diff-1cd7759d8aae59d02dddf1a45ea5762a9734eefbd759f0c81289107b59326097L160-R189) [[7]](diffhunk://#diff-1cd7759d8aae59d02dddf1a45ea5762a9734eefbd759f0c81289107b59326097L286-R209)

### Testing and Benchmarking Enhancements

* Expanded and updated performance benchmarks to cover new and refactored P3 routines, including state construction, distribution parameter calculation, terminal velocities, and ice nucleation/melt processes. Also added type stability checks in test cases. [[1]](diffhunk://#diff-0c5aa6c9492f0eb3c91e24688f05e4e8dd2198d016bd30851bc69a0d20802446R784-R791) [[2]](diffhunk://#diff-b71e4c4b5e231f8b415353504d02a73d49f7f6f91ad63f0244e7bec9bc0c7433L1249-R1257) [[3]](diffhunk://#diff-1cd7759d8aae59d02dddf1a45ea5762a9734eefbd759f0c81289107b59326097L160-R189)

These changes collectively improve the robustness, maintainability, and test coverage of the P3 microphysics codebase.

