### PR TITLE
Adding microphysics options to bulk tendency (+ temperature dependent cloud ice formation)

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -9,8 +9,8 @@ CurrentModule = CloudMicrophysics
 ```@docs
 MicrophysicsNonEq
 MicrophysicsNonEq.τ_relax
-MicrophysicsNonEq.conv_q_vap_to_q_lcl_icl
-MicrophysicsNonEq.conv_q_vap_to_q_lcl_icl_MM2015
+MicrophysicsNonEq.conv_q_vap_to_q_lcl
+MicrophysicsNonEq.conv_q_vap_to_q_icl
 MicrophysicsNonEq.INP_limiter
 MicrophysicsNonEq.terminal_velocity
 MicrophysicsNonEq.dqcld_dT
@@ -41,22 +41,21 @@ Microphysics1M.get_n0
 Microphysics1M.lambda_inverse
 Microphysics1M.terminal_velocity
 Microphysics1M.conv_q_lcl_to_q_rai
-Microphysics1M.conv_q_icl_to_q_sno_no_supersat
 Microphysics1M.conv_q_icl_to_q_sno
 Microphysics1M.accretion
 Microphysics1M.accretion_rain_sink
 Microphysics1M.accretion_snow_rain
-Microphysics1M.evaporation_sublimation
-Microphysics1M.∂evaporation_sublimation_∂q_precip
-Microphysics1M.snow_melt
-Microphysics1M.∂snow_melt_∂q_sno
+Microphysics1M.conv_q_rai_to_q_vap
+Microphysics1M.conv_q_sno_to_q_vap
+Microphysics1M.conv_q_icl_to_q_lcl
+Microphysics1M.conv_q_sno_to_q_rai
 ```
 
 ## Parameters
 
 ```@autodocs
 Modules = [Parameters]
-Pages   = ["Microphysics1M.jl", "Microphysics1MParams.jl"]
+Pages   = ["Microphysics1M.jl", "Microphysics1MOptions.jl", "Microphysics1MParams.jl"]
 ```
 
 # 2-moment precipitation microphysics

--- a/docs/src/Microphysics1M.md
+++ b/docs/src/Microphysics1M.md
@@ -747,12 +747,5 @@ include("plots/Microphysics1M_plots.jl")
 ![](snow_sublimation_deposition_rate.svg)
 ![](snow_melt_rate.svg)
 
-## Example derivative figures
 
-![](rain_evap_deriv_vs_T.svg)
-![](rain_evap_deriv_vs_qrai.svg)
-![](snow_subl_deriv_vs_T.svg)
-![](snow_subl_deriv_vs_qsno.svg)
-![](snow_melt_deriv_vs_T.svg)
-![](snow_melt_deriv_vs_qsno.svg)
 

--- a/docs/src/MicrophysicsNonEq.md
+++ b/docs/src/MicrophysicsNonEq.md
@@ -19,6 +19,13 @@ They consist of:
 |``\tau_{l}``| cloud water condensation/evaporation timescale | ``s`` | ``10``        |
 |``\tau_{i}``| cloud ice deposition/sublimation timescale     | ``s`` | ``10``        |
 
+!!! note
+    For ice, the deposition timescale ``\tau_{dep}`` can optionally be computed
+    from the [Frostenberg2023](@cite) INP parameterization (see
+    [below](@ref ice-relaxation-timescale-frostenberg-et-al-2023)),
+    while the sublimation timescale ``\tau_{sub}`` remains at the constant
+    ``\tau_i``.
+
 ## Simple condensation/evaporation and deposition/sublimation
 
 Condensation/evaporation of cloud liquid water and
@@ -124,9 +131,69 @@ include("plots/NonEqCondEvapRate.jl")
 ![](condensation_evaporation_ql_z.svg)
 ![](condensation_evaporation_ql_T.svg)
 
+## [Ice relaxation timescale — Frostenberg et al. (2023)](@id ice-relaxation-timescale-frostenberg-et-al-2023)
 
+The constant ice relaxation timescale ``\tau_i`` can be replaced with
+  a temperature-dependent timescale derived from the
+  Frostenberg et al. [Frostenberg2023](@cite)
+  parameterization of ice nucleating particle (INP) concentrations.
+This makes the deposition timescale physically dependent on the
+  number of available INPs and the ice crystal size.
 
+The INP number concentration is estimated as a function of temperature:
+```math
+\begin{equation}
+  N_{icl} = \exp\!\left(\overline{\ln(\mathrm{INPC})}(T)\right)
+\end{equation}
+```
+where ``\overline{\ln(\mathrm{INPC})}(T)`` is the mean log-INP concentration
+from the Frostenberg et al. (2023) parameterization.
 
+Given ``N_{icl}`` and the cloud ice specific content ``q_{icl}``,
+  the mean crystal radius is computed assuming spherical ice particles
+  with a monodisperse size distribution:
+```math
+\begin{equation}
+  r = \left(\frac{3 \, q_{icl}}{4 \pi \, N_{icl} \, \rho_i}\right)^{1/3}
+\end{equation}
+```
+A minimum radius ``r_0 = 1\,\mu m`` is enforced to avoid singularities
+  when ``q_{icl} = 0`` or ``N_{icl} = 0``.
+
+The Frostenberg deposition timescale is then:
+```math
+\begin{equation}
+  \tau_{dep} = \frac{1}{4 \pi \, D_v \, N_{icl} \, r_{safe}}
+\end{equation}
+```
+where ``D_v`` is the water vapor diffusivity and ``r_{safe} = \max(r, r_0)``.
+
+### Asymmetric deposition and sublimation timescales
+
+The ice tendency uses **different timescales** for deposition and sublimation:
+
+```math
+\begin{equation}
+  \left. \frac{d \, q_{icl}}{dt} \right|_{dep, sub} =
+  \begin{cases}
+    \dfrac{q_{vap} - q_{si}}{\tau_{dep} \, \Gamma_i} & \text{if } q_{vap} > q_{si} \text{ (deposition)} \\[10pt]
+    \dfrac{-\min(-\Delta q,\; q_{icl})}{\tau_{sub} \, \Gamma_i} & \text{if } q_{vap} \le q_{si} \text{ (sublimation)}
+  \end{cases}
+\end{equation}
+```
+where:
+- ``\tau_{dep}`` is the Frostenberg INP-based timescale (temperature-dependent),
+- ``\Gamma_i`` is the psychometric correction factor (applied to both deposition and sublimation),
+- ``\tau_{sub}`` is a constant sublimation timescale (default: ``\tau_i = 10\,s``),
+- ``\Delta q = q_{vap} - q_{si}`` is the saturation excess.
+
+An additional INP limiter suppresses deposition (positive tendency) at
+  temperatures above freezing, where no INPs are available.
+
+```@example
+include("plots/plotting_tau_relax_frostenberg.jl")
+```
+![](tau_relax_frostenberg.svg)
 
 ## Cloud condensate sedimentation
 

--- a/docs/src/plots/Microphysics1M_plots.jl
+++ b/docs/src/plots/Microphysics1M_plots.jl
@@ -17,6 +17,7 @@ snow = CMP.Snow(FT)
 Chen2022 = CMP.Chen2022VelType(FT)
 Blk1MVel = CMP.Blk1MVelType(FT)
 ce = CMP.CollisionEff(FT)
+mp = CMP.Microphysics1MParams(FT)
 
 # eq. 5b in [Grabowski1996](@cite)
 function accretion_empirical(q_rai::DT, q_lcl::DT, q_tot::DT) where {DT <: Real}
@@ -66,7 +67,16 @@ MK.set_theme!(MK.theme_minimal())
 T = 273.15
 fig = MK.Figure()
 ax = MK.Axis(fig[1, 1]; xlabel = "q_lcl or q_icl [g/kg]", ylabel = "autoconversion rate [1/s]", limits)
-q_icl_to_q_sno_rate = T -> CM1.conv_q_icl_to_q_sno.(ice, aps, tps, q_tot, FT(0), q_icl_range, q_rai, q_sno, ρ_air, T)
+mp_ss = CMP.Microphysics1MParams(FT;
+    options = CMP.Microphysics1MOptions(snow_autoconversion = CMP.SnowAutoconvWithSupersat()),
+)
+q_icl_to_q_sno_rate = function (T)
+    map(q_icl_range) do q_icl
+        micro = (; q_tot, q_lcl = FT(0), q_icl, q_rai, q_sno)
+        thermo = (; ρ = ρ_air, T)
+        CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconvWithSupersat(), mp_ss, tps, micro, thermo)
+    end
+end
 MK.lines!(q_lcl_range * 1e3, CM1.conv_q_lcl_to_q_rai.(rain.acnv1M, q_lcl_range), label = "Rain")
 MK.lines!(q_icl_range * 1e3, q_icl_to_q_sno_rate(T - 5), label = "Snow T = −5°C")
 MK.lines!(q_icl_range * 1e3, q_icl_to_q_sno_rate(T - 10), label = "Snow T = −10°C")
@@ -151,18 +161,14 @@ ax = MK.Axis(fig[1, 1]; xlabel = "q_rain [g/kg]", ylabel = "rain evaporation rat
 MK.xlims!(ax, 0, q_max * 1e3)
 MK.lines!(
     q_rain_range * 1e3,
-    CM1.evaporation_sublimation.(
-        rain,
-        Blk1MVel.rain,
-        aps,
-        tps,
-        q_tot,
-        q_lcl .- q_rain_range,
-        q_icl,
+    (
+        q_rai -> CM1.conv_q_rai_to_q_vap(
+            CMP.EvaporationOnly(), mp, tps,
+            (; q_tot, q_lcl = q_lcl - q_rai, q_icl, q_rai, q_sno),
+            (; ρ, T),
+        )
+    ).(
         q_rain_range,
-        q_sno,
-        ρ,
-        T,
     ),
     label = "ClimateMachine",
 )
@@ -189,18 +195,14 @@ q_rai = 0.0
 R = TDI.Rₘ(tps, q_tot, q_lcl + q_rai, q_icl)
 ρ = p / R / T
 rate =
-    CM1.evaporation_sublimation.(
-        snow,
-        Blk1MVel.snow,
-        aps,
-        tps,
-        q_tot,
-        q_lcl,
-        q_icl .- q_snow_range,
-        q_rai,
+    (
+        q_sno -> CM1.conv_q_sno_to_q_vap(
+            CMP.DepositionSublimation(), mp, tps,
+            (; q_tot, q_lcl, q_icl = q_icl - q_sno, q_rai, q_sno),
+            (; ρ, T),
+        )
+    ).(
         q_snow_range,
-        ρ,
-        T,
     )
 MK.lines!(q_snow_range * 1e3, rate, label = "T < 0°C")
 
@@ -218,18 +220,14 @@ q_rai = 0.0
 R = TDI.Rₘ(tps, q_tot, q_lcl + q_rai, q_icl)
 ρ = p / R / T
 rate =
-    CM1.evaporation_sublimation.(
-        snow,
-        Blk1MVel.snow,
-        aps,
-        tps,
-        q_tot,
-        q_lcl,
-        q_icl .- q_snow_range,
-        q_rai,
+    (
+        q_sno -> CM1.conv_q_sno_to_q_vap(
+            CMP.DepositionSublimation(), mp, tps,
+            (; q_tot, q_lcl, q_icl = q_icl - q_sno, q_rai, q_sno),
+            (; ρ, T),
+        )
+    ).(
         q_snow_range,
-        ρ,
-        T,
     )
 MK.lines!(q_snow_range * 1e3, rate, label = "T > 0°C")
 
@@ -240,247 +238,18 @@ MK.save("snow_sublimation_deposition_rate.svg", fig) # hide
 fig = MK.Figure()
 ax = MK.Axis(fig[1, 1]; xlabel = "q_snow [g/kg]", ylabel = "snow melt rate [1/s]", limits)
 T = 273.15
-_snow_melt(ΔT) = CM1.snow_melt.(snow, Blk1MVel.snow, aps, tps, q_snow_range, ρ, T + ΔT)
+_snow_melt(ΔT) = map(
+    q_sno -> CM1.conv_q_sno_to_q_rai(
+        CMP.SnowMelt(),
+        mp,
+        tps,
+        (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno),
+        (; ρ, T = T + ΔT),
+    ),
+    q_snow_range,
+)
 MK.lines!(q_snow_range * 1e3, _snow_melt(2), label = "T = 2°C")
 MK.lines!(q_snow_range * 1e3, _snow_melt(4), label = "T = 4°C")
 MK.lines!(q_snow_range * 1e3, _snow_melt(6), label = "T = 6°C")
 MK.axislegend(ax; position = :lt)
 MK.save("snow_melt_rate.svg", fig) # hide
-
-# -------------------------------------------------------------------
-# Derivative plots: tendency and ∂tendency/∂q for rain evap, snow subl, snow melt
-# -------------------------------------------------------------------
-
-T_freeze = TDI.TD.Parameters.T_freeze(tps)
-
-# ---------- Rain evaporation vs temperature ----------
-fig = MK.Figure(size = (900, 450))
-ax1 = MK.Axis(fig[1, 1];
-    xlabel = "Temperature (K)", ylabel = "Evaporation rate (1/s)",
-    title = "Rain evaporation vs T\n(q_rai=1e-3, q_tot=15e-3 g/kg, 15% RH, ρ from p=90kPa)",
-)
-ax2 = MK.Axis(fig[1, 2];
-    xlabel = "Temperature (K)", ylabel = "∂(rate)/∂q_rai (1/s)",
-    title = "Derivative of rain evaporation",
-)
-
-T_range = collect(range(250.0, stop = 310.0, length = 121))
-for q_rai_val in [FT(5e-4), FT(1e-3), FT(2e-3)]
-    rates = zeros(FT, length(T_range))
-    drates = zeros(FT, length(T_range))
-    for (i, T) in enumerate(T_range)
-        p = FT(90000)
-        ϵ = TDI.Rd_over_Rv(tps)
-        p_sat = TDI.saturation_vapor_pressure_over_liquid(tps, T)
-        q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1))
-        q_tot = FT(15e-3)
-        q_vap = FT(0.15) * q_sat
-        q_lcl = max(q_tot - q_vap - q_rai_val, FT(0))
-        R = TDI.Rₘ(tps, q_tot, q_lcl + q_rai_val, FT(0))
-        ρ_loc = p / R / T
-        r = CM1.evaporation_sublimation(
-            rain, Blk1MVel.rain, aps, tps, q_tot, q_lcl, FT(0), q_rai_val, FT(0), ρ_loc, T,
-        )
-        dr = CM1.∂evaporation_sublimation_∂q_precip(
-            rain, Blk1MVel.rain, aps, tps, q_tot, q_lcl, FT(0), q_rai_val, FT(0), ρ_loc, T,
-        )
-        rates[i] = r
-        drates[i] = dr
-    end
-    lbl = "q_rai=$(q_rai_val*1e3) g/kg"
-    MK.lines!(ax1, T_range, rates; label = lbl)
-    MK.lines!(ax2, T_range, drates; label = lbl)
-end
-MK.hlines!(ax1, [0]; color = :black, linewidth = 0.5)
-MK.axislegend(ax1; position = :lb, framevisible = false)
-MK.axislegend(ax2; position = :lb, framevisible = false)
-MK.save("rain_evap_deriv_vs_T.svg", fig) # hide
-
-# ---------- Rain evaporation vs q_rai ----------
-fig = MK.Figure(size = (900, 450))
-ax1 = MK.Axis(fig[1, 1];
-    xlabel = "q_rai (g/kg)", ylabel = "Evaporation rate (1/s)",
-    title = "Rain evaporation vs q_rai",
-)
-ax2 = MK.Axis(fig[1, 2];
-    xlabel = "q_rai (g/kg)", ylabel = "∂(rate)/∂q_rai (1/s)",
-    title = "Derivative of rain evaporation",
-)
-
-q_rai_range = collect(range(FT(1e-6), stop = FT(5e-3), length = 100))
-for T in [FT(275), FT(290), FT(305)]
-    p = FT(90000)
-    ϵ = TDI.Rd_over_Rv(tps)
-    p_sat = TDI.saturation_vapor_pressure_over_liquid(tps, T)
-    q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1))
-    q_tot = FT(15e-3)
-    q_vap = FT(0.15) * q_sat
-    rates = zeros(FT, length(q_rai_range))
-    drates = zeros(FT, length(q_rai_range))
-    for (i, q_rai_val) in enumerate(q_rai_range)
-        q_lcl = max(q_tot - q_vap - q_rai_val, FT(0))
-        R = TDI.Rₘ(tps, q_tot, q_lcl + q_rai_val, FT(0))
-        ρ_loc = p / R / T
-        r = CM1.evaporation_sublimation(
-            rain, Blk1MVel.rain, aps, tps, q_tot, q_lcl, FT(0), q_rai_val, FT(0), ρ_loc, T,
-        )
-        dr = CM1.∂evaporation_sublimation_∂q_precip(
-            rain, Blk1MVel.rain, aps, tps, q_tot, q_lcl, FT(0), q_rai_val, FT(0), ρ_loc, T,
-        )
-        rates[i] = r
-        drates[i] = dr
-    end
-    lbl = "T=$(Int(T))K"
-    MK.lines!(ax1, q_rai_range * 1e3, rates; label = lbl)
-    MK.lines!(ax2, q_rai_range * 1e3, drates; label = lbl)
-end
-MK.hlines!(ax1, [0]; color = :black, linewidth = 0.5)
-MK.axislegend(ax1; position = :lb, framevisible = false)
-MK.axislegend(ax2; position = :lt, framevisible = false)
-MK.save("rain_evap_deriv_vs_qrai.svg", fig) # hide
-
-# ---------- Snow sublimation/deposition vs temperature ----------
-fig = MK.Figure(size = (900, 450))
-ax1 = MK.Axis(fig[1, 1];
-    xlabel = "Temperature (K)", ylabel = "Subl/Dep rate (1/s)",
-    title = "Snow sublimation/deposition vs T\n(q_sno=1e-4, subsaturated over ice)",
-)
-ax2 = MK.Axis(fig[1, 2];
-    xlabel = "Temperature (K)", ylabel = "∂(rate)/∂q_sno (1/s)",
-    title = "Derivative of snow subl/dep",
-)
-
-T_range_cold = collect(range(220.0, stop = 280.0, length = 121))
-for (q_sno_val, rh_ice) in [(FT(5e-5), FT(0.8)), (FT(1e-4), FT(0.8)), (FT(1e-4), FT(1.05))]
-    rates = zeros(FT, length(T_range_cold))
-    drates = zeros(FT, length(T_range_cold))
-    for (i, T) in enumerate(T_range_cold)
-        p = FT(90000)
-        ϵ = TDI.Rd_over_Rv(tps)
-        p_sat = TDI.saturation_vapor_pressure_over_ice(tps, T)
-        q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1))
-        q_tot = rh_ice * q_sat + q_sno_val
-        R = TDI.Rₘ(tps, q_tot, FT(0), q_sno_val)
-        ρ_loc = p / R / T
-        r = CM1.evaporation_sublimation(
-            snow, Blk1MVel.snow, aps, tps, q_tot, FT(0), FT(0), FT(0), q_sno_val, ρ_loc, T,
-        )
-        dr = CM1.∂evaporation_sublimation_∂q_precip(
-            snow, Blk1MVel.snow, aps, tps, q_tot, FT(0), FT(0), FT(0), q_sno_val, ρ_loc, T,
-        )
-        rates[i] = r
-        drates[i] = dr
-    end
-    rh_pct = Int(round(rh_ice * 100))
-    lbl = "q_sno=$(q_sno_val*1e3)g/kg, RH_ice=$(rh_pct)%"
-    MK.lines!(ax1, T_range_cold, rates; label = lbl)
-    MK.lines!(ax2, T_range_cold, drates; label = lbl)
-end
-MK.hlines!(ax1, [0]; color = :black, linewidth = 0.5)
-MK.axislegend(ax1; position = :lb, framevisible = false)
-MK.axislegend(ax2; position = :lb, framevisible = false)
-MK.save("snow_subl_deriv_vs_T.svg", fig) # hide
-
-# ---------- Snow sublimation vs q_sno ----------
-fig = MK.Figure(size = (900, 450))
-ax1 = MK.Axis(fig[1, 1];
-    xlabel = "q_sno (g/kg)", ylabel = "Sublimation rate (1/s)",
-    title = "Snow sublimation vs q_sno\n(subsaturated: RH_ice = 80%)",
-)
-ax2 = MK.Axis(fig[1, 2];
-    xlabel = "q_sno (g/kg)", ylabel = "∂(rate)/∂q_sno (1/s)",
-    title = "Derivative of snow sublimation",
-)
-
-q_sno_range = collect(range(FT(1e-6), stop = FT(5e-3), length = 100))
-for T in [FT(240), FT(255), FT(270)]
-    p = FT(90000)
-    ϵ = TDI.Rd_over_Rv(tps)
-    p_sat_ice = TDI.saturation_vapor_pressure_over_ice(tps, T)
-    q_sat_ice = ϵ * p_sat_ice / (p + p_sat_ice * (ϵ - 1))
-    rates = zeros(FT, length(q_sno_range))
-    drates = zeros(FT, length(q_sno_range))
-    for (i, q_sno_val) in enumerate(q_sno_range)
-        q_tot = FT(0.8) * q_sat_ice + q_sno_val
-        R = TDI.Rₘ(tps, q_tot, FT(0), q_sno_val)
-        ρ_loc = p / R / T
-        r = CM1.evaporation_sublimation(
-            snow, Blk1MVel.snow, aps, tps, q_tot, FT(0), FT(0), FT(0), q_sno_val, ρ_loc, T,
-        )
-        dr = CM1.∂evaporation_sublimation_∂q_precip(
-            snow, Blk1MVel.snow, aps, tps, q_tot, FT(0), FT(0), FT(0), q_sno_val, ρ_loc, T,
-        )
-        rates[i] = r
-        drates[i] = dr
-    end
-    lbl = "T=$(Int(T))K"
-    MK.lines!(ax1, q_sno_range * 1e3, rates; label = lbl)
-    MK.lines!(ax2, q_sno_range * 1e3, drates; label = lbl)
-end
-MK.hlines!(ax1, [0]; color = :black, linewidth = 0.5)
-MK.axislegend(ax1; position = :lb, framevisible = false)
-MK.axislegend(ax2; position = :lt, framevisible = false)
-MK.save("snow_subl_deriv_vs_qsno.svg", fig) # hide
-
-# ---------- Snow melt vs temperature ----------
-fig = MK.Figure(size = (900, 450))
-ax1 = MK.Axis(fig[1, 1];
-    xlabel = "Temperature (K)", ylabel = "Melt rate (1/s)",
-    title = "Snow melt rate vs T",
-)
-ax2 = MK.Axis(fig[1, 2];
-    xlabel = "Temperature (K)", ylabel = "∂(rate)/∂q_sno (1/s)",
-    title = "Derivative of snow melt",
-)
-
-T_range_warm = collect(range(T_freeze - 2, stop = T_freeze + 10, length = 121))
-for q_sno_val in [FT(5e-5), FT(1e-4), FT(5e-4)]
-    rates = zeros(FT, length(T_range_warm))
-    drates = zeros(FT, length(T_range_warm))
-    ρ_loc = FT(1.2)
-    for (i, T) in enumerate(T_range_warm)
-        r = CM1.snow_melt(snow, Blk1MVel.snow, aps, tps, q_sno_val, ρ_loc, T)
-        dr = CM1.∂snow_melt_∂q_sno(snow, Blk1MVel.snow, aps, tps, q_sno_val, ρ_loc, T)
-        rates[i] = r
-        drates[i] = dr
-    end
-    lbl = "q_sno=$(q_sno_val*1e3) g/kg"
-    MK.lines!(ax1, T_range_warm, rates; label = lbl)
-    MK.lines!(ax2, T_range_warm, drates; label = lbl)
-end
-MK.hlines!(ax1, [0]; color = :black, linewidth = 0.5)
-MK.axislegend(ax1; position = :lt, framevisible = false)
-MK.axislegend(ax2; position = :lt, framevisible = false)
-MK.save("snow_melt_deriv_vs_T.svg", fig) # hide
-
-# ---------- Snow melt vs q_sno ----------
-fig = MK.Figure(size = (900, 450))
-ax1 = MK.Axis(fig[1, 1];
-    xlabel = "q_sno (g/kg)", ylabel = "Melt rate (1/s)",
-    title = "Snow melt rate vs q_sno",
-)
-ax2 = MK.Axis(fig[1, 2];
-    xlabel = "q_sno (g/kg)", ylabel = "∂(rate)/∂q_sno (1/s)",
-    title = "Derivative of snow melt",
-)
-
-q_sno_range2 = collect(range(FT(1e-6), stop = FT(5e-3), length = 100))
-ρ_loc = FT(1.2)
-for ΔT in [FT(2), FT(4), FT(6)]
-    T = T_freeze + ΔT
-    rates = zeros(FT, length(q_sno_range2))
-    drates = zeros(FT, length(q_sno_range2))
-    for (i, q_sno_val) in enumerate(q_sno_range2)
-        r = CM1.snow_melt(snow, Blk1MVel.snow, aps, tps, q_sno_val, ρ_loc, T)
-        dr = CM1.∂snow_melt_∂q_sno(snow, Blk1MVel.snow, aps, tps, q_sno_val, ρ_loc, T)
-        rates[i] = r
-        drates[i] = dr
-    end
-    lbl = "T = T_freeze + $(Int(ΔT))K"
-    MK.lines!(ax1, q_sno_range2 * 1e3, rates; label = lbl)
-    MK.lines!(ax2, q_sno_range2 * 1e3, drates; label = lbl)
-end
-MK.hlines!(ax1, [0]; color = :black, linewidth = 0.5)
-MK.axislegend(ax1; position = :lt, framevisible = false)
-MK.axislegend(ax2; position = :lt, framevisible = false)
-MK.save("snow_melt_deriv_vs_qsno.svg", fig) # hide

