### PR TITLE
Guard cloud tv against negative N or q

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.26.3"
+version = "0.26.4"
 
 [deps]
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -623,6 +623,10 @@ function cloud_terminal_velocity(
     q_liq, ρₐ, N_liq,
 ) where {FT}
 
+    if N_liq < eps(FT) || q_liq < eps(FT)
+        return (FT(0), FT(0))
+    end
+
     (; νc, μc) = pdf_c
     (; Bc) = pdf_cloud_parameters_mass(pdf_c, q_liq, ρₐ, N_liq)
 
@@ -634,9 +638,6 @@ function cloud_terminal_velocity(
         q_liq < eps(FT) ? FT(0) :
         terminal_velocity_prefactor * DT.generalized_gamma_Mⁿ(νc, μc, Bc, N_liq, FT(5 / 3)) / ρₐ / q_liq
 
-    if q_liq >= 5e-3
-        @show terminal_velocity_prefactor, vt0, vt1
-    end
     return (vt0, vt1)
 
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Guard cloud tv against negative N or q

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
