### PR TITLE
fix ClimaParams compat; tag v0.27.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.27.3"
+version = "0.27.4"
 
 [deps]
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
@@ -23,7 +23,7 @@ MLJ = "add582a8-e3ab-11e8-2d5e-e98b27df1bc7"
 EmulatorModelsExt = ["DataFrames", "MLJ"]
 
 [compat]
-ClimaParams = "0.12, 1"
+ClimaParams = "1"
 DataFrames = "1.6"
 DocStringExtensions = "0.8, 0.9"
 ForwardDiff = "0.10, 1"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Fix ClimaParams compat to always use v1+
With the current compat, the ClimaAtmos downgrade test fails, e.g. [here](https://github.com/CliMA/ClimaAtmos.jl/actions/runs/17687417386/job/50274988312?pr=4013)
