### PR TITLE
Fix 2M type instabilities and add tests to catch them

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.31.1"
+version = "0.31.2"
 
 [deps]
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"

--- a/test/microphysics2M_tests.jl
+++ b/test/microphysics2M_tests.jl
@@ -350,7 +350,7 @@ function test_microphysics2M(FT)
             (; Br) = CM2.pdf_rain_parameters_mass(SB.pdf_r, q_rai, ρ, N_rai)
 
             dNrdt_sc = -krr * N_rai * ρ * q_rai * (1 + κrr / Br)^-5 * √(ρ0 / ρ)
-            Dr = ∛(xr_mean / 1000 / FT(π) * 6)
+            Dr = cbrt(xr_mean / 1000 / FT(π) * 6)
             ΔDr = Dr - Deq
             ϕ_br =
                 Dr < 0.35e-3 ? FT(-1) :

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ TT.@testset "All tests" begin
     include("microphysics0M_tests.jl")
     include("microphysics1M_tests.jl")
     include("bulk_tendencies_tests.jl")
+    include("type_stability_tests.jl")
     include("microphysics2M_tests.jl")
     include("microphysics_noneq_tests.jl")
     include("cloud_diagnostics.jl")

--- a/test/type_stability_tests.jl
+++ b/test/type_stability_tests.jl
@@ -1,0 +1,114 @@
+using Test
+import ClimaParams as CP
+import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.BulkMicrophysicsTendencies as BMT
+import CloudMicrophysics.ThermodynamicsInterface as TDI
+
+
+
+function run_type_stability_tests()
+
+    @testset "BulkMicrophysicsTendencies - Broadcast Type Stability" begin
+
+        for FT in (Float32, Float64)
+            println("Testing type stability for $FT...")
+
+            tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
+            N = 10
+
+            # --- 0-Moment ---
+            mp0 = CMP.Microphysics0MParams(FT)
+            T_0M = fill(FT(280), N)
+            q_lcl_0M = fill(FT(1e-3), N)
+            q_icl_0M = fill(FT(1e-4), N)
+
+            tendencies_0M =
+                BMT.bulk_microphysics_tendencies.(
+                    Ref(BMT.Microphysics0Moment()),
+                    Ref(mp0),
+                    Ref(tps),
+                    T_0M,
+                    q_lcl_0M,
+                    q_icl_0M,
+                )
+
+            @test tendencies_0M isa Vector
+            @test eltype(tendencies_0M) <: NamedTuple
+            # strict check
+            val0 = tendencies_0M[1]
+            for k in keys(val0)
+                @test getproperty(val0, k) isa FT
+            end
+
+            # --- 1-Moment ---
+            mp1 = CMP.Microphysics1MParams(FT)
+            ρ = fill(FT(1.2), N)
+            T = fill(FT(280), N)
+            q_tot = fill(FT(0.012), N)
+            q_lcl = fill(FT(1e-3), N)
+            q_icl = fill(FT(1e-4), N)
+            q_rai = fill(FT(1e-4), N)
+            q_sno = fill(FT(1e-4), N)
+
+            tendencies_1M =
+                BMT.bulk_microphysics_tendencies.(
+                    Ref(BMT.Microphysics1Moment()),
+                    Ref(mp1),
+                    Ref(tps),
+                    ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno,
+                )
+
+            @test tendencies_1M isa Vector
+            val1 = tendencies_1M[1]
+            for k in keys(val1)
+                @test getproperty(val1, k) isa FT
+            end
+
+            # --- 2-Moment (Warm Rain) ---
+            mp2_warm = CMP.Microphysics2MParams(FT; with_ice = false)
+
+            n_lcl = fill(FT(1e8), N)
+            n_rai = fill(FT(1e4), N)
+
+            tendencies_2M_warm =
+                BMT.bulk_microphysics_tendencies.(
+                    Ref(BMT.Microphysics2Moment()),
+                    Ref(mp2_warm),
+                    Ref(tps),
+                    ρ, T, q_lcl, n_lcl, q_rai, n_rai,
+                )
+
+            @test tendencies_2M_warm isa Vector
+            val2w = tendencies_2M_warm[1]
+            for k in keys(val2w)
+                @test getproperty(val2w, k) isa FT
+            end
+
+            # --- 2-Moment (Warm + Ice P3) ---
+            mp2_p3 = CMP.Microphysics2MParams(FT; with_ice = true)
+            q_ice = fill(FT(1e-4), N)
+            n_ice = fill(FT(1e5), N)
+            q_rim = fill(FT(1e-5), N)
+            b_rim = fill(FT(1e-7), N)
+            logλ = fill(FT(0), N) # Not used if ice=0, but we test ice path
+
+            tendencies_2M_p3 =
+                BMT.bulk_microphysics_tendencies.(
+                    Ref(BMT.Microphysics2Moment()),
+                    Ref(mp2_p3),
+                    Ref(tps),
+                    ρ, T, q_lcl, n_lcl, q_rai, n_rai,
+                    q_ice, n_ice, q_rim, b_rim, logλ,
+                )
+
+            @test tendencies_2M_p3 isa Vector
+            val2p3 = tendencies_2M_p3[1]
+            for k in keys(val2p3)
+                @test getproperty(val2p3, k) isa FT
+            end
+
+        end
+    end
+end
+
+run_type_stability_tests()


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
* Fixes type instability in 2M microphysics that caused broadcasting errors
* Adds tests to catch such type instabilities
* Bumps patch release

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