--- a/docs/src/plots/NonEqCondEvapRate.jl
+++ b/docs/src/plots/NonEqCondEvapRate.jl
@@ -2,6 +2,7 @@ using CairoMakie
 CairoMakie.activate!(type = "svg")
 import Thermodynamics as TD
 import CloudMicrophysics as CM
+import CloudMicrophysics.Parameters as CMP
 import CloudMicrophysics.MicrophysicsNonEq as CMNe
 
 include(joinpath(@__DIR__, "plotting_utilities.jl"))  # spliced_cmap
@@ -53,7 +54,15 @@ function generate_cond_evap_rate(::HydrostaticBalance_qₗ_z)
     cm_params = CM.Parameters.CloudLiquid(FT)
     cm_params = CM.Parameters.CloudLiquid(FT(τ_relax), cm_params.ρw, cm_params.r_eff, cm_params.N_0) # overwrite τ_relax
 
-    data = @. CMNe.conv_q_vap_to_q_lcl_icl_MM2015(cm_params, thp, qₜ, qₗ, qᵢ, qᵣ, qₛ, ρ, T)
+    data = broadcast(qₗ, T) do q_lcl, temp
+        CMNe.conv_q_vap_to_q_lcl(
+            CMP.ConstantTimescaleCloudLiquidFormation(),
+            (; cloud = (; liquid = cm_params)),
+            thp,
+            (; q_tot = qₜ, q_lcl, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ),
+            (; ρ, T = temp)
+        )
+    end
     colorrange = extrema(data)
     @. data[iszero(data)] = NaN  # set zero values to NaN, then use `nan_color=:gray` to show them as gray. These are clipped values.
     colormap = spliced_cmap(:blues, :reds, colorrange...; mid = 0, categorical = true, symmetrize_color_ranges = true)
@@ -85,7 +94,15 @@ function generate_cond_evap_rate(::Range_qₗ_T)
     cm_params = CM.Parameters.CloudLiquid(FT)
     cm_params = CM.Parameters.CloudLiquid(FT(τ_relax), cm_params.ρw, cm_params.r_eff, cm_params.N_0) # overwrite τ_relax
 
-    data = @. CMNe.conv_q_vap_to_q_lcl_icl_MM2015(cm_params, thp, qₜ, qₗ, qᵢ, qᵣ, qₛ, ρ, T')
+    data = broadcast(qₗ, T') do q_lcl, temp
+        CMNe.conv_q_vap_to_q_lcl(
+            CMP.ConstantTimescaleCloudLiquidFormation(),
+            (; cloud = (; liquid = cm_params)),
+            thp,
+            (; q_tot = qₜ, q_lcl, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ),
+            (; ρ, T = temp)
+        )
+    end
     colorrange = extrema(data)
     @. data[iszero(data)] = NaN  # set zero values to NaN, then use `nan_color=:gray` to show them as gray. These are clipped values.
     colormap = spliced_cmap(:blues, :reds, colorrange...; mid = 0, categorical = true, symmetrize_color_ranges = true)

--- a/docs/src/plots/plotting_tau_relax_frostenberg.jl
+++ b/docs/src/plots/plotting_tau_relax_frostenberg.jl
@@ -1,0 +1,100 @@
+import CairoMakie as MK
+CairoMakie = MK
+
+import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.MicrophysicsNonEq as CMNe
+import CloudMicrophysics.ThermodynamicsInterface as TDI
+
+FT = Float64
+
+# Parameters
+ice = CMP.CloudIce(FT)
+aps = CMP.AirProperties(FT)
+frs = CMP.Frostenberg2023(FT)
+tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
+
+# Temperature range: -40°C to 20°C
+T_freeze = FT(273.15)
+T_range = range(T_freeze - 40, T_freeze + 20, length = 500)
+T_celsius = T_range .- T_freeze
+
+# q_icl values to plot
+q_icl_values = [FT(0), FT(1e-8), FT(1e-6), FT(1e-4), FT(1e-2)]
+q_icl_labels = ["0", "10⁻⁸", "10⁻⁶", "10⁻⁴", "10⁻²"]
+
+# Air density (representative value for mid-troposphere)
+ρ = FT(0.8)
+
+# Sublimation timescale (constant)
+τ_sub = CMNe.τ_relax(ice)
+
+# Compute the effective timescale used in conv_q_vap_to_q_icl:
+#   T < T_freeze (deposition):  τ_dep × Γᵢ  (Frostenberg τ with thermodynamic correction)
+#   T ≥ T_freeze (sublimation): τ_sub × Γᵢ  (constant τ_sub with thermodynamic correction)
+τ_data = Matrix{FT}(undef, length(T_range), length(q_icl_values))
+for (j, q_icl) in enumerate(q_icl_values)
+    q_tot = FT(0.01)  # representative total water content
+    q_lcl = FT(0)
+    q_rai = FT(0)
+    q_sno = FT(0)
+    for (i, T) in enumerate(T_range)
+        Rᵥ = TDI.Rᵥ(tps)
+        Lₛ = TDI.Lₛ(tps, T)
+        cₚ_air = TDI.cpₘ(tps, q_tot, q_lcl + q_rai, q_icl + q_sno)
+        qᵥ_sat_ice = TDI.saturation_vapor_specific_content_over_ice(tps, T, ρ)
+        dqsi_dT = CMNe.dqcld_dT(qᵥ_sat_ice, Lₛ, Rᵥ, T)
+        Γᵢ = CMNe.gamma_helper(Lₛ, cₚ_air, dqsi_dT)
+
+        if T < T_freeze
+            # Deposition branch: τ_dep × Γᵢ
+            τ_dep = CMNe.τ_relax(ice, aps, frs, q_icl, T)
+            τ_data[i, j] = τ_dep * Γᵢ
+        else
+            # Sublimation branch: τ_sub × Γᵢ
+            τ_data[i, j] = τ_sub * Γᵢ
+        end
+    end
+end
+
+# Replace Inf with NaN for plotting (log scale can't handle Inf)
+τ_data[.!isfinite.(τ_data)] .= NaN
+
+# Colors — distinct, colorblind-friendly
+colors = [
+    MK.RGBf(0.12, 0.47, 0.71),  # blue
+    MK.RGBf(1.0, 0.50, 0.05),  # orange
+    MK.RGBf(0.17, 0.63, 0.17),  # green
+    MK.RGBf(0.84, 0.15, 0.16),  # red
+    MK.RGBf(0.58, 0.40, 0.74),  # purple
+]
+
+linestyles = [:solid, :dash, :dot, :dashdot, :dashdotdot]
+
+# Plot
+fig = MK.Figure(size = (800, 550))
+ax = MK.Axis(
+    fig[1, 1],
+    xlabel = "Temperature [°C]",
+    ylabel = "Effective timescale [s]",
+    title = "Ice relaxation timescale — Frostenberg et al. (2023)\nDeposition: τ_dep×Γᵢ (T < 0°C) | Sublimation: τ_sub×Γᵢ (T ≥ 0°C)",
+    yscale = log10,
+)
+
+for (j, (q_icl, label)) in enumerate(zip(q_icl_values, q_icl_labels))
+    MK.lines!(
+        ax, T_celsius, τ_data[:, j],
+        label = "q_icl = $(label) kg/kg",
+        color = colors[j],
+        linewidth = 2.5,
+        linestyle = linestyles[j],
+    )
+end
+
+# Add vertical line at T_freeze
+MK.vlines!(ax, 0.0, color = :gray, linestyle = :dash, linewidth = 1)
+MK.text!(ax, 0.5, 1e10, text = "T_freeze", fontsize = 12, color = :gray)
+
+MK.axislegend(ax, position = :rt)
+MK.save("tau_relax_frostenberg.svg", fig)
+
+println("Plot saved to tau_relax_frostenberg.svg")

--- a/parcel/ParcelModel.jl
+++ b/parcel/ParcelModel.jl
@@ -327,7 +327,7 @@ function run_parcel(IC, t_0, t_end, pp)
     elseif pp.deposition_growth == "NonEq_Deposition_simple"
         ds_params = NonEqDepParams_simple{FT}(pp.tps, pp.ice)
     elseif pp.deposition_growth == "NonEq_Deposition"
-        ds_params = NonEqDepParams{FT}(pp.tps, pp.ice, pp.const_dt)
+        ds_params = NonEqDepParams{FT}(pp.tps, pp.ice, pp.aps, pp.ip, pp.const_dt)
     else
         throw("Unrecognized deposition growth mode")
     end

--- a/parcel/ParcelParameters.jl
+++ b/parcel/ParcelParameters.jl
@@ -108,5 +108,7 @@ end
 struct NonEqDepParams{FT} <: CMP.ParametersType
     tps::TDP.ThermodynamicsParameters{FT}
     ice::CMP.CloudIce{FT}
+    aps::CMP.AirProperties{FT}
+    ip::CMP.Frostenberg2023{FT}
     dt::FT
 end

--- a/parcel/ParcelTendencies.jl
+++ b/parcel/ParcelTendencies.jl
@@ -239,7 +239,8 @@ function condensation(params::NonEqCondParams_simple, PSD, state, ρ_air)
 
     q_sat_liq = max(Sₗ * qᵥ - qᵥ, 0)
 
-    new_q = MNE.conv_q_vap_to_q_lcl_icl(liquid, q_sat_liq, qₗ)
+    τ = MNE.τ_relax(liquid)
+    new_q = (q_sat_liq - qₗ) / τ
 
     return new_q
 end
@@ -253,7 +254,12 @@ function condensation(params::NonEqCondParams, PSD, state, ρ_air)
 
         qₜ = qᵥ + qₗ + qᵢ
 
-        cond_rate = MNE.conv_q_vap_to_q_lcl_icl_MM2015(liquid, tps, qₜ, qₗ, qᵢ, FT(0), FT(0), ρ_air, T)
+        mp_mock = (; cloud = (; liquid))
+        micro_mock = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = FT(0), q_sno = FT(0))
+        thermo_mock = (; ρ = ρ_air, T = T)
+        cond_rate = MNE.conv_q_vap_to_q_lcl(
+            CMP.ConstantTimescaleCloudLiquidFormation(), mp_mock, tps, micro_mock, thermo_mock,
+        )
 
         # Using same limiter as ClimaAtmos for now
         # Not sure why, but without intermediate storing of the tendencies for the
@@ -296,7 +302,8 @@ function deposition(params::NonEqDepParams_simple, PSD, state, ρ_air)
     Sᵢ = S_i(tps, T, Sₗ)
     q_sat_ice = max(Sᵢ * qᵥ - qᵥ, 0)
 
-    new_q = MNE.conv_q_vap_to_q_lcl_icl(ice, q_sat_ice, qᵢ)
+    τ = MNE.τ_relax(ice)
+    new_q = (q_sat_ice - qᵢ) / τ
 
     return new_q
 end
@@ -305,12 +312,17 @@ function deposition(params::NonEqDepParams, PSD, state, ρ_air)
     FT = eltype(state)
     (; T, qₗ, qᵥ, qᵢ) = state
 
-    (; tps, ice, dt) = params
+    (; tps, ice, aps, ip, dt) = params
 
     if qᵥ + qᵢ > FT(0)
         qₜ = qᵥ + qₗ + qᵢ
 
-        dep_rate = MNE.conv_q_vap_to_q_lcl_icl_MM2015(ice, tps, qₜ, qₗ, qᵢ, FT(0), FT(0), ρ_air, T)
+        mp_mock = (; cloud = (; ice), frostenberg2023 = ip, air_properties = aps)
+        micro_mock = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = FT(0), q_sno = FT(0))
+        thermo_mock = (; ρ = ρ_air, T = T)
+        dep_rate = MNE.conv_q_vap_to_q_icl(
+            CMP.TemperatureDependentCloudIceFormation(), mp_mock, tps, micro_mock, thermo_mock,
+        )
 
         # Using same limiter as ClimaAtmos for now
         # Not sure why, but without intermediate storing of the tendencies for the

