### PR TITLE
Add q_tot to 2M BMT API (not needed now, but likely will be later)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.31.2"
+version = "0.31.3"
 
 [deps]
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"

--- a/src/BulkMicrophysicsTendencies.jl
+++ b/src/BulkMicrophysicsTendencies.jl
@@ -423,6 +423,7 @@ For warm rain + P3 ice, see the method that accepts `Microphysics2MParams{FT, WR
 - `tps`: Thermodynamics parameters
 - `ρ`: Air density (kg/m³)
 - `T`: Temperature (K)
+- `q_tot`: Total water specific content (kg/kg)
 - `q_lcl`: Cloud liquid specific content (kg/kg)
 - `n_lcl`: Cloud droplet number per kg air (1/kg)
 - `q_rai`: Rain specific content (kg/kg)
@@ -444,6 +445,7 @@ For warm rain + P3 ice, see the method that accepts `Microphysics2MParams{FT, WR
     tps,
     ρ,
     T,
+    q_tot,
     q_lcl,
     n_lcl,
     q_rai,
@@ -511,6 +513,7 @@ to be non-Nothing, eliminating runtime type checks and dynamic dispatch.
 - `tps`: Thermodynamics parameters
 - `ρ`: Air density (kg/m³)
 - `T`: Temperature (K)
+- `q_tot`: Total water specific content (kg/kg) 
 - `q_lcl`: Cloud liquid specific content (kg/kg)
 - `n_lcl`: Cloud droplet number per kg air (1/kg)
 - `q_rai`: Rain specific content (kg/kg)
@@ -539,6 +542,7 @@ to be non-Nothing, eliminating runtime type checks and dynamic dispatch.
     tps,
     ρ,
     T,
+    q_tot,
     q_lcl,
     n_lcl,
     q_rai,

--- a/test/bulk_tendencies_tests.jl
+++ b/test/bulk_tendencies_tests.jl
@@ -573,10 +573,8 @@ function test_bulk_microphysics_2m_tendencies(FT)
             T,
             q_tot,
             q_lcl,
-            FT(0),
-            q_rai,
-            FT(0),
             n_lcl,
+            q_rai,
             n_rai,
         )
 
@@ -596,13 +594,11 @@ function test_bulk_microphysics_2m_tendencies(FT)
             tps,
             ρ,
             T,
