### PR TITLE
Clamp densities for safety; use cbrt(floatmin) for eps_numerics; bump patch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 authors = ["Climate Modeling Alliance"]
-version = "0.31.7"
+version = "0.31.8"
 
 [deps]
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"

--- a/src/BulkMicrophysicsTendencies.jl
+++ b/src/BulkMicrophysicsTendencies.jl
@@ -167,7 +167,8 @@ This is a pure function of local thermodynamic state, suitable for:
     q_sno,
     N_lcl = zero(ρ),
 )
-    # Clamp negative specific contents to zero (robustness against numerical errors)
+    # Clamp negative inputs to zero (robustness against numerical errors)
+    ρ = UT.clamp_to_nonneg(ρ)
     q_tot = UT.clamp_to_nonneg(q_tot)
     q_lcl = UT.clamp_to_nonneg(q_lcl)
     q_icl = UT.clamp_to_nonneg(q_icl)
@@ -484,7 +485,8 @@ For warm rain + P3 ice, see the method that accepts `Microphysics2MParams{FT, WR
     b_rim = zero(ρ),
     logλ = zero(ρ),
 ) where {FT, WR}
-    # Clamp negative specific contents and number concentrations to zero (robustness against numerical errors)
+    # Clamp negative inputs to zero (robustness against numerical errors)
+    ρ = UT.clamp_to_nonneg(ρ)
     q_tot = UT.clamp_to_nonneg(q_tot)
     q_lcl = UT.clamp_to_nonneg(q_lcl)
     q_rai = UT.clamp_to_nonneg(q_rai)
@@ -592,7 +594,8 @@ to be non-Nothing, eliminating runtime type checks and dynamic dispatch.
     b_rim = zero(ρ),
     logλ = zero(ρ),
 ) where {FT, WR, ICE <: CMP.P3IceParams}
-    # Clamp negative specific contents and number concentrations to zero (robustness against numerical errors)
+    # Clamp negative inputs to zero (robustness against numerical errors)
+    ρ = UT.clamp_to_nonneg(ρ)
     q_tot = UT.clamp_to_nonneg(q_tot)
     q_lcl = UT.clamp_to_nonneg(q_lcl)
     q_rai = UT.clamp_to_nonneg(q_rai)

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -11,24 +11,24 @@ export clamp_to_nonneg, ϵ_numerics, ϵ_numerics_2M_M, ϵ_numerics_2M_N
 """
     clamp_to_nonneg(x)
 
-Clamp values to be non-negative in an automatic differentiation (AD) compatible way.
-Uses `ifelse` to preserve dual number types during AD.
+Clamp values to be non-negative.
+Compatible with dual numbers (AD) and GPUs.
 
 # Arguments
 - `x`: value to clamp
 
 # Returns
-- `x` if `x ≥ 0`, otherwise `0*x` (preserving the type of x)
+- `max(zero(x), x)`
 """
-@inline clamp_to_nonneg(x) = ifelse(x < 0, 0 * x, x)
+@inline clamp_to_nonneg(x) = max(zero(x), x)
 
 """
     ϵ_numerics(FT)
 
 Smallest number that is different than zero for the purpose of microphysics
-computations. Returns `sqrt(floatmin(FT))` to avoid underflow issues.
+computations. Returns `cbrt(floatmin(FT))` to avoid underflow issues.
 """
-@inline ϵ_numerics(FT) = sqrt(floatmin(FT))
+@inline ϵ_numerics(FT) = cbrt(floatmin(FT))
 
 """
     ϵ_numerics_2M_M(FT)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
* Clamps input densities for safety; simplifies clamping function (to avoid getting `-0.0` returns)
* Changes eps_numerics to `cbrt(floatmin)` (`sqrt(floatmin)` could lead to overflow in ClimaAtmos)
* Bumps patch release

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
