### PR TITLE
fix: gpu tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -32,4 +32,4 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
 KernelAbstractions = "0.9"
-MLJFlux = "0.4"
+MLJFlux = "0.4 - 0.6"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

- make type check stronger by returning NamedTuples instead of writing floats to arrays. Arrays with floats allow for incorrect Float32/Float64 type changes, while arrays with NamedTuples ensure same type.
- fix GPU indexing bug: Group -> Global
- make more `@testset`s for easier overview
- fix AerosolActivation.M_activated_per_mode, which incorrectly always returned Float64



## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->

<details> <summary> Example of how nested testsets improves overview for failing tests </summary>

Note: Sub-sections are _only_ expanded if tests fail. If all tests succeed, they'd look like:
```
Test Summary:       | Pass  Broken  Total   Time
GPU tests (Float64) |  111       1    112  38.7s
Test Summary:       | Pass  Broken  Total   Time
GPU tests (Float32) |  111       1    112  39.7s
```

If some tests fail, it may look like:
```
GPU tests (Float64)                                           |   88     1      9     98  2m07.2s
  Aerosol activation kernels                                  |    6                   6     0.6s
  non-equilibrium microphysics kernels                        |                 1      1     1.4s
  Chen 2022 terminal velocity kernels                         |    4                   4     0.5s
  0-moment microphysics kernels                               |    1                   1     0.1s
  1-moment microphysics kernels                               |   11                  11     0.9s
  2-moment microphysics kernels                               |   45     1            46     1.2s
    2-moment autoconversion                                   |    6                   6     0.2s
    2-moment accretion                                        |    3     1             4     0.4s
  Common Kernels                                              |    7                   7     0.4s
  Ice Nucleation kernels                                      |    3            7     10     2.2s
    CMI_het.IN.dust_activated_number_fraction                 |                 1      1     0.6s
    CMI_het.IN.MohlerDepositionRate                           |                 1      1     0.4s
    CMI_het.IN.deposition_J                                   |                 1      1     0.2s
    CMI_het.IN.ABIFM_J                                        |                 1      1     0.2s
    CMI_het.P3_deposition_N_i                                 |                 1      1     0.2s
    CMI_het.P3_het_N_i                                        |                 1      1     0.2s
    CMI_het.INP_concentration_frequency                       |                 1      1     0.2s
    CMI_het.homogeneous_J_cubic, CMI_het.homogeneous_J_linear |    3                   3     0.1s
  Modal nucleation kernels                                    |    3                   3     0.5s
  Bulk microphysics tendencies kernels                        |    8            1      9     1.9s
    0M                                                        |    3                   3     0.1s
    1M                                                        |    2                   2     0.4s
    2M warm                                                   |    3                   3     0.2s
    2M+P3                                                     |                 1      1     1.2s
```

</details


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
