### PR TITLE
Use dedicated sqrt/cbrt instructions rather than generic pow

### DIFF
--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -541,9 +541,9 @@ function evaporation_sublimation(
             4 * FT(π) * n0 / ρ * S * G * λ_inv^FT(2) *
             (
                 a_vent +
-                b_vent * (ν_air / D_vapor)^FT(1 / 3) /
+                b_vent * cbrt(ν_air / D_vapor) /
                 (r0 / λ_inv)^((ve + Δv) / FT(2)) *
-                (FT(2) * v0 * χv / ν_air * λ_inv)^FT(1 / 2) *
+                sqrt(2v0 * χv / ν_air * λ_inv) *
                 SF.gamma((ve + Δv + FT(5)) / FT(2))
             )
     end


### PR DESCRIPTION
I was perusing the source and I noticed these. It is possibly unimportant, but in an isolated setting `sqrt` can be substantially faster than `pow` (eg 2-10x faster depending on float type and device). I believe this can also unblock registers in kernels with high register pressure (eg if trying to fuse lots of ops into big kernels).

I think the code is actually a bit easier to read as well.

(Perhaps there are other places where this same change can be made --- I am happy to look around and find them if this seems like a positive change.)