### PR TITLE
use TD v0.15; tag patch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.28.0"
+version = "0.28.1"
 
 [deps]
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
@@ -33,6 +33,6 @@ MLJ = "0.20"
 RootSolvers = "0.3, 0.4, 1"
 SpecialFunctions = "1, 2"
 StaticArrays = "1.9"
-Thermodynamics = "0.14"
+Thermodynamics = "0.14, 0.15"
 UnrolledUtilities = "0.1"
 julia = "1.6"

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -206,7 +206,7 @@ function benchmark_test(FT)
     bench_press(FT, CM0.remove_precipitation, (p0m, q_liq, q_ice), 12)
 
     # 1-moment
-    bench_press(FT, CM1.accretion, (liquid, rain, blk1mvel.rain, ce, q_liq, q_rai, ρ_air), 350)
+    bench_press(FT, CM1.accretion, (liquid, rain, blk1mvel.rain, ce, q_liq, q_rai, ρ_air), 360)
     bench_press(FT, CMD.radar_reflectivity_1M, (rain, q_rai, ρ_air), 300)
 
     # 2-moment


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Update the compat for Thermodynamics and tag a patch release so it can be used downstream (ClimaAtmos, ClimaCoupler)

Supersedes #647 

Increases the performance limit of one test from 350 to 360