--- a/src/BulkMicrophysicsTendencies.jl
+++ b/src/BulkMicrophysicsTendencies.jl
@@ -167,7 +167,11 @@ This is a pure function of local thermodynamic state, suitable for:
     ce = mp.collision
     aps = mp.air_properties
     vel = mp.terminal_velocity
-    var = mp.autoconv_2M
+    opts = mp.options
+
+    # Construct state tuples (reused across all process calls)
+    micro = (; q_tot, q_lcl, q_icl, q_rai, q_sno)
+    thermo = (; ρ, T)
 
     # Initialize tendencies
     dq_lcl_dt = zero(T)
@@ -178,25 +182,28 @@ This is a pure function of local thermodynamic state, suitable for:
     # --- Cloud condensate formation (non-equilibrium) ---
 
     # Condensation/evaporation of cloud liquid
-    S_lcl_cond = CMNonEq.conv_q_vap_to_q_lcl_icl_MM2015(lcl, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T)
+    S_lcl_cond = CMNonEq.conv_q_vap_to_q_lcl(opts.cloud_liquid_formation, mp, tps, micro, thermo)
     dq_lcl_dt += S_lcl_cond
 
-    # Deposition/sublimation of cloud ice (INP limiter applied inside conv_q_vap_to_q_lcl_icl_MM2015)
-    S_icl_dep = CMNonEq.conv_q_vap_to_q_lcl_icl_MM2015(icl, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T)
+    # Deposition/sublimation of cloud ice
+    S_icl_dep = CMNonEq.conv_q_vap_to_q_icl(opts.cloud_ice_formation, mp, tps, micro, thermo)
     dq_icl_dt += S_icl_dep
 
     # --- Autoconversion (cloud → precipitation) ---
 
     # Cloud liquid → rain
-    # Use 2M autoconversion when N_lcl > 0 and var provided, otherwise 1M
     S_acnv_1M = CM1.conv_q_lcl_to_q_rai(rai.acnv1M, q_lcl, true)
-    S_acnv_2M = isnothing(var) ? S_acnv_1M : CM2.conv_q_lcl_to_q_rai(var, q_lcl, ρ, N_lcl)
-    S_acnv_lcl = ifelse(N_lcl > zero(N_lcl), S_acnv_2M, S_acnv_1M)
+    S_acnv_lcl = if opts.cloud_liquid_autoconversion isa CMP.LiquidAutoconv2M
+        S_acnv_2M = CM2.conv_q_lcl_to_q_rai(mp.autoconv_2M, q_lcl, ρ, N_lcl)
+        ifelse(N_lcl > zero(N_lcl), S_acnv_2M, S_acnv_1M)
+    else
+        S_acnv_1M
+    end
     dq_lcl_dt -= S_acnv_lcl
     dq_rai_dt += S_acnv_lcl
 
-    # Cloud ice → snow (no supersaturation version for simplicity)
-    S_acnv_icl = CM1.conv_q_icl_to_q_sno_no_supersat(sno.acnv1M, q_icl, true)
+    # Cloud ice → snow
+    S_acnv_icl = CM1.conv_q_icl_to_q_sno(opts.snow_autoconversion, mp, tps, micro, thermo)
     dq_icl_dt -= S_acnv_icl
     dq_sno_dt += S_acnv_icl
 
@@ -261,17 +268,22 @@ This is a pure function of local thermodynamic state, suitable for:
     # --- Evaporation and sublimation ---
 
     # Rain evaporation
-    S_evap_rai = CM1.evaporation_sublimation(rai, vel.rain, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T)
+    S_evap_rai = CM1.conv_q_rai_to_q_vap(opts.rain_evaporation, mp, tps, micro, thermo)
     dq_rai_dt += S_evap_rai  # negative tendency (evaporation)
 
-    # Snow sublimation/deposition
-    S_subl_sno = CM1.evaporation_sublimation(sno, vel.snow, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T)
-    dq_sno_dt += S_subl_sno  # can be positive (deposition) or negative (sublimation)
+    # Snow sublimation (or sublimation + deposition, depending on option)
+    S_subl_sno = CM1.conv_q_sno_to_q_vap(opts.snow_sublimation, mp, tps, micro, thermo)
+    dq_sno_dt += S_subl_sno
 
     # --- Melting ---
 
+    # Cloud ice melt → cloud liquid
+    S_melt_icl = CM1.conv_q_icl_to_q_lcl(opts.cloud_ice_melt, mp, tps, micro, thermo)
+    dq_icl_dt -= S_melt_icl
+    dq_lcl_dt += S_melt_icl
+
     # Snow melt → rain
-    S_melt_sno = CM1.snow_melt(sno, vel.snow, aps, tps, q_sno, ρ, T)
+    S_melt_sno = CM1.conv_q_sno_to_q_rai(opts.snow_melt, mp, tps, micro, thermo)
     dq_sno_dt -= S_melt_sno
     dq_rai_dt += S_melt_sno
 
@@ -314,7 +326,11 @@ Returns a `NamedTuple` containing the nonzero entries of `M` and `e`.
     ce = mp.collision
     aps = mp.air_properties
     vel = mp.terminal_velocity
-    var = mp.autoconv_2M
+    opts = mp.options
+
+    # Construct state tuples (reused across all process calls)
+    micro = (; q_tot, q_lcl, q_icl, q_rai, q_sno)
+    thermo = (; ρ, T)
 
     FT = promote_type(
         typeof(ρ), typeof(T), typeof(q_tot), typeof(q_lcl),
@@ -322,6 +338,7 @@ Returns a `NamedTuple` containing the nonzero entries of `M` and `e`.
     )
 
     M11 = zero(FT)
+    M12 = zero(FT)
     M22 = zero(FT)
     M31 = zero(FT)
     M33 = zero(FT)
@@ -340,33 +357,41 @@ Returns a `NamedTuple` containing the nonzero entries of `M` and `e`.
     # ------------------------------------------------------------
     # Vapor -> cloud condensate: constant sources
     # ------------------------------------------------------------
-    S_lcl_cond = CMNonEq.conv_q_vap_to_q_lcl_icl_MM2015(
-        lcl, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T,
-    )
+    S_lcl_cond = CMNonEq.conv_q_vap_to_q_lcl(opts.cloud_liquid_formation, mp, tps, micro, thermo)
     D = S_lcl_cond / max(q_min, q_lcl)
     is_source = S_lcl_cond >= zero(FT)
     e1 += ifelse(is_source, S_lcl_cond, zero(FT))
     M11 += ifelse(is_source, zero(FT), D)
 
-    S_icl_dep = CMNonEq.conv_q_vap_to_q_lcl_icl_MM2015(
-        icl, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T,
-    )
+    S_icl_dep = CMNonEq.conv_q_vap_to_q_icl(opts.cloud_ice_formation, mp, tps, micro, thermo)
     D = S_icl_dep / max(q_min, q_icl)
     is_source = S_icl_dep >= zero(FT)
     e2 += ifelse(is_source, S_icl_dep, zero(FT))
     M22 += ifelse(is_source, zero(FT), D)
 
     # ------------------------------------------------------------
+    # Cloud ice melt: ice → cloud liquid
+    # ------------------------------------------------------------
+    S_melt_icl = CM1.conv_q_icl_to_q_lcl(opts.cloud_ice_melt, mp, tps, micro, thermo)
+    D = S_melt_icl / max(q_min, q_icl)
+    M22 -= D
+    M12 += D
+
+    # ------------------------------------------------------------
     # Autoconversion: donor-based transfer
     # ------------------------------------------------------------
     S_acnv_1M = CM1.conv_q_lcl_to_q_rai(rai.acnv1M, q_lcl, true)
-    S_acnv_2M = isnothing(var) ? S_acnv_1M : CM2.conv_q_lcl_to_q_rai(var, q_lcl, ρ, N_lcl)
-    S_acnv_lcl = ifelse(N_lcl > zero(N_lcl), S_acnv_2M, S_acnv_1M)
+    S_acnv_lcl = if opts.cloud_liquid_autoconversion isa CMP.LiquidAutoconv2M
+        S_acnv_2M = CM2.conv_q_lcl_to_q_rai(mp.autoconv_2M, q_lcl, ρ, N_lcl)
+        ifelse(N_lcl > zero(N_lcl), S_acnv_2M, S_acnv_1M)
+    else
+        S_acnv_1M
+    end
     D = S_acnv_lcl / max(q_min, q_lcl)
     M11 -= D
     M31 += D
 
-    S_acnv_icl = CM1.conv_q_icl_to_q_sno_no_supersat(sno.acnv1M, q_icl, true)
+    S_acnv_icl = CM1.conv_q_icl_to_q_sno(opts.snow_autoconversion, mp, tps, micro, thermo)
     D = S_acnv_icl / max(q_min, q_icl)
     M22 -= D
     M42 += D
@@ -430,18 +455,14 @@ Returns a `NamedTuple` containing the nonzero entries of `M` and `e`.
     # ------------------------------------------------------------
     # Rain evaporation: sink to vapor (always zero or negative)
     # ------------------------------------------------------------
-    S_evap_rai = CM1.evaporation_sublimation(
-        rai, vel.rain, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T,
-    )
+    S_evap_rai = CM1.conv_q_rai_to_q_vap(opts.rain_evaporation, mp, tps, micro, thermo)
     D = (-S_evap_rai) / max(q_min, q_rai)
     M33 -= D
 
     # ------------------------------------------------------------
-    # Snow sublimation/deposition
+    # Snow sublimation/deposition (generic: handles both options)
     # ------------------------------------------------------------
-    S_subl_sno = CM1.evaporation_sublimation(
-        sno, vel.snow, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T,
-    )
+    S_subl_sno = CM1.conv_q_sno_to_q_vap(opts.snow_sublimation, mp, tps, micro, thermo)
     D = S_subl_sno / max(q_min, q_sno)
     is_source = S_subl_sno >= zero(FT)
     e4 += ifelse(is_source, S_subl_sno, zero(FT))
@@ -450,13 +471,13 @@ Returns a `NamedTuple` containing the nonzero entries of `M` and `e`.
     # ------------------------------------------------------------
     # Snow melt: snow -> rain
     # ------------------------------------------------------------
