### PR TITLE
Expose 0M microphysics tendency based on saturation excess; bump patch release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.31.6"
+version = "0.31.7"
 
 [deps]
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"

--- a/test/type_stability_tests.jl
+++ b/test/type_stability_tests.jl
@@ -40,6 +40,27 @@ function run_type_stability_tests()
                 @test getproperty(val0, k) isa FT
             end
 
+            # --- 0-Moment (S_0 mode) ---
+            ρ_0M = fill(FT(1.2), N)
+            q_vap_sat_0M = fill(FT(0.01), N)
+            tendencies_0M_S0 =
+                BMT.bulk_microphysics_tendencies.(
+                    Ref(BMT.Microphysics0Moment()),
+                    Ref(mp0),
+                    Ref(tps),
+                    T_0M,
+                    q_lcl_0M,
+                    q_icl_0M,
+                    q_vap_sat_0M,
+                )
+
+            @test tendencies_0M_S0 isa Vector
+            @test eltype(tendencies_0M_S0) <: NamedTuple
+            val0s = tendencies_0M_S0[1]
+            for k in keys(val0s)
+                @test getproperty(val0s, k) isa FT
+            end
+
             # --- 1-Moment ---
             mp1 = CMP.Microphysics1MParams(FT)
             ρ = fill(FT(1.2), N)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Exposes the 0M microphysics option in BMT where condensate is removed that exceeds a supersaturation threshold.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
