### PR TITLE
revert 2M epsilon change

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.29.0"
+version = "0.29.1"
 
 [deps]
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"

--- a/src/Common.jl
+++ b/src/Common.jl
@@ -26,6 +26,8 @@ export ventilation_factor
     computations.
 """
 ϵ_numerics(FT) = sqrt(floatmin(FT))
+ϵ_numerics_2M_M(FT) = eps(FT)
+ϵ_numerics_2M_N(FT) = eps(FT)
 
 """
     G_func_liquid(air_props, tps, T)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Revert 2M epsilon change for numerical stability. Using `eps(FT)` for 2M microphysics is safer as we have division of variables. These thresholds will be replaced by appropriate variable limits in the future.
This PR will fix the failure of CI in `KinematicDriver.jl` and `ClimaAtmos.jl`.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