-    S_melt_sno = CM1.snow_melt(sno, vel.snow, aps, tps, q_sno, ρ, T)
+    S_melt_sno = CM1.conv_q_sno_to_q_rai(opts.snow_melt, mp, tps, micro, thermo)
     D = S_melt_sno / max(q_min, q_sno)
     M44 -= D
     M34 += D
 
     return (
-        M11 = M11, M22 = M22,
+        M11 = M11, M12 = M12, M22 = M22,
         M31 = M31, M33 = M33, M34 = M34,
         M41 = M41, M42 = M42, M43 = M43, M44 = M44,
         e1 = e1, e2 = e2, e4 = e4,
@@ -474,9 +495,8 @@ and returns the average tendency
 
     dq/dt = (q* - q⁰) / Δt.
 
-The system uses a sparse structure specific to the 1-moment microphysics model:
-`q_lcl` and `q_icl` are solved independently, while `q_rai` and `q_sno` are
-solved from a coupled 2×2 system.
+The system uses a sparse structure specific to the 1-moment microphysics model.
+`q_lcl` and `q_icl` as well as `q_rai` and `q_sno` are solved from a coupled 2×2 system.
 
 Because sinks are linearized as `-D q`, they are effectively integrated as
 exponential decays over the substep.
@@ -497,6 +517,7 @@ exponential decays over the substep.
 
     # A = I/Δt - M
     a11 = invΔt - lin.M11
+    a12 = -lin.M12
     a22 = invΔt - lin.M22
     a31 = -lin.M31
     a33 = invΔt - lin.M33
@@ -513,15 +534,17 @@ exponential decays over the substep.
     b3 = invΔt * q_rai
     b4 = lin.e4 + invΔt * q_sno
 
-    q_lcl_new = b1 / a11
-    q_icl_new = b2 / a22
+    # Solve 2×2 system for q_lcl, q_icl (coupled via ice melt M12)
+    det12 = a11 * a22  # a21 = 0
+    q_lcl_new = (b1 * a22 - a12 * b2) / det12
+    q_icl_new = a11 * b2 / det12
 
     # Reduced 2x2 system for q_rai_new, q_sno_new
     r3 = muladd(-a31, q_lcl_new, b3)
     r4 = muladd(-a41, q_lcl_new, muladd(-a42, q_icl_new, b4))
 
     det = muladd(-a34, a43, a33 * a44)
-    # det is a positive number because a44 and a33 are positive (greater than invΔt) 
+    # det is a positive number because a44 and a33 are positive (greater than invΔt)
     # and a34 and a43 are non-positive so we don't need to safeguard division by det.
     q_rai_new = (r3 * a44 - a34 * r4) / det
     q_sno_new = (a33 * r4 - r3 * a43) / det
@@ -704,7 +727,12 @@ Used by both warm-only and warm+ice dispatch methods to reduce code duplication.
     dn_rai_dt = zero(FT)
 
     # --- Condensation of vapor / evaporation of cloud liquid water ---
-    ∂ₜq_lcl_cond = CMNonEq.conv_q_vap_to_q_lcl_icl_MM2015(condevap, tps, q_tot, q_lcl, q_ice, q_rai, zero(q_ice), ρ, T)
+    mp_mock = (; cloud = (; liquid = condevap))
+    micro_mock = (; q_tot, q_lcl, q_icl = q_ice, q_rai, q_sno = zero(q_ice))
+    thermo_mock = (; ρ, T)
+    ∂ₜq_lcl_cond = CMNonEq.conv_q_vap_to_q_lcl(
+        CMP.ConstantTimescaleCloudLiquidFormation(), mp_mock, tps, micro_mock, thermo_mock,
+    )
     ∂ₜn_lcl_cond = zero(∂ₜq_lcl_cond)  # neglect number change from condensation/evaporation
     dq_lcl_dt += ∂ₜq_lcl_cond
     dn_lcl_dt += ∂ₜn_lcl_cond

--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -33,14 +33,13 @@ import ..Utilities as UT
 export terminal_velocity,
     conv_q_lcl_to_q_rai,
     conv_q_icl_to_q_sno,
-    conv_q_icl_to_q_sno_no_supersat,
     accretion,
     accretion_rain_sink,
     accretion_snow_rain,
-    evaporation_sublimation,
-    ∂evaporation_sublimation_∂q_precip,
-    snow_melt,
-    ∂snow_melt_∂q_sno,
+    conv_q_rai_to_q_vap,
+    conv_q_sno_to_q_vap,
+    conv_q_icl_to_q_lcl,
+    conv_q_sno_to_q_rai,
     lambda_inverse
 
 abstract type AbstractSnowShape end
@@ -345,58 +344,36 @@ over the threshold, avoiding discontinuities in the tendency.
     max(0, q_lcl - q_threshold) / τ
 
 """
-    conv_q_icl_to_q_sno_no_supersat(acnv::Acnv1M, q_icl, smooth_transition)
+    conv_q_icl_to_q_sno(::SnowAutoconvNoSupersat, mp, tps, micro, thermo)
+    conv_q_icl_to_q_sno(::SnowAutoconvWithSupersat, mp, tps, micro, thermo)
 
 Returns the snow tendency due to autoconversion from cloud ice.
-This is a simplified version for use in simulations without supersaturation
-(e.g., with saturation adjustment).
+
+**SnowAutoconvNoSupersat**: Simplified Kessler-type threshold autoconversion,
+for use in simulations without supersaturation (e.g., with saturation adjustment).
+
+**SnowAutoconvWithSupersat**: Supersaturation-dependent autoconversion following
+Harrington et al. (1995) and Kaul et al. (2015).
 
 # Arguments
-- `acnv`: autoconversion parameters (contains `τ`, `q_threshold`, `k`)
-- `q_icl`: cloud ice specific content
-- `smooth_transition`: flag to switch on smoothing
+- `option`: `SnowAutoconvNoSupersat()` or `SnowAutoconvWithSupersat()`
+- `mp`: 1-moment microphysics parameters
+- `tps`: thermodynamics parameters
+- `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
+- `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline conv_q_icl_to_q_sno_no_supersat(
-    (; τ, q_threshold, k)::CMP.Acnv1M{FT},
-    q_icl::FT,
-    smooth_transition::Bool = false,
-) where {FT} =
-    smooth_transition ?
-    CO.logistic_function_integral(q_icl, q_threshold, k) / τ :
-    max(0, q_icl - q_threshold) / τ
+@inline function conv_q_icl_to_q_sno(::CMP.SnowAutoconvNoSupersat, mp, tps, micro, thermo)
+    (; τ, q_threshold, k) = mp.precip.snow.acnv1M
+    q_icl = micro.q_icl
+    return CO.logistic_function_integral(q_icl, q_threshold, k) / τ
+end
 
-"""
-    conv_q_icl_to_q_sno(ice::CloudIce, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T)
-
-Returns the snow tendency due to autoconversion from ice.
-Parameterized following:
-  - Harrington et al. (1995), https://doi.org/10.1175/1520-0469(1995)052<4344:POICCP>2.0.CO;2
-  - Kaul et al. (2015), https://doi.org/10.1175/MWR-D-14-00319.1
-
-# Arguments
-- `ice`: ice parameters (contains `r_ice_snow`, `pdf`, `mass`)
-- `aps`: air properties struct
-- `tps`: thermodynamics parameters struct
-- `q_tot`: total water specific content [kg/kg]
-- `q_lcl`: cloud liquid water specific content [kg/kg]
-- `q_icl`: cloud ice specific content [kg/kg]
-- `q_rai`: rain specific content [kg/kg]
-- `q_sno`: snow specific content [kg/kg]
-- `ρ`: air density [kg/m³]
-- `T`: air temperature [K]
-"""
-@inline function conv_q_icl_to_q_sno(
-    (; r_ice_snow, pdf, mass)::CMP.CloudIce{FT},
-    aps::CMP.AirProperties{FT},
-    tps::TDI.PS,
-    q_tot::FT,
-    q_lcl::FT,
-    q_icl::FT,
-    q_rai::FT,
-    q_sno::FT,
-    ρ::FT,
-    T::FT,
-) where {FT}
+@inline function conv_q_icl_to_q_sno(::CMP.SnowAutoconvWithSupersat, mp, tps, micro, thermo)
+    (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
+    (; ρ, T) = thermo
+    (; r_ice_snow, pdf, mass) = mp.cloud.ice
+    aps = mp.air_properties
+    FT = eltype(ρ)
     acnv_rate = FT(0)
     S = TDI.supersaturation_over_ice(tps, q_tot, q_lcl + q_rai, q_icl + q_sno, ρ, T)
 
@@ -575,53 +552,33 @@ deviations are proportional to the mean fall velocities, with coefficient
 end
 
 """
-    evaporation_sublimation(rain::Rain, vel::Blk1MVelTypeRain, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T)
-    evaporation_sublimation(snow::Snow, vel::Blk1MVelTypeSnow, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T)
+    conv_q_rai_to_q_vap(::EvaporationOnly, mp, tps, micro, thermo)
 
-Returns the tendency due to rain evaporation or snow sublimation/deposition.
-Ventilation factor parameterization follows Seifert and Beheng (2006),
-https://doi.org/10.1007/s00703-005-0112-4.
+Returns the tendency due to rain evaporation.
+Ventilation factor parameterization follows Seifert and Beheng (2006).
 
-**Rain**: Only evaporation is considered (S < 0), result is clamped to be ≤ 0.
-**Snow**: Both sublimation (S < 0) and deposition (S > 0) are considered.
+Only evaporation is considered (sub-saturated over liquid); result is clamped ≤ 0.
 
 # Arguments
-- `rain` or `snow`: particle parameters (contains `pdf`, `mass`, `vent`)
-- `vel`: terminal velocity parameters (Blk1MVelTypeRain or Blk1MVelTypeSnow)
-- `aps`: air properties struct
-- `tps`: thermodynamics parameters struct
-- `q_tot`: total water specific content [kg/kg]
-- `q_lcl`: cloud liquid water specific content [kg/kg]
-- `q_icl`: cloud ice specific content [kg/kg]
-- `q_rai`: rain specific content [kg/kg]
-- `q_sno`: snow specific content [kg/kg]
-- `ρ`: air density [kg/m³]
-- `T`: air temperature [K]
-
-# Returns
-- Evaporation/sublimation/deposition rate [kg/kg/s]
+- `option`: `EvaporationOnly()`
+- `mp`: 1-moment microphysics parameters
+- `tps`: thermodynamics parameters
+- `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
+- `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline function evaporation_sublimation(
-    (; pdf, mass, vent)::CMP.Rain{FT},
-    vel::CMP.Blk1MVelTypeRain{FT},
-    aps::CMP.AirProperties{FT},
-    tps::TDI.PS,
-    q_tot::FT,
-    q_lcl::FT,
-    q_icl::FT,
-    q_rai::FT,
-    q_sno::FT,
-    ρ::FT,
-    T::FT,
-) where {FT}
-    evap_subl_rate = FT(0)
+@inline function conv_q_rai_to_q_vap(::CMP.EvaporationOnly, mp, tps, micro, thermo)
+    (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
+    (; ρ, T) = thermo
+    (; pdf, mass, vent) = mp.precip.rain
+    vel = mp.terminal_velocity.rain
+    aps = mp.air_properties
+    FT = eltype(ρ)
+    evap_rate = FT(0)
 
-    # Early return if no rain
     if q_rai > UT.ϵ_numerics(FT)
         S = TDI.supersaturation_over_liquid(tps, q_tot, q_lcl + q_rai, q_icl + q_sno, ρ, T)
 
         if S < FT(0)
-
             (; ν_air, D_vapor) = aps
             G = CO.G_func_liquid(aps, tps, T)
             n0 = get_n0(pdf, q_rai, ρ)
@@ -632,11 +589,9 @@ https://doi.org/10.1007/s00703-005-0112-4.
             b_vent = vent.b
 
             λ_inv = lambda_inverse(pdf, mass, q_rai, ρ)
-
-            # Schmidt number (guard against division by near-zero D_vapor)
             Sc = ν_air / max(D_vapor, UT.ϵ_numerics(FT))
 
-            evap_subl_rate =
+            evap_rate =
                 4 * FT(π) * n0 / ρ * S * G * λ_inv^2 *
                 (
                     a_vent +
@@ -647,43 +602,62 @@ https://doi.org/10.1007/s00703-005-0112-4.
                 )
         end
     end
-    # only evaporation is considered for rain
-    return min(0, evap_subl_rate)
+    return min(0, evap_rate)
 end
 
-@inline function evaporation_sublimation(
-    (; pdf, mass, vent)::CMP.Snow{FT},
-    vel::CMP.Blk1MVelTypeSnow{FT},
-    aps::CMP.AirProperties{FT},
-    tps::TDI.PS,
-    q_tot::FT,
-    q_lcl::FT,
-    q_icl::FT,
-    q_rai::FT,
-    q_sno::FT,
-    ρ::FT,
-    T::FT,
-) where {FT}
-    evap_subl_rate = FT(0)
+"""
+    conv_q_sno_to_q_vap(::SublimationOnly, mp, tps, micro, thermo)
+    conv_q_sno_to_q_vap(::DepositionSublimation, mp, tps, micro, thermo)
+
+Returns the tendency due to snow sublimation or sublimation+deposition.
+Ventilation factor parameterization follows Seifert and Beheng (2006).
+
+**SublimationOnly**: only sublimation (S < 0 over ice) is computed;
+deposition is handled separately by non-equilibrium relaxation.
+
+**DepositionSublimation**: both sublimation and deposition are computed
+in the Marshall-Palmer integral.
+
+# Arguments
+- `option`: `SublimationOnly()` or `DepositionSublimation()`
+- `mp`: 1-moment microphysics parameters
+- `tps`: thermodynamics parameters
+- `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
+- `thermo`: thermodynamic state `(; ρ, T)`
+"""
+@inline function conv_q_sno_to_q_vap(::CMP.SublimationOnly, mp, tps, micro, thermo)
+    return min(0, _snow_subl_dep_rate(mp, tps, micro, thermo))
+end
+
+@inline function conv_q_sno_to_q_vap(::CMP.DepositionSublimation, mp, tps, micro, thermo)
+    return _snow_subl_dep_rate(mp, tps, micro, thermo)
+end
+
+"""Internal helper: snow sublimation/deposition physics kernel."""
+@inline function _snow_subl_dep_rate(mp, tps, micro, thermo)
+    (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
+    (; ρ, T) = thermo
+    (; pdf, mass, vent) = mp.precip.snow
+    vel = mp.terminal_velocity.snow
+    aps = mp.air_properties
+    FT = eltype(ρ)
+    subl_rate = FT(0)
+
     if q_sno > UT.ϵ_numerics(FT)
         (; ν_air, D_vapor) = aps
         S = TDI.supersaturation_over_ice(tps, q_tot, q_lcl + q_rai, q_icl + q_sno, ρ, T)
         G = CO.G_func_ice(aps, tps, T)
-
         n0 = get_n0(pdf, q_sno, ρ)
         v0 = get_v0(vel, ρ)
         (; r0) = mass
         (; χv, ve, Δv, gamma_vent) = vel
-
         a_vent = vent.a
         b_vent = vent.b
 
         λ_inv = lambda_inverse(pdf, mass, q_sno, ρ)
-
-        # Schmidt number (guard against division by near-zero D_vapor)
         Sc = ν_air / max(D_vapor, UT.ϵ_numerics(FT))
 
-        evap_subl_rate =
+        subl_rate =
             4 * FT(π) * n0 / ρ * S * G * λ_inv^2 *
             (
                 a_vent +
@@ -693,78 +667,67 @@ end
                 gamma_vent
             )
     end
-    # both sublimation (S < 0) and deposition (S > 0) are considered for snow
-    return evap_subl_rate
+    return subl_rate
+end
+
+
+"""
+    conv_q_icl_to_q_lcl(::NoCloudIceMelt, mp, tps, micro, thermo)
+    conv_q_icl_to_q_lcl(::CloudIceMeltToLiquid, mp, tps, micro, thermo)
+
+Returns the tendency due to cloud ice melt.
+
+**NoCloudIceMelt**: returns zero (cloud ice melt disabled).
+
+**CloudIceMeltToLiquid**: melts cloud ice to cloud liquid above freezing,
+parameterized as diffusional growth of ice crystals.
+
+# Arguments
+- `option`: `NoCloudIceMelt()` or `CloudIceMeltToLiquid()`
+- `mp`: 1-moment microphysics parameters
+- `tps`: thermodynamics parameters
+- `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
+- `thermo`: thermodynamic state `(; ρ, T)`
+"""
+@inline conv_q_icl_to_q_lcl(::CMP.NoCloudIceMelt, mp, tps, micro, thermo) = zero(thermo.T)
+
+@inline function conv_q_icl_to_q_lcl(::CMP.CloudIceMeltToLiquid, mp, tps, micro, thermo)
+    q_icl = micro.q_icl
+    (; ρ, T) = thermo
+    (; pdf, mass) = mp.cloud.ice
+    (; K_therm) = mp.air_properties
+    FT = eltype(ρ)
+    cloud_ice_melt_rate = FT(0)
+    T_freeze = TDI.T_freeze(tps)
+
+    if (q_icl > UT.ϵ_numerics(FT) && T > T_freeze)
+        L = TDI.Lf(tps, T)
+        (; n0) = pdf
+        λ_inv = lambda_inverse(pdf, mass, q_icl, ρ)
+        cloud_ice_melt_rate = 4 * FT(π) * n0 / ρ * K_therm / L * (T - T_freeze) * λ_inv^2
+    end
+    return cloud_ice_melt_rate
 end
 
 """
-    ∂evaporation_sublimation_∂q_precip(rain::Rain, vel, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T)
-    ∂evaporation_sublimation_∂q_precip(snow::Snow, vel, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T)
-
-Returns the leading-order derivative of the evaporation/sublimation rate
-with respect to the precipitating species specific content:
- - `∂(evaporation_sublimation)/∂q_rai` for the `Rain` dispatch
- - `∂(evaporation_sublimation)/∂q_sno` for the `Snow` dispatch
-
-The approximation used is `∂(rate)/∂q_precip ≈ rate / q_precip`.
-"""
-@inline function ∂evaporation_sublimation_∂q_precip(
-    rain_params::CMP.Rain{FT},
-    vel::CMP.Blk1MVelTypeRain{FT},
-    aps::CMP.AirProperties{FT},
-    tps::TDI.PS,
-    q_tot::FT,
-    q_lcl::FT,
-    q_icl::FT,
-    q_rai::FT,
-    q_sno::FT,
-    ρ::FT,
-    T::FT,
-) where {FT}
-    rate = evaporation_sublimation(rain_params, vel, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T)
-    return rate / max(q_rai, UT.ϵ_numerics(FT))
-end
-
-@inline function ∂evaporation_sublimation_∂q_precip(
-    snow_params::CMP.Snow{FT},
-    vel::CMP.Blk1MVelTypeSnow{FT},
-    aps::CMP.AirProperties{FT},
-    tps::TDI.PS,
-    q_tot::FT,
-    q_lcl::FT,
-    q_icl::FT,
-    q_rai::FT,
-    q_sno::FT,
-    ρ::FT,
-    T::FT,
-) where {FT}
-    rate = evaporation_sublimation(snow_params, vel, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T)
-    return rate / max(q_sno, UT.ϵ_numerics(FT))
-end
-
-"""
-    snow_melt(snow::Snow, vel::Blk1MVelTypeSnow, aps, tps, q_sno, ρ, T)
+    conv_q_sno_to_q_rai(::SnowMelt, mp, tps, micro, thermo)
 
 Returns the tendency due to snow melt.
 
 # Arguments
-- `snow`: snow parameters (contains `T_freeze`, `pdf`, `mass`, `vent`)
-- `vel`: terminal velocity parameters
-- `aps`: air properties struct
-- `tps`: thermodynamics parameters struct
-- `q_sno`: snow water specific content
-- `ρ`: air density
-- `T`: air temperature
+- `option`: `SnowMelt()`
+- `mp`: 1-moment microphysics parameters
+- `tps`: thermodynamics parameters
+- `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
+- `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline function snow_melt(
-    (; T_freeze, pdf, mass, vent)::CMP.Snow{FT},
-    vel::CMP.Blk1MVelTypeSnow{FT},
-    aps::CMP.AirProperties{FT},
-    tps::TDI.PS,
-    q_sno::FT,
-    ρ::FT,
-    T::FT,
-) where {FT}
+@inline function conv_q_sno_to_q_rai(::CMP.SnowMelt, mp, tps, micro, thermo)
+    q_sno = micro.q_sno
+    (; ρ, T) = thermo
+    (; T_freeze, pdf, mass, vent) = mp.precip.snow
+    vel = mp.terminal_velocity.snow
+    aps = mp.air_properties
+    FT = eltype(ρ)
     snow_melt_rate = FT(0)
 
     if (q_sno > UT.ϵ_numerics(FT) && T > T_freeze)
@@ -796,26 +759,6 @@ Returns the tendency due to snow melt.
             )
     end
     return snow_melt_rate
-end
-
-"""
-    ∂snow_melt_∂q_sno(snow::Snow, vel::Blk1MVelTypeSnow, aps, tps, q_sno, ρ, T)
-
-Returns `∂(snow_melt)/∂q_sno`, the derivative of the snow melt rate
-with respect to snow specific content.
-The approximation used is `∂(rate)/∂q_sno ≈ rate / q_sno`.
-"""
-@inline function ∂snow_melt_∂q_sno(
-    snow_params::CMP.Snow{FT},
-    vel::CMP.Blk1MVelTypeSnow{FT},
-    aps::CMP.AirProperties{FT},
-    tps::TDI.PS,
-    q_sno::FT,
-    ρ::FT,
-    T::FT,
-) where {FT}
-    rate = snow_melt(snow_params, vel, aps, tps, q_sno, ρ, T)
-    return rate / max(q_sno, UT.ϵ_numerics(FT))
 end
 
 end #module Microphysics1M.jl

--- a/src/MicrophysicsNonEq.jl
+++ b/src/MicrophysicsNonEq.jl
@@ -13,10 +13,11 @@ import ..Parameters as CMP
 import ..ThermodynamicsInterface as TDI
 import ..Common as CO
 import ..Utilities as UT
+import ..HetIceNucleation as IN
 
 export τ_relax
-export conv_q_vap_to_q_lcl_icl
-export conv_q_vap_to_q_lcl_icl_MM2015
+export conv_q_vap_to_q_lcl
+export conv_q_vap_to_q_icl
 export INP_limiter
 export dqcld_dT
 export gamma_helper
@@ -36,39 +37,38 @@ Returns the relaxation timescale for phase change processes.
 # Returns
 - Relaxation timescale [s] for condensation/evaporation (liquid) or
   deposition/sublimation (ice)
+
+an option to calculate ice relaxation timescale through
+the Frostenberg et al., (2023). See DOI: 10.5194/acp-23-10883-2023
+parameterization that approximates ice droplet number from temperature.
 """
 @inline τ_relax(p::CondEvap) = p.τ_relax
 @inline τ_relax(p::SubDep) = p.τ_relax
+@inline function τ_relax(
+    (; ρᵢ)::CMP.CloudIce, (; D_vapor)::CMP.AirProperties,
+    ip::CMP.Frostenberg2023, q_icl, T,
+)
+    FT = eltype(ρᵢ)
+    # Get the estimated number of INPs
+    N_icl = exp(IN.INP_concentration_mean(ip, T))
 
-"""
-    conv_q_vap_to_q_lcl_icl(params::CloudLiquid, q_sat_liq, q_lcl)
-    conv_q_vap_to_q_lcl_icl(params::CloudIce, q_sat_ice, q_icl)
+    # TODO - edge cases
+    # q_icl is zero, but we still want to compute a timescale
+    # assume some sort of minimal crystal size?
 
-Computes the tendency of cloud condensate specific content using a
-simple relaxation-to-equilibrium formulation with a constant timescale.
+    # q_icl is not zero but N_icl is zero
+    # Get N from q_icl by assuming minimal crystal size
 
-# Arguments
-- `params` - cloud liquid or ice parameters struct containing `τ_relax`
-- `q_sat_liq` or `q_sat_ice` - saturation specific humidity [kg/kg]
-- `q_lcl` or `q_icl` - cloud liquid water or ice specific content [kg/kg]
+    # Compute the radius assuming spherical particles and
+    # mono-modal distribution
+    r = N_icl > UT.ϵ_numerics(FT) ? cbrt((3 * q_icl) / (4 * FT(π) * N_icl * ρᵢ)) : zero(FT)
+    r0 = FT(1e-6)
+    r_safe = max(r, r0)
 
-# Returns
-- Cloud condensate tendency in kg/kg/s, positive for condensation/deposition,
-  negative for evaporation/sublimation
-
-The tendency is computed as:
-```math
-\\frac{dq}{dt} = \\frac{q_{sat} - q}{\\tau_{relax}}
-```
-"""
-@inline function conv_q_vap_to_q_lcl_icl((; τ_relax)::CondEvap, q_sat_liq, q_lcl)
-    return (q_sat_liq - q_lcl) / τ_relax
+    # Compute the relaxation timescale
+    τ = (4 * FT(π) * D_vapor * N_icl * r_safe)^(-1)
+    return τ
 end
-
-@inline function conv_q_vap_to_q_lcl_icl((; τ_relax)::SubDep, q_sat_ice, q_icl)
-    return (q_sat_ice - q_icl) / τ_relax
-end
-
 
 """
     INP_limiter(tendency, tps, T)
@@ -111,38 +111,29 @@ Computes the thermodynamic adjustment factor Γ.
 end
 
 """
-    conv_q_vap_to_q_lcl_icl_MM2015(params, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T)
+    conv_q_vap_to_q_lcl(::ConstantTimescaleCloudLiquidFormation, mp, tps, micro, thermo)
 
-Computes cloud condensate tendency using the formulation from
+Computes cloud liquid tendency from condensation and evaporation using the formulation from
 Morrison & Grabowski (2008), https://doi.org/10.1175/2007JAS2374.1, and
 Morrison & Milbrandt (2015), https://doi.org/10.1175/JAS-D-14-0065.1.
 
-This formulation includes a thermodynamic adjustment factor Γ that
-accounts for latent heat release modifying the saturation state.
-
 # Arguments
-- `params` - cloud liquid or ice parameters struct containing `τ_relax`
-- `tps` - thermodynamics parameters struct
-- `q_tot` - total water specific content [kg/kg]
-- `q_lcl` - cloud liquid water specific content [kg/kg]
-- `q_icl` - cloud ice specific content [kg/kg]
-- `q_rai` - rain specific content [kg/kg]
-- `q_sno` - snow specific content [kg/kg]
-- `ρ` - air density [kg/m³]
-- `T` - air temperature [K]
+- `option`: `ConstantTimescaleCloudLiquidFormation()`
+- `mp`: 1-moment microphysics parameters
+- `tps`: thermodynamics parameters
+- `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
+- `thermo`: thermodynamic state `(; ρ, T)`
 
 # Returns
 - Cloud condensate tendency [kg/kg/s]
-
-# Notes
-This function does NOT apply limiters for small or negative specific humidities.
-Users should apply appropriate bounds checking when integrating in a model.
 """
-function conv_q_vap_to_q_lcl_icl_MM2015(
-    (; τ_relax)::CondEvap, tps::TDI.PS,
-    q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T,
+function conv_q_vap_to_q_lcl(
+    ::CMP.ConstantTimescaleCloudLiquidFormation, mp, tps::TDI.PS, micro, thermo,
 )
-    FT = eltype(tps)
+    (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
+    (; ρ, T) = thermo
+    τ = τ_relax(mp.cloud.liquid)
+
     Rᵥ = TDI.Rᵥ(tps)
     Lᵥ = TDI.Lᵥ(tps, T)
     cₚ_air = TDI.cpₘ(tps, q_tot, q_lcl + q_rai, q_icl + q_sno)
@@ -154,7 +145,7 @@ function conv_q_vap_to_q_lcl_icl_MM2015(
     Γₗ = gamma_helper(Lᵥ, cₚ_air, dqsl_dT)
 
     sat_excess = qᵥ - qᵥ_sat_liq
-    timescale = τ_relax * Γₗ
+    timescale = τ * Γₗ
 
     # compute the tendency
     return ifelse(
@@ -163,11 +154,32 @@ function conv_q_vap_to_q_lcl_icl_MM2015(
         sat_excess / timescale,
     )
 end
-function conv_q_vap_to_q_lcl_icl_MM2015(
-    (; τ_relax)::SubDep, tps::TDI.PS,
-    q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T,
+
+"""
+    conv_q_vap_to_q_icl(::ConstantTimescaleCloudIceFormation, mp, tps, micro, thermo)
+    conv_q_vap_to_q_icl(::TemperatureDependentCloudIceFormation, mp, tps, micro, thermo)
+
+Computes cloud ice tendency from deposition and sublimation using the formulation from
+Morrison & Grabowski (2008), https://doi.org/10.1175/2007JAS2374.1, and
+Morrison & Milbrandt (2015), https://doi.org/10.1175/JAS-D-14-0065.1.
+
+# Arguments
+- `option`: `ConstantTimescaleCloudIceFormation()` or `TemperatureDependentCloudIceFormation()`
+- `mp`: 1-moment microphysics parameters
+- `tps`: thermodynamics parameters
+- `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
+- `thermo`: thermodynamic state `(; ρ, T)`
+
+# Returns
+- Cloud condensate tendency [kg/kg/s]
+"""
+function conv_q_vap_to_q_icl(
+    ::CMP.ConstantTimescaleCloudIceFormation, mp, tps::TDI.PS, micro, thermo,
 )
-    FT = eltype(tps)
+    (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
+    (; ρ, T) = thermo
+    τ = τ_relax(mp.cloud.ice)
+
     Rᵥ = TDI.Rᵥ(tps)
     Lₛ = TDI.Lₛ(tps, T)
     cₚ_air = TDI.cpₘ(tps, q_tot, q_lcl + q_rai, q_icl + q_sno)
@@ -179,13 +191,44 @@ function conv_q_vap_to_q_lcl_icl_MM2015(
     Γᵢ = gamma_helper(Lₛ, cₚ_air, dqsi_dT)
 
     sat_excess = qᵥ - qᵥ_sat_ice
-    timescale = τ_relax * Γᵢ
+    timescale = τ * Γᵢ
 
     # compute the tendency
     tendency = ifelse(
         sat_excess < 0,
         -min(-sat_excess, max(0, q_icl)) / timescale,
         sat_excess / timescale,
+    )
+    limiter = INP_limiter(tendency, tps, T)
+    return ifelse(limiter, zero(tendency), tendency)
+end
+function conv_q_vap_to_q_icl(
+    ::CMP.TemperatureDependentCloudIceFormation, mp, tps::TDI.PS, micro, thermo,
+)
+    (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
+    (; ρ, T) = thermo
+    τ_sub = τ_relax(mp.cloud.ice)
+    τ_dep = τ_relax(mp.cloud.ice, mp.air_properties, mp.frostenberg2023, q_icl, T)
+
+    Rᵥ = TDI.Rᵥ(tps)
+    Lₛ = TDI.Lₛ(tps, T)
+    cₚ_air = TDI.cpₘ(tps, q_tot, q_lcl + q_rai, q_icl + q_sno)
+
+    qᵥ = TDI.q_vap(q_tot, q_lcl + q_rai, q_icl + q_sno)
+    qᵥ_sat_ice = TDI.saturation_vapor_specific_content_over_ice(tps, T, ρ)
+
+    dqsi_dT = dqcld_dT(qᵥ_sat_ice, Lₛ, Rᵥ, T)
+    Γᵢ = gamma_helper(Lₛ, cₚ_air, dqsi_dT)
+
+    sat_excess = qᵥ - qᵥ_sat_ice
+    sublimation_timescale = τ_sub * Γᵢ
+    deposition_timescale = τ_dep * Γᵢ
+
+    # compute the tendency
+    tendency = ifelse(
+        sat_excess < 0,
+        -min(-sat_excess, max(0, q_icl)) / sublimation_timescale,
+        sat_excess / deposition_timescale,
     )
     limiter = INP_limiter(tendency, tps, T)
     return ifelse(limiter, zero(tendency), tendency)

--- a/src/parameters/Microphysics1MOptions.jl
+++ b/src/parameters/Microphysics1MOptions.jl
@@ -1,0 +1,116 @@
+export Microphysics1MOptions,
+    MicrophysicsOption,
+    ConstantTimescaleCloudLiquidFormation,
+    ConstantTimescaleCloudIceFormation,
+    TemperatureDependentCloudIceFormation,
+    NoCloudIceMelt,
+    CloudIceMeltToLiquid,
+    LiquidAutoconv1M,
+    LiquidAutoconv2M,
+    SnowAutoconvNoSupersat,
+    SnowAutoconvWithSupersat,
+    EvaporationOnly,
+    SublimationOnly,
+    DepositionSublimation,
+    SnowMelt
+"""
+    MicrophysicsOption
+
+Abstract type for all microphysics process options.
+"""
+abstract type MicrophysicsOption end
+
+"""Use a constant relaxation timescale for liquid condensation and evaporation."""
+struct ConstantTimescaleCloudLiquidFormation <: MicrophysicsOption end
+
+"""Use a constant relaxation timescale for ice deposition and sublimation."""
+struct ConstantTimescaleCloudIceFormation <: MicrophysicsOption end
+
+"""Use the INP-dependent Frostenberg (2023) timescale for deposition,
+   with constant timescale for sublimation."""
+struct TemperatureDependentCloudIceFormation <: MicrophysicsOption end
+
+"""No cloud ice melting process."""
+struct NoCloudIceMelt <: MicrophysicsOption end
+
+"""Cloud ice melts to cloud liquid above freezing."""
+struct CloudIceMeltToLiquid <: MicrophysicsOption end
+
+"""1-moment Kessler autoconversion only."""
+struct LiquidAutoconv1M <: MicrophysicsOption end
+
+"""Variable-timescale 2-moment autoconversion (uses prescribed Nc)."""
+struct LiquidAutoconv2M <: MicrophysicsOption end
+
+"""Simplified autoconversion without supersaturation dependence."""
+struct SnowAutoconvNoSupersat <: MicrophysicsOption end
+
+"""Harrington/Kaul autoconversion with supersaturation dependence."""
+struct SnowAutoconvWithSupersat <: MicrophysicsOption end
+
+"""Evaporation only (sub-saturated conditions over liquid)."""
+struct EvaporationOnly <: MicrophysicsOption end
+
+"""Only sublimation (S < 0); deposition handled separately by non-equilibrium."""
+struct SublimationOnly <: MicrophysicsOption end
+
+"""Both sublimation (S < 0) and deposition (S > 0) in the Marshall-Palmer integral."""
+struct DepositionSublimation <: MicrophysicsOption end
+
+"""Snow melts to rain above freezing."""
+struct SnowMelt <: MicrophysicsOption end
+
+"""
+    Microphysics1MOptions{CLF, CIF, CIM, CLA, SA, RE, SS, SM}
+
+Process configuration for 1-moment microphysics.
+Each field selects a variant for one microphysical process.
+
+Defaults match the baseline (old main branch) behavior.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+
+# Example
+```julia
+using CloudMicrophysics.Parameters as CMP
+
+# Default (baseline) options:
+opts = CMP.Microphysics1MOptions()
+
+# New branch options (INP-dependent ice, cloud ice melt, deposition+sublimation):
+opts = CMP.Microphysics1MOptions(
+    cloud_liquid_formation  = CMP.ConstantTimescaleCloudLiquidFormation(),
+    cloud_ice_formation     = CMP.TemperatureDependentCloudIceFormation(),
+    cloud_ice_melt          = CMP.CloudIceMeltToLiquid(),
+    snow_sublimation    = CMP.DepositionSublimation(),
+)
+```
+"""
+@kwdef struct Microphysics1MOptions{
+    CLF <: MicrophysicsOption,
+    CIF <: MicrophysicsOption,
+    CIM <: MicrophysicsOption,
+    CLA <: MicrophysicsOption,
+    SA <: MicrophysicsOption,
+    RE <: MicrophysicsOption,
+    SS <: MicrophysicsOption,
+    SM <: MicrophysicsOption,
+} <: ParametersType
+    "cloud liquid formation timescale option"
+    cloud_liquid_formation::CLF = ConstantTimescaleCloudLiquidFormation()
+    "cloud ice formation timescale option"
+    cloud_ice_formation::CIF = ConstantTimescaleCloudIceFormation()
+    "cloud ice melting option"
+    cloud_ice_melt::CIM = CloudIceMeltToLiquid()
+    "cloud liquid autoconversion option"
+    cloud_liquid_autoconversion::CLA = LiquidAutoconv1M()
+    "cloud ice to snow autoconversion option"
+    snow_autoconversion::SA = SnowAutoconvNoSupersat()
+    "rain evaporation option"
+    rain_evaporation::RE = EvaporationOnly()
+    "snow sublimation/deposition option"
+    snow_sublimation::SS = DepositionSublimation()
+    "snow melting option"
+    snow_melt::SM = SnowMelt()
+end

--- a/src/parameters/Microphysics1MParams.jl
+++ b/src/parameters/Microphysics1MParams.jl
@@ -35,31 +35,55 @@ Base.show(io::IO, mime::MIME"text/plain", x::PrecipPhaseParams1M) =
     ShowMethods.verbose_show_type_and_fields(io, mime, x)
 
 """
-    Microphysics1MParams{FT, CP, PP, CE, AP, VL, VA}
+    Microphysics1MParams{FT, OPT, CP, PP, CE, AP, VL, VA, FR}
 
 Unified parameter container for 1-moment bulk microphysics.
 
 # Fields
+- `options::OPT`: Microphysics1MOptions — process configuration (selects parameterization variants)
 - `cloud::CP`: CloudPhaseParams1M — cloud liquid and ice parameters
 - `precip::PP`: PrecipPhaseParams1M — rain and snow parameters
 - `collision::CE`: CollisionEff — collision efficiencies between species
 - `air_properties::AP`: AirProperties — air properties (diffusivities, thermal conductivity)
 - `terminal_velocity::VL`: Blk1MVelType — terminal velocity parameters for rain and snow
-- `autoconv_2M::VA`: VarTimescaleAcnv or Nothing — optional 2M autoconversion fallback
+- `autoconv_2M::VA`: VarTimescaleAcnv or Nothing — 2M autoconversion parameters (built when `LiquidAutoconv2M` is selected)
 - `prescribed_Nc::FT`: Prescribed cloud droplet number concentration [1/m³]
+- `frostenberg2023::FR`: Frostenberg 2023 INP parameters or Nothing (built when `INPDependentIceFormation` is selected)
+
+# Constructors
+
+    Microphysics1MParams(::Type{FT}; options = Microphysics1MOptions())
+    Microphysics1MParams(toml_dict::CP.ParamDict; options = Microphysics1MOptions())
+
+Create a `Microphysics1MParams` from a float type or a ClimaParams TOML dictionary.
+The `options` keyword argument selects parameterization variants; sub-parameters
+(`autoconv_2M`, `frostenberg2023`) are conditionally built based on the chosen options.
 
 # Example
 ```julia
 using CloudMicrophysics.Parameters as CMP
 
-# Create 1M parameters with default settings
+# Create 1M parameters with default (baseline) settings
 mp = CMP.Microphysics1MParams(Float64)
 
-# Create with optional 2M autoconversion fallback
-mp_with_2M = CMP.Microphysics1MParams(Float64; with_2M_autoconv = true)
+# Create with INP-dependent ice formation and cloud ice melt
+mp = CMP.Microphysics1MParams(Float64;
+    options = CMP.Microphysics1MOptions(
+        cloud_ice_formation  = CMP.TemperatureDependentCloudIceFormation(),
+        cloud_ice_melt = CMP.CloudIceMeltToLiquid(),
+    ),
+)
+
+# Create with 2M autoconversion
+mp = CMP.Microphysics1MParams(Float64;
+    options = CMP.Microphysics1MOptions(
+        cloud_liquid_autoconversion = CMP.LiquidAutoconv2M(),
+    ),
+)
 ```
 """
-@kwdef struct Microphysics1MParams{FT, CP, PP, CE, AP, VL, VA} <: ParametersType
+@kwdef struct Microphysics1MParams{FT, OPT, CP, PP, CE, AP, VL, VA, FR} <: ParametersType
+    options::OPT
     cloud::CP
     precip::PP
     collision::CE
@@ -67,24 +91,34 @@ mp_with_2M = CMP.Microphysics1MParams(Float64; with_2M_autoconv = true)
     terminal_velocity::VL
     autoconv_2M::VA
     prescribed_Nc::FT
+    frostenberg2023::FR
 end
 Base.show(io::IO, mime::MIME"text/plain", x::Microphysics1MParams) =
     ShowMethods.verbose_show_type_and_fields(io, mime, x)
 
 """
-    Microphysics1MParams(toml_dict::CP.ParamDict; with_2M_autoconv = false)
+    Microphysics1MParams(toml_dict::CP.ParamDict; options = Microphysics1MOptions())
 
 Create a `Microphysics1MParams` object from a ClimaParams TOML dictionary.
 
 # Arguments
 - `toml_dict`: ClimaParams parameter dictionary
-- `with_2M_autoconv`: Include 2-moment autoconversion parameters (default: false)
+- `options`: Process configuration (default: baseline behavior)
 """
-function Microphysics1MParams(toml_dict::CP.ParamDict; with_2M_autoconv = false)
+function Microphysics1MParams(toml_dict::CP.ParamDict; options = Microphysics1MOptions())
     (; prescribed_cloud_droplet_number_concentration) = CP.get_parameter_values(
         toml_dict, "prescribed_cloud_droplet_number_concentration", "CloudMicrophysics",
     )
+    # Conditional construction driven by options
+    autoconv_2M = options.cloud_liquid_autoconversion isa LiquidAutoconv2M ?
+                  VarTimescaleAcnv(toml_dict) : nothing
+    frostenberg2023 =
+        options.cloud_ice_formation isa TemperatureDependentCloudIceFormation ?
+        Frostenberg2023(toml_dict) : nothing
+
     return Microphysics1MParams(;
+        # Process options
+        options,
         # Cloud phase parameters
         cloud = CloudPhaseParams1M(;
             liquid = CloudLiquid(toml_dict),
@@ -99,9 +133,10 @@ function Microphysics1MParams(toml_dict::CP.ParamDict; with_2M_autoconv = false)
         collision = CollisionEff(toml_dict),
         air_properties = AirProperties(toml_dict),
         terminal_velocity = Blk1MVelType(toml_dict),
-        # Optional 2M autoconversion
-        autoconv_2M = with_2M_autoconv ? VarTimescaleAcnv(toml_dict) : nothing,
+        # Conditionally built parameters
+        autoconv_2M,
         # Prescribed cloud droplet number concentration
         prescribed_Nc = prescribed_cloud_droplet_number_concentration,
+        frostenberg2023,
     )
 end

--- a/src/parameters/Parameters.jl
+++ b/src/parameters/Parameters.jl
@@ -48,6 +48,7 @@ include("TerminalVelocity.jl")
 
 # Unified parameter containers
 include("Microphysics0MParams.jl")
+include("Microphysics1MOptions.jl")
 include("Microphysics1MParams.jl")
 include("Microphysics2MParams.jl")
 

--- a/test/bulk_tendencies_tests.jl
+++ b/test/bulk_tendencies_tests.jl
@@ -394,7 +394,7 @@ function test_bulk_microphysics_1m_tendencies(FT)
             ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno,
         )
 
-        # Snow should increase from deposition (evaporation_sublimation returns positive for S > 0)
+        # Snow should increase from deposition (conv_q_sno_to_q_vap returns positive for S > 0)
         @test tendencies.dq_sno_dt > FT(0)
     end
 
@@ -554,8 +554,10 @@ function test_bulk_microphysics_1m_tendencies(FT)
 
         # Calculate individual components
         S_accr = CM1.accretion(liquid, snow, vel.snow, ce, q_lcl, q_sno, ρ)
-        S_melt = CM1.snow_melt(snow, vel.snow, aps, tps, q_sno, ρ, T)
-        S_subl = CM1.evaporation_sublimation(snow, vel.snow, aps, tps, q_tot, q_lcl, FT(0), FT(0), q_sno, ρ, T)
+        micro_s = (; q_tot, q_lcl, q_icl = FT(0), q_rai = FT(0), q_sno)
+        thermo_s = (; ρ, T)
+        S_melt = CM1.conv_q_sno_to_q_rai(CMP.SnowMelt(), mp, tps, micro_s, thermo_s)
+        S_subl = CM1.conv_q_sno_to_q_vap(CMP.DepositionSublimation(), mp, tps, micro_s, thermo_s)
 
         # Calculate α
         T_frz = TDI.T_freeze(tps)
@@ -625,6 +627,7 @@ function test_average_bulk_microphysics_1m_tendencies(FT)
         )
 
         @test isfinite(lin.M11)
+        @test isfinite(lin.M12)
         @test isfinite(lin.M22)
         @test isfinite(lin.M31)
         @test isfinite(lin.M33)
@@ -678,6 +681,7 @@ function test_average_bulk_microphysics_1m_tendencies(FT)
 
         @test lin.M33 <= FT(0)
         @test lin.M11 == FT(0)
+        @test lin.M12 == FT(0)
         @test lin.M22 == FT(0)
         @test lin.M31 == FT(0)
         @test lin.M34 == FT(0)
@@ -711,6 +715,7 @@ function test_average_bulk_microphysics_1m_tendencies(FT)
         @test lin.M34 > FT(0)
         @test lin.M44 < FT(0)
         @test lin.M11 == FT(0)
+        @test lin.M12 == FT(0)
         @test lin.M22 == FT(0)
         @test lin.M31 == FT(0)
         @test lin.M41 == FT(0)
@@ -817,7 +822,7 @@ function test_average_bulk_microphysics_1m_tendencies(FT)
         q_rai_new = q_rai + Δt * tendencies.dq_rai_dt
         q_sno_new = q_sno + Δt * tendencies.dq_sno_dt
 
-        @test (q_lcl_new - q_lcl) * invΔt ≈ lin.M11 * q_lcl_new + lin.e1 atol = FT(100) * eps(FT)
+        @test (q_lcl_new - q_lcl) * invΔt ≈ lin.M11 * q_lcl_new + lin.M12 * q_icl_new + lin.e1 atol = FT(100) * eps(FT)
         @test (q_icl_new - q_icl) * invΔt ≈ lin.M22 * q_icl_new + lin.e2 atol = FT(100) * eps(FT)
         @test (q_rai_new - q_rai) * invΔt ≈ lin.M31 * q_lcl_new + lin.M33 * q_rai_new + lin.M34 * q_sno_new atol =
             FT(100) * eps(FT)

--- a/test/gpu_tests.jl
+++ b/test/gpu_tests.jl
@@ -80,11 +80,13 @@ end
     i = @index(Global, Linear)
     FT = eltype(tps)
     q_lcl = q_icl = q_rai = q_sno = FT(0) # set to zero in this test
-    S_cond_MM2015 = CMN.conv_q_vap_to_q_lcl_icl_MM2015(
-        lcl, tps, qᵥ_sl[i], q_lcl, q_icl, q_rai, q_sno, ρ[i], T[i],
+    mp_mock = (; cloud = (; liquid = lcl))
+    micro_mock = (; q_tot = qᵥ_sl[i], q_lcl, q_icl, q_rai, q_sno)
+    thermo_mock = (; ρ = ρ[i], T = T[i])
+    S_cond = CMN.conv_q_vap_to_q_lcl(
+        CMP.ConstantTimescaleCloudLiquidFormation(), mp_mock, tps, micro_mock, thermo_mock,
     )
-    S_cond = CMN.conv_q_vap_to_q_lcl_icl(icl, qᵢ_s[i], qᵢ[i])
-    output[i] = (; S_cond_MM2015, S_cond)
+    output[i] = (; S_cond)
 end
 
 @kernel inbounds = true function test_chen2022_terminal_velocity_kernel!(
@@ -155,9 +157,11 @@ end
 end
 
 @kernel inbounds = true function test_1_moment_micro_snow_melt_kernel!(
-    snow, blk1mvel, aps, tps, output, ρ, T, qs)
+    mp, tps, output, ρ, T, qs)
     i = @index(Global, Linear)
-    output[i] = CM1.snow_melt(snow, blk1mvel.snow, aps, tps, qs[i], ρ[i], T[i])
+    micro = (; q_tot = zero(ρ[i]), q_lcl = zero(ρ[i]), q_icl = zero(ρ[i]), q_rai = zero(ρ[i]), q_sno = qs[i])
+    thermo = (; ρ = ρ[i], T = T[i])
+    output[i] = CM1.conv_q_sno_to_q_rai(CMP.SnowMelt(), mp, tps, micro, thermo)
 end
 
 @kernel inbounds = true function test_2_moment_acnv_kernel!(
@@ -488,7 +492,7 @@ function test_gpu(FT)
     end
 
     TT.@testset "non-equilibrium microphysics kernels" begin
-        DT = @NamedTuple{S_cond_MM2015::FT, S_cond::FT}
+        DT = @NamedTuple{S_cond::FT}
         (; ndrange, output) = setup_output(1, DT)
 
         ρ = ArrayType([FT(0.8)])
@@ -499,10 +503,9 @@ function test_gpu(FT)
 
         kernel! = test_noneq_micro_kernel!(backend, work_groups)
         kernel!(lcl, icl, tps, output, ρ, T, qᵥ_sl, qᵢ, qᵢ_s; ndrange)
-        (; S_cond_MM2015, S_cond) = Array(output)[1]
+        (; S_cond) = Array(output)[1]
         # test that nonequilibrium cloud formation is callable and returns a reasonable value
-        TT.@test S_cond_MM2015 ≈ FT(3.76347635339803e-5)
-        TT.@test S_cond ≈ FT(-1e-4)
+        TT.@test S_cond ≈ FT(3.76347635339803e-5)
     end
 
     TT.@testset "Chen 2022 terminal velocity kernels" begin
@@ -611,7 +614,7 @@ function test_gpu(FT)
         qs = ArrayType([FT(1e-4), FT(0), FT(1e-4)])
 
         kernel! = test_1_moment_micro_snow_melt_kernel!(backend, work_groups)
-        kernel!(snow, blk1mvel, aps, tps, output, ρ, T, qs; ndrange)
+        kernel!(mp_1m, tps, output, ρ, T, qs; ndrange)
         out = Array(output)
 
         # test if 1-moment snow melt is callable and returns reasonable values

--- a/test/microphysics1M_tests.jl
+++ b/test/microphysics1M_tests.jl
@@ -19,6 +19,7 @@ function test_microphysics1M(FT)
     liquid = CMP.CloudLiquid(FT)
 
     ce = CMP.CollisionEff(FT)
+    mp = CMP.Microphysics1MParams(FT)
 
     Ch2022 = CMP.Chen2022VelType(FT)
     blk1mvel = CMP.Blk1MVelType(FT)
@@ -166,10 +167,9 @@ function test_microphysics1M(FT)
         ρ = p / R / T
 
         # Rain evaporates, rate should be negative
-        evap_rate = CM1.evaporation_sublimation(
-            rain, blk1mvel.rain, aps, tps,
-            q_tot, q_liq, q_ice, q_rai, q_sno, ρ, T,
-        )
+        micro = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
+        thermo = (; ρ, T)
+        evap_rate = CM1.conv_q_rai_to_q_vap(CMP.EvaporationOnly(), mp, tps, micro, thermo)
         TT.@test evap_rate < 0
     end
 
@@ -191,10 +191,9 @@ function test_microphysics1M(FT)
         ρ = p / R / T
 
         # Snow sublimation rate should be negative (losing mass)
-        subl_rate = CM1.evaporation_sublimation(
-            snow, blk1mvel.snow, aps, tps,
-            q_tot, q_liq, q_ice, q_rai, q_sno, ρ, T,
-        )
+        micro = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
+        thermo = (; ρ, T)
+        subl_rate = CM1.conv_q_sno_to_q_vap(CMP.SublimationOnly(), mp, tps, micro, thermo)
         TT.@test subl_rate < 0
     end
 
@@ -224,35 +223,21 @@ function test_microphysics1M(FT)
         q_icl_threshold = snow.acnv1M.q_threshold
         τ_acnv_sno = snow.acnv1M.τ
 
+        # Below threshold → rate near zero (uses logistic smoothing)
         q_icl_small = FT(0.5) * q_icl_threshold
-        TT.@test CM1.conv_q_icl_to_q_sno_no_supersat(
-            snow.acnv1M,
-            q_icl_small,
-        ) == FT(0)
-
-        TT.@test CM1.conv_q_icl_to_q_sno_no_supersat(
-            snow.acnv1M,
-            q_icl_small,
-            true,
+        micro_s = (; q_tot = FT(0), q_lcl = FT(0), q_icl = q_icl_small, q_rai = FT(0), q_sno = FT(0))
+        thermo_s = (; ρ = FT(1), T = FT(250))
+        TT.@test CM1.conv_q_icl_to_q_sno(
+            CMP.SnowAutoconvNoSupersat(), mp, tps, micro_s, thermo_s,
         ) ≈ FT(0.0) atol = FT(0.15) * q_icl_threshold / τ_acnv_sno
 
+        # Above threshold → positive rate
         q_icl_big = FT(1.5) * q_icl_threshold
-        TT.@test CM1.conv_q_icl_to_q_sno_no_supersat(snow.acnv1M, q_icl_big) ≈
-                 FT(0.5) * q_icl_threshold / τ_acnv_sno
-
-        TT.@test CM1.conv_q_icl_to_q_sno_no_supersat(
-            snow.acnv1M,
-            q_icl_big,
-            true,
+        micro_b = (; q_tot = FT(0), q_lcl = FT(0), q_icl = q_icl_big, q_rai = FT(0), q_sno = FT(0))
+        TT.@test CM1.conv_q_icl_to_q_sno(
+            CMP.SnowAutoconvNoSupersat(), mp, tps, micro_b, thermo_s,
         ) ≈ FT(0.5) * q_icl_threshold / τ_acnv_sno atol =
             FT(0.15) * q_icl_threshold / τ_acnv_sno
-
-        TT.@test CM1.conv_q_icl_to_q_sno_no_supersat(snow.acnv1M, q_icl_big) ==
-                 CM1.conv_q_icl_to_q_sno_no_supersat(
-            snow.acnv1M,
-            q_icl_big,
-            false,
-        )
 
     end
 
@@ -263,26 +248,37 @@ function test_microphysics1M(FT)
         qₛ = FT(1e-4)
         T_freeze = TDI.TD.Parameters.T_freeze(tps)
 
+        # Use mp with SnowAutoconvWithSupersat
+        mp_ss = CMP.Microphysics1MParams(FT;
+            options = CMP.Microphysics1MOptions(snow_autoconversion = CMP.SnowAutoconvWithSupersat()),
+        )
+
         # above freezing temperatures -> no snow
         qᵥ = FT(15e-3)
         qₗ = FT(2e-3)
         qᵢ = FT(1e-3)
         qₜ = qᵥ + qₗ + qᵢ + qᵣ + qₛ
         T = T_freeze + FT(30)
-        TT.@test CM1.conv_q_icl_to_q_sno(ice, aps, tps, qₜ, qₗ, qᵢ, qᵣ, qₛ, ρ, T) == FT(0)
+        micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
+        thermo = (; ρ, T)
+        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconvWithSupersat(), mp_ss, tps, micro, thermo) == FT(0)
 
         # no cloud ice -> no snow
         qᵢ = FT(0)
         qₜ = qᵥ + qₗ + qᵢ + qᵣ + qₛ
         T = T_freeze - FT(30)
-        TT.@test CM1.conv_q_icl_to_q_sno(ice, aps, tps, qₜ, qₗ, qᵢ, qᵣ, qₛ, ρ, T) == FT(0)
+        micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
+        thermo = (; ρ, T)
+        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconvWithSupersat(), mp_ss, tps, micro, thermo) == FT(0)
 
         # no supersaturation -> no snow
         T = T_freeze - FT(5)
         qᵢ = FT(3e-3)
         q_sat_ice = TDI.saturation_vapor_specific_content_over_ice(tps, T, ρ)
         qₜ = q_sat_ice
-        TT.@test CM1.conv_q_icl_to_q_sno(ice, aps, tps, qₜ, qₗ, qᵢ, qᵣ, qₛ, ρ, T) ≈ FT(0)
+        micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
+        thermo = (; ρ, T)
+        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconvWithSupersat(), mp_ss, tps, micro, thermo) ≈ FT(0)
 
         # Regression test: keep result constant when code changes
         T = T_freeze - FT(10)
@@ -291,7 +287,9 @@ function test_microphysics1M(FT)
         qᵢ = FT(0.03) * qᵥ
         qₜ = qᵥ + qₗ + qᵢ + qᵣ + qₛ
         ref = FT(2.5408135723057333e-9)
-        TT.@test CM1.conv_q_icl_to_q_sno(ice, aps, tps, qₜ, qₗ, qᵢ, qᵣ, qₛ, ρ, T) ≈ ref
+        micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
+        thermo = (; ρ, T)
+        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconvWithSupersat(), mp_ss, tps, micro, thermo) ≈ ref
     end
 
     TT.@testset "RainLiquidAccretion" begin
@@ -447,24 +445,12 @@ function test_microphysics1M(FT)
             R = TDI.Rₘ(tps, q_tot, q_lcl + q_rai, FT(0))
             ρ = p / R / T
 
-            tmp1 = CM1.evaporation_sublimation(rain, blk1mvel.rain, aps, tps, q_tot, q_lcl, FT(0), q_rai, FT(0), ρ, T)
-            dtmp1 = CM1.∂evaporation_sublimation_∂q_precip(
-                rain,
-                blk1mvel.rain,
-                aps,
-                tps,
-                q_tot,
-                q_lcl,
-                FT(0),
-                q_rai,
-                FT(0),
-                ρ,
-                T,
-            )
+            micro = (; q_tot, q_lcl, q_icl = FT(0), q_rai, q_sno = FT(0))
+            thermo = (; ρ, T)
+            tmp1 = CM1.conv_q_rai_to_q_vap(CMP.EvaporationOnly(), mp, tps, micro, thermo)
             tmp2 = rain_evap_empir(tps, q_rai, q_tot, q_lcl, FT(0), T, p, ρ)
 
             TT.@test tmp1 ≈ tmp2 atol = 1e-6
-            TT.@test dtmp1 ≈ tmp1 / q_rai
         end
 
         # no condensational growth for rain
@@ -481,25 +467,53 @@ function test_microphysics1M(FT)
         R = TDI.Rₘ(tps, q_tot, q_liq, q_ice)
         ρ = p / R / T
 
-        TT.@test CM1.evaporation_sublimation(
-            rain,
-            blk1mvel.rain,
-            aps,
-            tps,
-            q_tot,
-            q_liq,
-            q_ice,
-            q_rai,
-            q_sno,
-            ρ,
-            T,
-        ) ≈ FT(0)
+        micro = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
+        thermo = (; ρ, T)
+        TT.@test CM1.conv_q_rai_to_q_vap(CMP.EvaporationOnly(), mp, tps, micro, thermo) ≈ FT(0)
 
     end
 
     TT.@testset "SnowSublimation" begin
         # Regression test: keep results constant when code changes
 
+        cnt = 0
+        ref_val = [
+            FT(-1.9756907119482267e-7),
+            FT(0),
+            FT(-1.6641552112891826e-7),
+            FT(0),
+        ]
+        # some example values
+        T_freeze = TDI.TD.Parameters.T_freeze(tps)
+        for T in [T_freeze + FT(2), T_freeze - FT(2)]
+            p = FT(90000)
+            ϵ = TDI.Rd_over_Rv(tps)
+            p_sat = TDI.saturation_vapor_pressure_over_ice(tps, T)
+            q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1))
+
+            for eps in [FT(0.95), FT(1.05)]
+                cnt += 1
+
+                q_sno = FT(1e-4)
+                q_rai = FT(0)
+                q_tot = eps * q_sat + q_sno
+                q_ice = FT(0)
+                q_liq = FT(0)
+
+                R = TDI.Rₘ(tps, q_tot, q_liq + q_rai, q_ice + q_sno)
+                ρ = p / R / T
+
+                micro = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
+                thermo = (; ρ, T)
+                tmp1 = CM1.conv_q_sno_to_q_vap(CMP.SublimationOnly(), mp, tps, micro, thermo)
+                TT.@test tmp1 ≈ ref_val[cnt] rtol = 1e-2
+            end
+        end
+    end
+
+    TT.@testset "SnowSublimation and Deposition" begin
+        # Regression test: keep results constant when code changes
+        # Uses DepositionSublimation() and original reference values that include deposition
         cnt = 0
         ref_val = [
             FT(-1.9756907119482267e-7),
@@ -527,34 +541,10 @@ function test_microphysics1M(FT)
                 R = TDI.Rₘ(tps, q_tot, q_liq + q_rai, q_ice + q_sno)
                 ρ = p / R / T
 
-                tmp1 = CM1.evaporation_sublimation(
-                    snow,
-                    blk1mvel.snow,
-                    aps,
-                    tps,
-                    q_tot,
-                    q_liq,
-                    q_ice,
-                    q_rai,
-                    q_sno,
-                    ρ,
-                    T,
-                )
-                dtmp1 = CM1.∂evaporation_sublimation_∂q_precip(
-                    snow,
-                    blk1mvel.snow,
-                    aps,
-                    tps,
-                    q_tot,
-                    q_liq,
-                    q_ice,
-                    q_rai,
-                    q_sno,
-                    ρ,
-                    T,
-                )
+                micro = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
+                thermo = (; ρ, T)
+                tmp1 = CM1.conv_q_sno_to_q_vap(CMP.DepositionSublimation(), mp, tps, micro, thermo)
                 TT.@test tmp1 ≈ ref_val[cnt] rtol = 1e-2
-                TT.@test dtmp1 ≈ tmp1 / q_sno
             end
         end
     end
@@ -566,161 +556,74 @@ function test_microphysics1M(FT)
         T = T_freeze + FT(2)
         ρ = FT(1.2)
         q_sno = FT(1e-4)
-        (melt_rate) = CM1.snow_melt(snow, blk1mvel.snow, aps, tps, q_sno, ρ, T)
-        melt_deriv = CM1.∂snow_melt_∂q_sno(snow, blk1mvel.snow, aps, tps, q_sno, ρ, T)
+        micro_sno = (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno)
+        thermo_sno = (; ρ, T)
+        (melt_rate) = CM1.conv_q_sno_to_q_rai(CMP.SnowMelt(), mp, tps, micro_sno, thermo_sno)
         TT.@test melt_rate ≈ FT(9.516553267013085e-6)
-        TT.@test melt_deriv ≈ melt_rate / q_sno
 
         # no snow -> no snow melt
         T = T_freeze + FT(2)
         ρ = FT(1.2)
         q_sno = FT(0)
-        TT.@test CM1.snow_melt(snow, blk1mvel.snow, aps, tps, q_sno, ρ, T) ≈
+        micro_sno = (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno)
+        thermo_sno = (; ρ, T)
+        TT.@test CM1.conv_q_sno_to_q_rai(CMP.SnowMelt(), mp, tps, micro_sno, thermo_sno) ≈
                  FT(0)
 
         # T < T_freeze -> no snow melt
         T = T_freeze - FT(2)
         ρ = FT(1.2)
         q_sno = FT(1e-4)
-        TT.@test CM1.snow_melt(snow, blk1mvel.snow, aps, tps, q_sno, ρ, T) ≈
+        micro_sno = (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno)
+        thermo_sno = (; ρ, T)
+        TT.@test CM1.conv_q_sno_to_q_rai(CMP.SnowMelt(), mp, tps, micro_sno, thermo_sno) ≈
                  FT(0)
 
     end
 
-    TT.@testset "RainEvaporationDerivative_FiniteDiff" begin
-        # Verify ∂(evap)/∂q_rai via central finite differences at constant e_tot, ρ, q_tot.
-        # The analytical derivative uses rate/q_rai, which neglects the n0(q)‐dependence
-        # in the Marshall–Palmer distribution and temperature feedback through latent heat.
+    TT.@testset "CloudIceMelt" begin
+
+        # Regression test: keep result constant when code changes
         T_freeze = TDI.TD.Parameters.T_freeze(tps)
-        T, p = T_freeze + FT(15), FT(90000)
-        ϵ = TDI.Rd_over_Rv(tps)
-        p_sat = TDI.saturation_vapor_pressure_over_liquid(tps, T)
-        q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1))
-        q_rai = FT(1e-3)
-        q_tot = FT(15e-3)
-        q_vap = FT(0.15) * q_sat  # subsaturated
-        q_lcl = q_tot - q_vap - q_rai
-        q_icl = FT(0)
-        q_sno = FT(0)
-        R = TDI.Rₘ(tps, q_tot, q_lcl + q_rai, q_icl + q_sno)
-        ρ = p / R / T
-
-        rate = CM1.evaporation_sublimation(
-            rain, blk1mvel.rain, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T,
-        )
-        drate = CM1.∂evaporation_sublimation_∂q_precip(
-            rain, blk1mvel.rain, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T,
-        )
-        TT.@test rate < 0  # evaporation
-        TT.@test drate ≈ rate / q_rai
-
-        # Central finite difference at constant e_tot, ρ, q_tot:
-        # perturb q_rai, recover T from energy conservation
-        q_liq = q_lcl + q_rai
-        q_ice = q_icl + q_sno
-        e_int = TDI.TD.internal_energy(tps, T, q_tot, q_liq, q_ice)
-
-        Δq = FT(1e-8)
-        q_liq_p = q_lcl + (q_rai + Δq)
-        q_liq_m = q_lcl + (q_rai - Δq)
-        T_p = TDI.TD.air_temperature(tps, e_int, q_tot, q_liq_p, q_ice)
-        T_m = TDI.TD.air_temperature(tps, e_int, q_tot, q_liq_m, q_ice)
-        rate_p = CM1.evaporation_sublimation(
-            rain, blk1mvel.rain, aps, tps, q_tot, q_lcl, q_icl, q_rai + Δq, q_sno, ρ, T_p,
-        )
-        rate_m = CM1.evaporation_sublimation(
-            rain, blk1mvel.rain, aps, tps, q_tot, q_lcl, q_icl, q_rai - Δq, q_sno, ρ, T_m,
-        )
-        fd_deriv = (rate_p - rate_m) / (2Δq)
-        TT.@test sign(drate) == sign(fd_deriv)
-        TT.@test drate ≈ fd_deriv rtol = FT(0.2)
-    end
-
-    TT.@testset "SnowSublimationDerivative_FiniteDiff" begin
-        # Verify ∂(subl)/∂q_sno via central finite differences at constant e_tot, ρ, q_tot.
-        # The analytical derivative uses rate/q_sno, which neglects the n0(q_sno)‐dependence
-        # in the Marshall–Palmer distribution (n0 ~ q_sno^ν for snow) and temperature
-        # feedback through latent heat. This is a cruder approximation for snow than
-        # for rain because snow n0 depends on q_sno.
-        T_freeze = TDI.TD.Parameters.T_freeze(tps)
-        T, p = T_freeze - FT(10), FT(90000)
-        ϵ = TDI.Rd_over_Rv(tps)
-        p_sat = TDI.saturation_vapor_pressure_over_ice(tps, T)
-        q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1))
-        q_sno = FT(1e-4)
-        q_tot = FT(0.95) * q_sat + q_sno
-        q_lcl = FT(0)
-        q_icl = FT(0)
-        q_rai = FT(0)
-        R = TDI.Rₘ(tps, q_tot, q_lcl + q_rai, q_icl + q_sno)
-        ρ = p / R / T
-
-        rate = CM1.evaporation_sublimation(
-            snow, blk1mvel.snow, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T,
-        )
-        drate = CM1.∂evaporation_sublimation_∂q_precip(
-            snow, blk1mvel.snow, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, T,
-        )
-        TT.@test rate < 0  # sublimation
-        TT.@test drate ≈ rate / q_sno
-
-        # Central finite difference at constant e_tot, ρ, q_tot:
-        # perturb q_sno, recover T from energy conservation
-        q_liq = q_lcl + q_rai
-        q_ice = q_icl + q_sno
-        e_int = TDI.TD.internal_energy(tps, T, q_tot, q_liq, q_ice)
-
-        Δq = FT(1e-8)
-        q_ice_p = q_icl + (q_sno + Δq)
-        q_ice_m = q_icl + (q_sno - Δq)
-        T_p = TDI.TD.air_temperature(tps, e_int, q_tot, q_liq, q_ice_p)
-        T_m = TDI.TD.air_temperature(tps, e_int, q_tot, q_liq, q_ice_m)
-        rate_p = CM1.evaporation_sublimation(
-            snow, blk1mvel.snow, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno + Δq, ρ, T_p,
-        )
-        rate_m = CM1.evaporation_sublimation(
-            snow, blk1mvel.snow, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno - Δq, ρ, T_m,
-        )
-        fd_deriv = (rate_p - rate_m) / (2Δq)
-        TT.@test sign(drate) == sign(fd_deriv)
-        TT.@test drate ≈ fd_deriv rtol = FT(0.7)
-    end
-
-    TT.@testset "SnowMeltDerivative_FiniteDiff" begin
-        # Verify ∂(melt)/∂q_sno via central finite differences at constant e_tot, ρ, q_tot.
-        # The analytical derivative uses rate/q_sno.  Snow melt has a weaker n0(q_sno)
-        # dependence than sublimation, so the approximation is more accurate (~3% error).
-        T_freeze = TDI.TD.Parameters.T_freeze(tps)
-        T = T_freeze + FT(4)
+        T = T_freeze + FT(2)
         ρ = FT(1.2)
-        q_sno = FT(1e-4)
-        q_lcl = FT(0)
-        q_icl = FT(0)
-        q_rai = FT(0)
-        q_tot = FT(10e-3)
+        q_icl = FT(1e-4)
+        mp_melt = CMP.Microphysics1MParams(FT;
+            options = CMP.Microphysics1MOptions(cloud_ice_melt = CMP.CloudIceMeltToLiquid()),
+        )
+        micro = (; q_tot = FT(0), q_lcl = FT(0), q_icl, q_rai = FT(0), q_sno = FT(0))
+        thermo = (; ρ, T)
+        melt_rate = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMeltToLiquid(), mp_melt, tps, micro, thermo)
+        TT.@test melt_rate > 0
 
-        rate = CM1.snow_melt(snow, blk1mvel.snow, aps, tps, q_sno, ρ, T)
-        drate = CM1.∂snow_melt_∂q_sno(snow, blk1mvel.snow, aps, tps, q_sno, ρ, T)
-        TT.@test rate > 0  # melting
-        TT.@test drate ≈ rate / q_sno
+        # no cloud ice → no melt
+        micro_0 = (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
+        TT.@test CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMeltToLiquid(), mp_melt, tps, micro_0, thermo) ≈ FT(0)
 
-        # Central finite difference at constant e_tot, ρ, q_tot:
-        # perturb q_sno, recover T from energy conservation
-        q_liq = q_lcl + q_rai
-        q_ice = q_icl + q_sno
-        e_int = TDI.TD.internal_energy(tps, T, q_tot, q_liq, q_ice)
+        # T < T_freeze → no melt
+        thermo_cold = (; ρ, T = T_freeze - FT(2))
+        TT.@test CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMeltToLiquid(), mp_melt, tps, micro, thermo_cold) ≈ FT(0)
 
-        Δq = FT(1e-8)
-        q_ice_p = q_icl + (q_sno + Δq)
-        q_ice_m = q_icl + (q_sno - Δq)
-        T_p = TDI.TD.air_temperature(tps, e_int, q_tot, q_liq, q_ice_p)
-        T_m = TDI.TD.air_temperature(tps, e_int, q_tot, q_liq, q_ice_m)
-        rate_p = CM1.snow_melt(snow, blk1mvel.snow, aps, tps, q_sno + Δq, ρ, T_p)
-        rate_m = CM1.snow_melt(snow, blk1mvel.snow, aps, tps, q_sno - Δq, ρ, T_m)
-        fd_deriv = (rate_p - rate_m) / (2Δq)
-        TT.@test sign(drate) == sign(fd_deriv)
-        TT.@test drate ≈ fd_deriv rtol = FT(0.05)
+        # more ice → higher melt rate
+        thermo_warm = (; ρ, T = T_freeze + FT(5))
+        micro_s = (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(1e-5), q_rai = FT(0), q_sno = FT(0))
+        micro_l = (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(1e-3), q_rai = FT(0), q_sno = FT(0))
+        rate_small = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMeltToLiquid(), mp_melt, tps, micro_s, thermo_warm)
+        rate_large = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMeltToLiquid(), mp_melt, tps, micro_l, thermo_warm)
+        TT.@test rate_large > rate_small
+
+        # warmer T → higher melt rate
+        thermo_w = (; ρ, T = T_freeze + FT(10))
+        thermo_c = (; ρ, T = T_freeze + FT(1))
+        rate_warm = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMeltToLiquid(), mp_melt, tps, micro, thermo_w)
+        rate_cool = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMeltToLiquid(), mp_melt, tps, micro, thermo_c)
+        TT.@test rate_warm > rate_cool
+
+        # NoCloudIceMelt returns zero
+        TT.@test CM1.conv_q_icl_to_q_lcl(CMP.NoCloudIceMelt(), mp, tps, micro, thermo) == FT(0)
+
     end
+
 end
 
 TT.@testset "Microphysics 1M Tests ($FT)" for FT in (Float64, Float32)

--- a/test/microphysics_noneq_tests.jl
+++ b/test/microphysics_noneq_tests.jl
@@ -10,6 +10,8 @@ function test_microphysics_noneq(FT)
 
     ice = CMP.CloudIce(FT)
     liquid = CMP.CloudLiquid(FT)
+    aps = CMP.AirProperties(FT)
+    frs = CMP.Frostenberg2023(FT)
     tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
     Ch2022 = CMP.Chen2022VelType(FT)
 
@@ -18,33 +20,21 @@ function test_microphysics_noneq(FT)
         TT.@test CMNe.τ_relax(ice) ≈ FT(10)
     end
 
-    TT.@testset "CloudLiquidCondEvap" begin
-
-        q_liq_sat = FT(5e-3)
-        frac = [FT(0), FT(0.5), FT(1), FT(1.5)]
-
-        _τ_cond_evap = CMNe.τ_relax(liquid)
-
-        for fr in frac
-            q_lcl = q_liq_sat * fr
-            TT.@test CMNe.conv_q_vap_to_q_lcl_icl(liquid, q_liq_sat, q_lcl) ≈ (1 - fr) * q_liq_sat / _τ_cond_evap
-        end
+    TT.@testset "τ_relax Frostenberg" begin
+        q_icl = FT(1e-4)
+        T_cold = FT(250)
+        τ_frs = CMNe.τ_relax(ice, aps, frs, q_icl, T_cold)
+        TT.@test τ_frs > FT(0)
+        TT.@test isfinite(τ_frs)
+        # Increasing ice content should decrease τ (larger crystals → faster relaxation)
+        τ_frs_more = CMNe.τ_relax(ice, aps, frs, FT(10) * q_icl, T_cold)
+        TT.@test τ_frs_more < τ_frs
     end
 
-    TT.@testset "CloudIceCondEvap" begin
+    TT.@testset "CondEvap_DepSub" begin
 
-        q_ice_sat = FT(2e-3)
-        frac = [FT(0), FT(0.5), FT(1), FT(1.5)]
-
-        _τ_cond_evap = CMNe.τ_relax(ice)
-
-        for fr in frac
-            q_icl = q_ice_sat * fr
-            TT.@test CMNe.conv_q_vap_to_q_lcl_icl(ice, q_ice_sat, q_icl) ≈ (1 - fr) * q_ice_sat / _τ_cond_evap
-        end
-    end
-
-    TT.@testset "CondEvap_DepSub_MM2015" begin
+        τ_liq = CMNe.τ_relax(liquid)
+        τ_ice = CMNe.τ_relax(ice)
 
         ρ = FT(0.8)
         T = FT(273 - 10)
@@ -56,26 +46,50 @@ function test_microphysics_noneq(FT)
         qᵥ_si = TDI.p2q(tps, T, ρ, pᵥ_si)
 
         #! format: off
-        # test sign
-        TT.@test CMNe.conv_q_vap_to_q_lcl_icl_MM2015(liquid, tps, FT(0.5 * qᵥ_sl), FT(0), FT(0), FT(0), FT(0), ρ, T) == FT(0)
-        TT.@test CMNe.conv_q_vap_to_q_lcl_icl_MM2015(liquid, tps, FT(1.5 * qᵥ_sl), FT(0), FT(0), FT(0), FT(0), ρ, T) > FT(0)
-        TT.@test CMNe.conv_q_vap_to_q_lcl_icl_MM2015(liquid, tps,          qᵥ_sl,  FT(0), FT(0), FT(0), FT(0), ρ, T) ≈ FT(0)
+        # Test helpers
+        _conv_lcl(q_tot, q_lcl, q_icl, ρ, T) = CMNe.conv_q_vap_to_q_lcl(
+            CMP.ConstantTimescaleCloudLiquidFormation(),
+            (; cloud = (; liquid = liquid)),
+            tps,
+            (; q_tot, q_lcl, q_icl, q_rai = FT(0), q_sno = FT(0)),
+            (; ρ, T)
+        )
 
-        TT.@test CMNe.conv_q_vap_to_q_lcl_icl_MM2015(ice, tps, FT(0.5 * qᵥ_si), FT(0), FT(0), FT(0), FT(0), ρ, T) == FT(0)
-        TT.@test CMNe.conv_q_vap_to_q_lcl_icl_MM2015(ice, tps, FT(1.5 * qᵥ_si), FT(0), FT(0), FT(0), FT(0), ρ, T) > FT(0)
-        TT.@test CMNe.conv_q_vap_to_q_lcl_icl_MM2015(ice, tps,          qᵥ_si,  FT(0), FT(0), FT(0), FT(0), ρ, T) ≈ FT(0)
+        _conv_icl(q_tot, q_lcl, q_icl, ρ, T) = CMNe.conv_q_vap_to_q_icl(
+            CMP.ConstantTimescaleCloudIceFormation(),
+            (; cloud = (; ice = ice)),
+            tps,
+            (; q_tot, q_lcl, q_icl, q_rai = FT(0), q_sno = FT(0)),
+            (; ρ, T)
+        )
+
+        _conv_icl_dep(q_tot, q_lcl, q_icl, ρ, T) = CMNe.conv_q_vap_to_q_icl(
+            CMP.TemperatureDependentCloudIceFormation(),
+            (; cloud = (; ice = ice), air_properties = aps, frostenberg2023 = frs),
+            tps,
+            (; q_tot, q_lcl, q_icl, q_rai = FT(0), q_sno = FT(0)),
+            (; ρ, T)
+        )
+
+        # test sign
+        TT.@test _conv_lcl(FT(0.5 * qᵥ_sl), FT(0), FT(0), ρ, T) == FT(0)
+        TT.@test _conv_lcl(FT(1.5 * qᵥ_sl), FT(0), FT(0), ρ, T) > FT(0)
+        TT.@test _conv_lcl(         qᵥ_sl,  FT(0), FT(0), ρ, T) ≈ FT(0)
+
+        TT.@test _conv_icl(FT(0.5 * qᵥ_si), FT(0), FT(0), ρ, T) == FT(0)
+        TT.@test _conv_icl(FT(1.5 * qᵥ_si), FT(0), FT(0), ρ, T) > FT(0)
+        TT.@test _conv_icl(         qᵥ_si,  FT(0), FT(0), ρ, T) ≈ FT(0)
 
         # smoke test for values
-        TT.@test CMNe.conv_q_vap_to_q_lcl_icl_MM2015(liquid, tps, FT(1.2 * qᵥ_sl), FT(0), FT(0), FT(0), FT(0), ρ, T) ≈ 3.763045798130144e-5  rtol = 1e-6
-        TT.@test CMNe.conv_q_vap_to_q_lcl_icl_MM2015(ice,    tps, FT(1.2 * qᵥ_si), FT(0), FT(0), FT(0), FT(0), ρ, T) ≈ 3.235984203087906e-5 rtol = 1e-6
+        TT.@test _conv_lcl(FT(1.2 * qᵥ_sl), FT(0), FT(0), ρ, T) ≈ 3.763045798130144e-5  rtol = 1e-6
+        TT.@test _conv_icl(FT(1.2 * qᵥ_si), FT(0), FT(0), ρ, T) ≈ 3.235984203087906e-5 rtol = 1e-6
 
-        TT.@test CMNe.conv_q_vap_to_q_lcl_icl_MM2015(liquid, tps, FT(1.2 * qᵥ_sl), FT(0), FT(0), FT(0), FT(0), ρ, T) ≈ 3.7630474f-5 rtol = 1e-6
-        TT.@test CMNe.conv_q_vap_to_q_lcl_icl_MM2015(ice,    tps, FT(1.2 * qᵥ_si), FT(0), FT(0), FT(0), FT(0), ρ, T) ≈ 3.2359854f-5 rtol = 1e-6
+        TT.@test _conv_lcl(FT(1.2 * qᵥ_sl), FT(0), FT(0), ρ, T) ≈ 3.7630474f-5 rtol = 1e-6
+        TT.@test _conv_icl(FT(1.2 * qᵥ_si), FT(0), FT(0), ρ, T) ≈ 3.2359854f-5 rtol = 1e-6
 
-        # ice grows faster than liquid
-        TT.@test CMNe.conv_q_vap_to_q_lcl_icl_MM2015(liquid, tps, FT(1.2 * qᵥ_sl), FT(0), FT(0), FT(0), FT(0), ρ, T) <
-                 CMNe.conv_q_vap_to_q_lcl_icl_MM2015(ice,    tps, FT(1.2 * qᵥ_sl), FT(0), FT(0), FT(0), FT(0), ρ, T)
-
+        # ice grows faster than liquid (same saturation excess w.r.t. liquid)
+        TT.@test _conv_lcl(FT(1.2 * qᵥ_sl), FT(0), FT(0), ρ, T) <
+                 _conv_icl(FT(1.2 * qᵥ_sl), FT(0), FT(0), ρ, T)
 
         # --- INP limiter: above freezing, positive ice deposition should be zero ---
         T_warm = FT(280) # above freezing
@@ -85,13 +99,45 @@ function test_microphysics_noneq(FT)
         qᵥ_sl_w = TDI.p2q(tps, T_warm, ρ, pᵥ_sl_w)
 
         # Supersaturated w.r.t. ice above freezing → would deposit, but INP limiter zeros it
-        TT.@test CMNe.conv_q_vap_to_q_lcl_icl_MM2015(ice, tps, FT(1.5 * qᵥ_si_w), FT(0), FT(0), FT(0), FT(0), ρ, T_warm) == FT(0)
+        TT.@test _conv_icl(FT(1.5 * qᵥ_si_w), FT(0), FT(0), ρ, T_warm) == FT(0)
         # Liquid condensation above freezing should be unaffected
-        TT.@test CMNe.conv_q_vap_to_q_lcl_icl_MM2015(liquid, tps, FT(1.5 * qᵥ_sl_w), FT(0), FT(0), FT(0), FT(0), ρ, T_warm) > FT(0)
+        TT.@test _conv_lcl(FT(1.5 * qᵥ_sl_w), FT(0), FT(0), ρ, T_warm) > FT(0)
         # Ice sublimation (negative tendency) above freezing should NOT be limited
-        # When subsaturated w.r.t. ice and q_icl > 0, the tendency is negative (sublimation).
-        # The INP limiter only zeroes positive tendencies above freezing, so sublimation passes through.
-        TT.@test CMNe.conv_q_vap_to_q_lcl_icl_MM2015(ice, tps, FT(0.5 * qᵥ_si_w), FT(0), FT(0.001), FT(0), FT(0), ρ, T_warm) <= FT(0)
+        TT.@test _conv_icl(FT(0.5 * qᵥ_si_w), FT(0), FT(0.001), ρ, T_warm) <= FT(0)
+
+        # --- Asymmetric τ_dep ≠ τ_sub ---
+        # Faster sublimation (smaller τ_sub) should give a larger magnitude sublimation rate
+        # We simulate this by changing the mp ice struct
+        ice_base = CMP.CloudIce(FT)
+        ice_slow = CMP.CloudIce(ice_base.pdf, ice_base.mass, ice_base.r0, ice_base.r_ice_snow, FT(100), ice_base.ρᵢ, ice_base.r_eff, ice_base.N_0)
+        ice_fast = CMP.CloudIce(ice_base.pdf, ice_base.mass, ice_base.r0, ice_base.r_ice_snow, FT(1), ice_base.ρᵢ, ice_base.r_eff, ice_base.N_0)
+        
+        function _conv_icl_custom(ice_mock, q_tot, q_lcl, q_icl, ρ, T)
+            CMNe.conv_q_vap_to_q_icl(
+                CMP.ConstantTimescaleCloudIceFormation(),
+                (; cloud = (; ice = ice_mock)),
+                tps,
+                (; q_tot, q_lcl, q_icl, q_rai = FT(0), q_sno = FT(0)),
+                (; ρ, T)
+            )
+        end
+        sub_fast = _conv_icl_custom(ice_fast, FT(0.5 * qᵥ_si), FT(0), FT(0.001), ρ, T)
+        sub_slow = _conv_icl_custom(ice_slow, FT(0.5 * qᵥ_si), FT(0), FT(0.001), ρ, T)
+        TT.@test sub_fast < sub_slow  # faster sublimation → more negative
+
+        # Deposition rate with TemperatureDependentCloudIceFormation should depend only on τ_dep, not τ_sub
+        function _conv_icl_dep_custom(ice_mock, q_tot, q_lcl, q_icl, ρ, T)
+            CMNe.conv_q_vap_to_q_icl(
+                CMP.TemperatureDependentCloudIceFormation(),
+                (; cloud = (; ice = ice_mock), air_properties = aps, frostenberg2023 = frs),
+                tps,
+                (; q_tot, q_lcl, q_icl, q_rai = FT(0), q_sno = FT(0)),
+                (; ρ, T)
+            )
+        end
+        dep_a = _conv_icl_dep_custom(ice_fast, FT(1.5 * qᵥ_si), FT(0), FT(0), ρ, T)
+        dep_b = _conv_icl_dep_custom(ice_slow, FT(1.5 * qᵥ_si), FT(0), FT(0), ρ, T)
+        TT.@test dep_a ≈ dep_b  # τ_sub doesn't affect deposition
 
         #! format: on
     end

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -170,13 +170,13 @@ function benchmark_test(FT)
         P3.P3State{FT, CMP.ParametersP3{FT, CMP.SlopePowerLaw{FT}}},
         (params, L_ice, N_ice, F_rim, ρ_rim) -> P3.get_state(params; L_ice, N_ice, F_rim, ρ_rim),
         (params_P3, L_ice, N_ice, F_rim, ρ_rim),
-        25,
+        50,
     )
     bench_press(FT, P3.get_distribution_logλ, (state,), 30_000)
     bench_press(FT, P3.get_distribution_logλ, (params_P3, L_ice, N_ice, F_rim, ρ_rim), 30_000)
-    bench_press(FT, P3.ice_terminal_velocity_number_weighted, (ch2022, ρ_air, state, logλ), 120_000)
-    bench_press(FT, P3.ice_terminal_velocity_mass_weighted, (ch2022, ρ_air, state, logλ), 135_000)
-    bench_press(FT, P3.integrate, (x -> x^4, FT(0), FT(1)), 3_700)
+    bench_press(FT, P3.ice_terminal_velocity_number_weighted, (ch2022, ρ_air, state, logλ), 140_000)
+    bench_press(FT, P3.ice_terminal_velocity_mass_weighted, (ch2022, ρ_air, state, logλ), 160_000)
+    bench_press(FT, P3.integrate, (x -> x^4, FT(0), FT(1)), 6_100)
     bench_press(FT, P3.D_m, (state, logλ), 3_000)
 
     @info "P3 Ice Nucleation"
@@ -190,7 +190,7 @@ function benchmark_test(FT)
         @NamedTuple{dNdt::FT, dLdt::FT},
         P3.ice_melt,
         (ch2022, aps, tps, T_air, ρ_air, Δt, state, logλ),
-        150_000,
+        180_000,
     )
     bench_press(FT, CMI_het.P3_deposition_N_i, (ip.p3, T_air_cold), 230)
     bench_press(FT, CMI_het.P3_het_N_i, (ip.p3, T_air_cold, N_liq, V_liq, Δt), 230)
@@ -223,9 +223,12 @@ function benchmark_test(FT)
 
     @info "Non-equilibrium Microphysics"
     bench_press(FT, CMN.τ_relax, (liquid,), 15)
-    bench_press(FT, CMN.conv_q_vap_to_q_lcl_icl, (ice, FT(2e-3), FT(1e-3)), 15)
-    bench_press(FT, CMN.conv_q_vap_to_q_lcl_icl_MM2015,
-        (liquid, tps, FT(0.00145), FT(0), FT(0), FT(0), FT(0), FT(0.8), FT(263)), 75)
+
+    mp_mock = (; cloud = (; liquid = liquid))
+    micro_mock = (; q_tot = FT(0.00145), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
+    thermo_mock = (; ρ = FT(0.8), T = FT(263))
+    bench_press(FT, CMN.conv_q_vap_to_q_lcl,
+        (CMP.ConstantTimescaleCloudLiquidFormation(), mp_mock, tps, micro_mock, thermo_mock), 140)
 
     @info "0-Moment Scheme"
     bench_press(FT, CM0.remove_precipitation, (p0m, q_liq, q_ice), 12)


### PR DESCRIPTION

### Core Design Change: Dispatch-Based Process Options

This PR introduces a **`Microphysics1MOptions`**. Each microphysical process (condensation, autoconversion, evaporation, etc.) is now selected at configuration time via a singleton type, enabling compile-time specialization from the point of view of ClimaAtmos.

**8 configurable processes:**

| Process | Options |
|---------|---------|
| Cloud liquid formation | `ConstantTimescaleCloudLiquidFormation` |
| Cloud ice formation | `ConstantTimescaleCloudIceFormation`, `TemperatureDependentCloudIceFormation` (**new**) |
| Cloud ice melt | `CloudIceMeltToLiquid` (**new**), `NoCloudIceMelt`  |
| Liquid autoconversion | `LiquidAutoconv1M`, `LiquidAutoconv2M` |
| Snow autoconversion | `SnowAutoconvNoSupersat`, `SnowAutoconvWithSupersat` |
| Rain evaporation | `EvaporationOnly` |
| Snow sublimation | `SublimationOnly`, `DepositionSublimation` |
| Snow melt | `SnowMelt` |

The change on the ClimaAtmos side is very minimal and consists of:
- adding flags to config yaml file
- adding code to parse those flags into microphysics options struct
- creating microphysics parameters based on options.

See the draft here: https://github.com/CliMA/ClimaAtmos.jl/pull/4502

### New Physics

1. **Frostenberg (2023) temperature-dependent ice formation** — Uses INP concentration from `HetIceNucleation` to compute a physically-based relaxation timescale for ice deposition (replacing the constant timescale). Selected via `TemperatureDependentCloudIceFormation`.

2. **Cloud ice melt to liquid** — New process where cloud ice melts to cloud liquid above freezing (`conv_q_icl_to_q_lcl`). Previously not represented. Adds `M12` coupling in the implicit solver Jacobian.

### API Refactoring

- **`Microphysics1MParams`** now carries an `options::Microphysics1MOptions` field and conditionally builds sub-parameters (`autoconv_2M`, `frostenberg2023`) based on the selected options.
- **Stale kwarg removed**: `with_2M_autoconv = true` → `options = Microphysics1MOptions(...)`.
- **Unified function signatures**: Process functions like `evaporation_sublimation`, `snow_melt`, `conv_q_icl_to_q_sno_no_supersat` are renamed to consistent `conv_X_to_Y(option, mp, tps, micro, thermo)` form, where `micro = (; q_tot, q_lcl, q_icl, q_rai, q_sno)` and `thermo = (; ρ, T)`.
- **`BulkMicrophysicsTendencies.jl`** dispatches on `mp.options` for every process call, making the tendency computation fully configurable from the options struct.

### Implicit Solver Update

The Jacobian matrix in `average_bulk_microphysics_tendencies` gains an `M12` entry for ice→liquid melt coupling, and autoconversion/sublimation entries are updated to use the new dispatched functions.