-            FT(0.01),
-            FT(1e-3),
-            FT(0),
-            FT(1e-4),
-            FT(0),
-            FT(1e8),
-            FT(1e4),
+            FT(0.01),   # q_tot
+            FT(1e-3),   # q_lcl
+            FT(1e8),    # n_lcl
+            FT(1e-4),   # q_rai
+            FT(1e4),    # n_rai
         )
         @test tendencies isa @NamedTuple{
             dq_lcl_dt::FT,
@@ -634,6 +630,7 @@ function test_bulk_microphysics_p3_tendencies(FT)
         # Test that P3 includes 2M warm rain processes
         ρ = FT(1.2)
         T = T_freeze + FT(10)  # Above freezing
+        q_tot = FT(0.015)
         q_lcl = FT(2e-3)  # Significant cloud liquid
         n_lcl = FT(1e8 / ρ)  # 100/mg
         q_rai = FT(0)
@@ -650,6 +647,7 @@ function test_bulk_microphysics_p3_tendencies(FT)
             tps,
             ρ,
             T,
+            q_tot,
             q_lcl,
             n_lcl,
             q_rai,
@@ -671,6 +669,7 @@ function test_bulk_microphysics_p3_tendencies(FT)
         # Ice should melt above freezing
         ρ = FT(1.2)
         T = T_freeze + FT(5)  # Above freezing
+        q_tot = FT(0.015)
         q_lcl = FT(0)
         n_lcl = FT(0)
         q_rai = FT(0)
@@ -694,6 +693,7 @@ function test_bulk_microphysics_p3_tendencies(FT)
             tps,
             ρ,
             T,
+            q_tot,
             q_lcl,
             n_lcl,
             q_rai,
@@ -715,6 +715,7 @@ function test_bulk_microphysics_p3_tendencies(FT)
         # Ice collecting cloud liquid below freezing
         ρ = FT(1.2)
         T = T_freeze - FT(10)  # Below freezing
+        q_tot = FT(0.015)
         q_lcl = FT(1e-3)  # Cloud liquid
         n_lcl = FT(1e8) / ρ
         q_rai = FT(1e-5)  # Some rain
@@ -738,6 +739,7 @@ function test_bulk_microphysics_p3_tendencies(FT)
             tps,
             ρ,
             T,
+            q_tot,
             q_lcl,
             n_lcl,
             q_rai,
@@ -758,6 +760,7 @@ function test_bulk_microphysics_p3_tendencies(FT)
     @testset "BulkMicrophysicsTendencies P3 - Return finiteness" begin
         ρ = FT(1.2)
         T = T_freeze - FT(5)
+        q_tot = FT(0.015)
         q_lcl = FT(1e-3)
         n_lcl = FT(1e8) / ρ
         q_rai = FT(1e-4)
@@ -780,6 +783,7 @@ function test_bulk_microphysics_p3_tendencies(FT)
             tps,
             ρ,
             T,
+            q_tot,
             q_lcl,
             n_lcl,
             q_rai,
@@ -803,6 +807,7 @@ function test_bulk_microphysics_p3_tendencies(FT)
     @testset "BulkMicrophysicsTendencies P3 - Type stability" begin
         ρ = FT(1.2)
         T = T_freeze - FT(5)
+        q_tot = FT(0.015)
         q_lcl = FT(1e-3)
         n_lcl = FT(1e8) / ρ
         q_rai = FT(1e-4)
@@ -825,6 +830,7 @@ function test_bulk_microphysics_p3_tendencies(FT)
             tps,
             ρ,
             T,
+            q_tot,
             q_lcl,
             n_lcl,
             q_rai,

--- a/test/gpu_tests.jl
+++ b/test/gpu_tests.jl
@@ -820,6 +820,7 @@ end
     output::AbstractArray{FT},
     ρ,
     T,
+    q_tot,
     q_lcl,
     n_lcl,
     q_rai,
@@ -834,6 +835,7 @@ end
             tps,
             ρ[i],
             T[i],
+            q_tot[i],
             q_lcl[i],
             n_lcl[i],
             q_rai[i],
@@ -855,6 +857,7 @@ end
     output::AbstractArray{FT},
     ρ,
     T,
+    q_tot,
     q_lcl,
     n_lcl,
     q_rai,
@@ -873,6 +876,7 @@ end
             tps,
             ρ[i],
             T[i],
+            q_tot[i],
             q_lcl[i],
             n_lcl[i],
             q_rai[i],
@@ -1575,7 +1579,7 @@ function test_gpu(FT)
             @. n_rai = FT(1e6)
 
             kernel! = test_bulk_tendencies_2m_warm_kernel!(backend, work_groups)
-            kernel!(mp_2m_warm, tps, output, ρ, T, q_lcl, n_lcl, q_rai, n_rai; ndrange)
+            kernel!(mp_2m_warm, tps, output, ρ, T, q_tot, q_lcl, n_lcl, q_rai, n_rai; ndrange)
             TT.@test !any(isnan.(Array(output)))  # No NaNs
             TT.@test all(Array(output)[5, :] .== FT(0))  # Ice tendency is zero for warm-only
             TT.@test all(Array(output)[6, :] .== FT(0))  # Rime tendency is zero for warm-only

--- a/test/type_stability_tests.jl
+++ b/test/type_stability_tests.jl
@@ -75,7 +75,7 @@ function run_type_stability_tests()
                     Ref(BMT.Microphysics2Moment()),
                     Ref(mp2_warm),
                     Ref(tps),
-                    ρ, T, q_lcl, n_lcl, q_rai, n_rai,
+                    ρ, T, q_tot, q_lcl, n_lcl, q_rai, n_rai,
                 )
 
             @test tendencies_2M_warm isa Vector
@@ -97,7 +97,7 @@ function run_type_stability_tests()
                     Ref(BMT.Microphysics2Moment()),
                     Ref(mp2_p3),
                     Ref(tps),
-                    ρ, T, q_lcl, n_lcl, q_rai, n_rai,
+                    ρ, T, q_tot, q_lcl, n_lcl, q_rai, n_rai,
                     q_ice, n_ice, q_rim, b_rim, logλ,
                 )
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Adds `q_tot` to 2M API. While it's not needed now, it likely will be needed later. This makes the 1M and 2M APIs more consistent and avoids breaking changes later. 


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
