### PR TITLE
Aj/bulk micro options part2

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -43,7 +43,6 @@ Microphysics1M.terminal_velocity
 Microphysics1M.conv_q_lcl_to_q_rai
 Microphysics1M.conv_q_icl_to_q_sno
 Microphysics1M.accretion
-Microphysics1M.accretion_rain_sink
 Microphysics1M.accretion_snow_rain
 Microphysics1M.conv_q_rai_to_q_vap
 Microphysics1M.conv_q_sno_to_q_vap

--- a/docs/src/guides/Parameters.jl
+++ b/docs/src/guides/Parameters.jl
@@ -15,6 +15,7 @@
 
 import ClimaParams as CP
 import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.Common as CO
 import CloudMicrophysics.Microphysics1M as CM1
 import CloudMicrophysics.Microphysics2M as CM2
 import CloudMicrophysics.HetIceNucleation as CMI_het
@@ -58,9 +59,11 @@ nothing #hide
 # Finally we check the values of the rain autoconversion timescales
 # and the corresponding rain formation rates.
 qₗ = FT(1e-3)
-default_acnv = CM1.conv_q_lcl_to_q_rai(default.acnv1M, qₗ) # Rain autoconversion rate
-overwrite_acnv = CM1.conv_q_lcl_to_q_rai(overwrite.acnv1M, qₗ) # Rain autoconversion rate
-overwrite_acnv2 = CM1.conv_q_lcl_to_q_rai(overwrite2.acnv1M, qₗ) # Rain autoconversion rate
+default_acnv = CO.logistic_function_integral(qₗ, default.acnv1M.q_threshold, default.acnv1M.k) / default.acnv1M.τ # Rain autoconversion rate
+overwrite_acnv =
+    CO.logistic_function_integral(qₗ, overwrite.acnv1M.q_threshold, overwrite.acnv1M.k) / overwrite.acnv1M.τ # Rain autoconversion rate
+overwrite_acnv2 =
+    CO.logistic_function_integral(qₗ, overwrite2.acnv1M.q_threshold, overwrite2.acnv1M.k) / overwrite2.acnv1M.τ # Rain autoconversion rate
 
 @info("Default:", default.acnv1M.τ, default_acnv)
 @info("Overwrite:", overwrite.acnv1M.τ, overwrite_acnv)

--- a/docs/src/guides/SimpleModel.jl
+++ b/docs/src/guides/SimpleModel.jl
@@ -8,6 +8,7 @@
 import OrdinaryDiffEqTsit5 as ODE
 import UnicodePlots as UP
 import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.Common as CO
 import CloudMicrophysics.Microphysics1M as CM1
 
 nothing #hide
@@ -24,7 +25,8 @@ function rain_formation(dY, Y, p, t)
     qₗ = Y[1] # Cloud water specific content
     qᵣ = Y[2] # Rain water specific content
 
-    acnv = CM1.conv_q_lcl_to_q_rai(rain.acnv1M, qₗ) # Rain autoconversion rate
+    (; τ, q_threshold, k) = rain.acnv1M
+    acnv = CO.logistic_function_integral(qₗ, q_threshold, k) / τ # Rain autoconversion rate
     accr = CM1.accretion(liquid, rain, v_term.rain, ce, qₗ, qᵣ, ρₐ) # Rain accretion rate
 
     dY[1] = -acnv - accr # Add the tendecies for cloud water

--- a/docs/src/plots/BulkTendencies_plots.jl
+++ b/docs/src/plots/BulkTendencies_plots.jl
@@ -22,7 +22,6 @@ function integrate_bulk_microphysics_reference(
     q_sno0,
     t_end;
     dt = 0.1,
-    N_lcl = zero(ρ),
 )
     FT = typeof(q_tot)
     nsteps = Int(round(t_end / dt))
@@ -55,7 +54,6 @@ function integrate_bulk_microphysics_reference(
             q_icl[i],
             q_rai[i],
             q_sno[i],
-            N_lcl,
         )
 
         q_lcl[i + 1] = q_lcl[i] + FT(dt) * rates.dq_lcl_dt
@@ -93,7 +91,6 @@ function integrate_bulk_microphysics_linearized_one_step(
     q_sno0,
     t_end;
     nsub = 1,
-    N_lcl = zero(ρ),
 )
     FT = typeof(q_tot)
 
@@ -129,7 +126,6 @@ function integrate_bulk_microphysics_linearized_one_step(
             q_rai[i],
             q_sno[i],
             Δt_sub,
-            N_lcl,
         )
 
         q_lcl[i + 1] = q_lcl[i] + Δt_sub * rates.dq_lcl_dt
@@ -194,7 +190,6 @@ function integrate_bulk_microphysics_instantaneous_one_step(
         q_icl0,
         q_rai0,
         q_sno0,
-        N_lcl,
     )
 
     Lv_over_cp = TDI.TD.Parameters.LH_v0(tps) / TDI.TD.Parameters.cp_d(tps)

--- a/docs/src/plots/Microphysics1M_plots.jl
+++ b/docs/src/plots/Microphysics1M_plots.jl
@@ -68,16 +68,26 @@ T = 273.15
 fig = MK.Figure()
 ax = MK.Axis(fig[1, 1]; xlabel = "q_lcl or q_icl [g/kg]", ylabel = "autoconversion rate [1/s]", limits)
 mp_ss = CMP.Microphysics1MParams(FT;
-    options = CMP.Microphysics1MOptions(snow_autoconversion = CMP.SnowAutoconvWithSupersat()),
+    options = CMP.Microphysics1MOptions(snow_autoconversion = CMP.SnowAutoconversionWithSupersaturation()),
 )
 q_icl_to_q_sno_rate = function (T)
     map(q_icl_range) do q_icl
         micro = (; q_tot, q_lcl = FT(0), q_icl, q_rai, q_sno)
         thermo = (; ρ = ρ_air, T)
-        CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconvWithSupersat(), mp_ss, tps, micro, thermo)
+        CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconversionWithSupersaturation(), mp_ss, tps, micro, thermo)
     end
 end
-MK.lines!(q_lcl_range * 1e3, CM1.conv_q_lcl_to_q_rai.(rain.acnv1M, q_lcl_range), label = "Rain")
+MK.lines!(
+    q_lcl_range * 1e3,
+    [
+        CM1.conv_q_lcl_to_q_rai(
+            CMP.RainAutoconversion1M(), mp, tps,
+            (; q_tot, q_lcl = q, q_icl, q_rai, q_sno),
+            (; ρ = ρ_air, T),
+        ) for q in q_lcl_range
+    ],
+    label = "Rain",
+)
 MK.lines!(q_icl_range * 1e3, q_icl_to_q_sno_rate(T - 5), label = "Snow T = −5°C")
 MK.lines!(q_icl_range * 1e3, q_icl_to_q_sno_rate(T - 10), label = "Snow T = −10°C")
 MK.lines!(q_icl_range * 1e3, q_icl_to_q_sno_rate(T - 15), label = "Snow T = −15°C")
@@ -88,19 +98,45 @@ MK.save("autoconversion_rate.svg", fig) # hide
 fig = MK.Figure()
 ax = MK.Axis(fig[1, 1]; xlabel = "q_rain or q_snow [g/kg]", ylabel = "accretion rate [1/s]", limits)
 MK.lines!(
-    q_rain_range * 1e3, CM1.accretion.(liquid, rain, Blk1MVel.rain, ce, q_lcl, q_rain_range, ρ_air),
+    q_rain_range * 1e3,
+    [
+        CM1.accretion(
+            CMP.CloudLiquidRainAccretion(), mp, tps,
+            (; q_tot, q_lcl, q_icl, q_rai = q_rai_val, q_sno),
+            (; ρ = ρ_air, T),
+        ) for q_rai_val in q_rain_range
+    ],
     label = "Liq+Rain-CliMA",
 )
 MK.lines!(
-    q_rain_range * 1e3, CM1.accretion.(ice, rain, Blk1MVel.rain, ce, q_icl, q_rain_range, ρ_air),
+    q_rain_range * 1e3,
+    [
+        CM1.accretion(
+            CMP.CloudIceRainAccretion(), mp, tps,
+            (; q_tot, q_lcl, q_icl, q_rai = q_rai_val, q_sno),
+            (; ρ = ρ_air, T),
+        ) for q_rai_val in q_rain_range
+    ],
     label = "Ice+Rain-CliMA",
 )
 MK.lines!(
-    q_snow_range * 1e3, CM1.accretion.(liquid, snow, Blk1MVel.snow, ce, q_lcl, q_snow_range, ρ_air),
+    q_snow_range * 1e3,
+    [
+        CM1.accretion(CMP.CloudLiquidSnowAccretion(), mp, tps,
+            (; q_tot, q_lcl, q_icl, q_rai, q_sno = q_sno_val),
+            (; ρ = ρ_air, T),
+        ).S_accr for q_sno_val in q_snow_range
+    ],
     label = "Liq+Snow-CliMA",
 )
 MK.lines!(
-    q_snow_range * 1e3, CM1.accretion.(ice, snow, Blk1MVel.snow, ce, q_icl, q_snow_range, ρ_air),
+    q_snow_range * 1e3,
+    [
+        CM1.accretion(CMP.CloudIceSnowAccretion(), mp, tps,
+            (; q_tot, q_lcl, q_icl, q_rai, q_sno = q_sno_val),
+            (; ρ = ρ_air, T),
+        ) for q_sno_val in q_snow_range
+    ],
     label = "Ice+Snow-CliMA", linewidth = 4, linestyle = :dash,
 )
 MK.lines!(
@@ -113,32 +149,47 @@ MK.save("accretion_rate.svg", fig) # hide
 # accretion rain sink rate figure
 fig = MK.Figure()
 ax = MK.Axis(fig[1, 1]; xlabel = "q_rain or q_snow [g/kg]", ylabel = "accretion rain sink rate [1/s]", limits)
-_accr_rain_sink(q_icl) = CM1.accretion_rain_sink.(rain, ice, Blk1MVel.rain, ce, q_icl, q_rain_range, ρ_air) # hide
+_accr_rain_sink(q_icl_val) = [
+    CM1.accretion_rain_sink(
+        mp.precip.rain, mp.cloud.ice, mp.terminal_velocity.rain, mp.collision,
+        q_icl_val, q_rai_val, ρ_air,
+    ) for q_rai_val in q_rain_range
+] # hide
 MK.lines!(q_rain_range * 1e3, _accr_rain_sink(1e-6), label = "q_icl = 1e-6")
 MK.lines!(q_rain_range * 1e3, _accr_rain_sink(1e-5), label = "q_icl = 1e-5")
 MK.lines!(q_rain_range * 1e3, _accr_rain_sink(1e-4), label = "q_icl = 1e-4")
 MK.axislegend(ax; position = :lt)
 MK.save("accretion_rain_sink_rate.svg", fig) # hide
 
-# accretion snow-rain rate figure
+# accretion snow-rain rate figure (warm: snow → rain, warm arm)
 fig = MK.Figure()
 ax = MK.Axis(fig[1, 1]; xlabel = "q_rain [g/kg]", ylabel = "snow-rain accretion rate [1/s] T>0", limits)
-_accr_snow_rain(q_sno) =
-    CM1.accretion_snow_rain.(rain, snow, Blk1MVel.rain, Blk1MVel.snow, ce, q_rain_range, q_sno, ρ_air)
-MK.lines!(q_rain_range * 1e3, _accr_snow_rain(1e-6), label = "q_snow = 1e-6")
-MK.lines!(q_rain_range * 1e3, _accr_snow_rain(1e-5), label = "q_snow = 1e-5")
-MK.lines!(q_rain_range * 1e3, _accr_snow_rain(1e-4), label = "q_snow = 1e-4")
+_accr_snow_rain_warm(q_sno_val) = [
+    CM1.accretion_snow_rain(
+        CMP.RainSnowAccretion(), mp, tps,
+        (; q_tot, q_lcl, q_icl, q_rai = q_rai_val, q_sno = q_sno_val),
+        (; ρ = ρ_air, T),
+    ).S_sno_rai for q_rai_val in q_rain_range
+]
+MK.lines!(q_rain_range * 1e3, _accr_snow_rain_warm(1e-6), label = "q_snow = 1e-6")
+MK.lines!(q_rain_range * 1e3, _accr_snow_rain_warm(1e-5), label = "q_snow = 1e-5")
+MK.lines!(q_rain_range * 1e3, _accr_snow_rain_warm(1e-4), label = "q_snow = 1e-4")
 MK.axislegend(ax; position = :lt)
 MK.save("accretion_snow_rain_above_freeze.svg", fig) # hide
 
-# accretion snow-rain rate figure
+# accretion snow-rain rate figure (cold: rain → snow, cold arm)
 fig = MK.Figure()
 ax = MK.Axis(fig[1, 1]; xlabel = "q_snow [g/kg]", ylabel = "snow-rain accretion rate [1/s] T<0", limits)
-_accr_snow_rain2(q_sno) =
-    CM1.accretion_snow_rain.(snow, rain, Blk1MVel.snow, Blk1MVel.rain, ce, q_snow_range, q_sno, ρ_air)
-MK.lines!(q_snow_range * 1e3, _accr_snow_rain2(1e-6), label = "q_rain = 1e-6")
-MK.lines!(q_snow_range * 1e3, _accr_snow_rain2(1e-5), label = "q_rain = 1e-5")
-MK.lines!(q_snow_range * 1e3, _accr_snow_rain2(1e-4), label = "q_rain = 1e-4")
+_accr_snow_rain_cold(q_sno_val) = [
+    CM1.accretion_snow_rain(
+        CMP.RainSnowAccretion(), mp, tps,
+        (; q_tot, q_lcl, q_icl, q_rai, q_sno = q_sno_val),
+        (; ρ = ρ_air, T),
+    ).S_rai_sno for q_rai_val in q_snow_range
+]
+MK.lines!(q_snow_range * 1e3, _accr_snow_rain_cold(1e-6), label = "q_rain = 1e-6")
+MK.lines!(q_snow_range * 1e3, _accr_snow_rain_cold(1e-5), label = "q_rain = 1e-5")
+MK.lines!(q_snow_range * 1e3, _accr_snow_rain_cold(1e-4), label = "q_rain = 1e-4")
 MK.axislegend(ax; position = :lt)
 MK.save("accretion_snow_rain_below_freeze.svg", fig) # hide
 
@@ -163,7 +214,7 @@ MK.lines!(
     q_rain_range * 1e3,
     (
         q_rai -> CM1.conv_q_rai_to_q_vap(
-            CMP.EvaporationOnly(), mp, tps,
+            CMP.RainEvaporation(), mp, tps,
             (; q_tot, q_lcl = q_lcl - q_rai, q_icl, q_rai, q_sno),
             (; ρ, T),
         )
@@ -197,7 +248,7 @@ R = TDI.Rₘ(tps, q_tot, q_lcl + q_rai, q_icl)
 rate =
     (
         q_sno -> CM1.conv_q_sno_to_q_vap(
-            CMP.DepositionSublimation(), mp, tps,
+            CMP.SnowDepositionSublimation(), mp, tps,
             (; q_tot, q_lcl, q_icl = q_icl - q_sno, q_rai, q_sno),
             (; ρ, T),
         )
@@ -222,7 +273,7 @@ R = TDI.Rₘ(tps, q_tot, q_lcl + q_rai, q_icl)
 rate =
     (
         q_sno -> CM1.conv_q_sno_to_q_vap(
-            CMP.DepositionSublimation(), mp, tps,
+            CMP.SnowDepositionSublimation(), mp, tps,
             (; q_tot, q_lcl, q_icl = q_icl - q_sno, q_rai, q_sno),
             (; ρ, T),
         )

--- a/docs/src/plots/Microphysics2M_plots.jl
+++ b/docs/src/plots/Microphysics2M_plots.jl
@@ -18,6 +18,8 @@ const LD2004 = CMP.LD2004(FT)
 const VarTSc = CMP.VarTimescaleAcnv(FT)
 const SB2006 = CMP.SB2006(FT)
 
+const mp_1m = CMP.Microphysics1MParams(FT)
+
 const ce = CMP.CollisionEff(FT)
 
 const liquid = CMP.CloudLiquid(FT)
@@ -49,7 +51,7 @@ q_lcl_LD2004 = [
     CM2.conv_q_lcl_to_q_rai(LD2004, q_lcl, ρ_air, N_d) for q_lcl in q_lcl_range
 ]
 q_lcl_VarTimeScaleAcnv = [
-    CM2.conv_q_lcl_to_q_rai(VarTSc, q_lcl, ρ_air, N_d) for q_lcl in q_lcl_range
+    max(0, q_lcl) / (VarTSc.τ * (N_d / 100_000_000)^VarTSc.α) for q_lcl in q_lcl_range
 ]
 q_lcl_SB2006 = [
     CM2.autoconversion(
@@ -61,8 +63,13 @@ q_lcl_SB2006 = [
         N_d,
     ).dq_rai_dt for q_lcl in q_lcl_range
 ]
-q_lcl_K1969 =
-    [CM1.conv_q_lcl_to_q_rai(rain.acnv1M, q_lcl) for q_lcl in q_lcl_range]
+q_lcl_K1969 = [
+    CM1.conv_q_lcl_to_q_rai(
+        CMP.RainAutoconversion1M(), mp_1m, nothing,
+        (; q_tot = FT(0), q_lcl = q, q_icl = FT(0), q_rai = FT(0), q_sno = FT(0)),
+        nothing,
+    ) for q in q_lcl_range
+]
 
 N_d_KK2000 =
     [CM2.conv_q_lcl_to_q_rai(KK2000, q_lcl, ρ_air, N_d) for N_d in N_d_range]
@@ -72,8 +79,9 @@ N_d_TC1980 =
     [CM2.conv_q_lcl_to_q_rai(TC1980, q_lcl, ρ_air, N_d) for N_d in N_d_range]
 N_d_LD2004 =
     [CM2.conv_q_lcl_to_q_rai(LD2004, q_lcl, ρ_air, N_d) for N_d in N_d_range]
-N_d_VarTimeScaleAcnv =
-    [CM2.conv_q_lcl_to_q_rai(VarTSc, q_lcl, ρ_air, N_d) for N_d in N_d_range]
+N_d_VarTimeScaleAcnv = [
+    max(0, q_lcl) / (VarTSc.τ * (N_d / 100_000_000)^VarTSc.α) for N_d in N_d_range
+]
 N_d_SB2006 = [
     CM2.autoconversion(
         SB2006.acnv,

--- a/docs/src/plots/Thersholds_transitions.jl
+++ b/docs/src/plots/Thersholds_transitions.jl
@@ -5,6 +5,7 @@ import ClimaParams
 const PL = Plots
 const CM1 = CloudMicrophysics.Microphysics1M
 const CM2 = CloudMicrophysics.Microphysics2M
+const CO = CloudMicrophysics.Common
 const CP = ClimaParams
 const CMP = CloudMicrophysics.Parameters
 
@@ -39,11 +40,14 @@ N_d_range = range(1e7, stop = 1e9, length = 1000)
 ρ_air = 1.0 # kg m^-3
 N_d = 1e8
 
-q_lcl_K1969 =
-    [CM1.conv_q_lcl_to_q_rai(rain[1].acnv1M, q_lcl) for q_lcl in q_lcl_range]
+q_lcl_K1969 = [
+    max(0, q_lcl - rain[1].acnv1M.q_threshold) / rain[1].acnv1M.τ
+    for q_lcl in q_lcl_range
+]
 q_lcl_K1969_s = [
-    CM1.conv_q_lcl_to_q_rai(rain[1].acnv1M, q_lcl, true) for
-    q_lcl in q_lcl_range
+    CO.logistic_function_integral(q_lcl, rain[1].acnv1M.q_threshold, rain[1].acnv1M.k) /
+    rain[1].acnv1M.τ
+    for q_lcl in q_lcl_range
 ]
 
 q_lcl_TC1980 = [

--- a/src/BulkMicrophysicsTendencies.jl
+++ b/src/BulkMicrophysicsTendencies.jl
@@ -16,9 +16,8 @@ using CloudMicrophysics.BulkMicrophysicsTendencies
 
 # For 1-moment microphysics
 tendencies = bulk_microphysics_tendencies(
-    Microphysics1Moment(),
-    lcl, icl, rai, sno, ce, aps, vel,
-    tps, ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno
+    Microphysics1Moment(), mp, tps,
+    ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno
 )
 (; dq_lcl_dt, dq_icl_dt, dq_rai_dt, dq_sno_dt) = tendencies
 ```
@@ -79,22 +78,6 @@ struct Microphysics2Moment <: MicrophysicsScheme end
 
 # --- Helper Functions ---
 
-"""
-    warm_accretion_melt_factor(tps, sno, T)
-
-Ratio of sensible heat available from warm liquid water to latent heat required
-for melting: α = cv_l / L_f × (T - T_freeze).
-
-Returns 0 if T ≤ T_freeze.
-"""
-@inline function warm_accretion_melt_factor(tps, sno, T)
-    L_f = TDI.Lf(tps, T)
-    cv_l = TDI.cv_l(tps)
-    ΔT = T - sno.T_freeze
-    # Branchless: return 0 when cold
-    is_cold = (T <= sno.T_freeze)
-    return ifelse(is_cold, zero(T), cv_l / L_f * ΔT)
-end
 
 # --- 1-Moment Microphysics ---
 
@@ -114,14 +97,17 @@ This is a pure function of local thermodynamic state, suitable for:
 
 # Arguments
 - `mp`: NamedTuple of microphysics parameters with fields:
-  - `lcl`: CloudLiquid parameters
-  - `icl`: CloudIce parameters
-  - `rai`: Rain parameters
-  - `sno`: Snow parameters
-  - `ce`: CollisionEff parameters
-  - `aps`: AirProperties parameters
-  - `vel`: Blk1MVelType parameters
-  - `var`: VarTimescaleAcnv parameters (optional, for 2M autoconversion)
+  - `cloud.liquid`: CloudLiquid parameters
+  - `cloud.ice`: CloudIce parameters
+  - `precip.rain`: Rain parameters
+  - `precip.snow`: Snow parameters
+  - `collision`: CollisionEff parameters
+  - `air_properties`: AirProperties parameters
+  - `terminal_velocity`: Blk1MVelType parameters
+  - `autoconv_2M`: VarTimescaleAcnv or Nothing (built when `RainAutoconversionPrescribedNd` is selected;
+    includes the prescribed cloud droplet number concentration `Nc`)
+  - `options`: Microphysics1MOptions (selects parameterization variants, including
+    `rain_autoconversion` to choose between 1M Kessler or VarTimescale 2M)
 - `tps`: Thermodynamics parameters
 - `ρ`: Air density [kg/m³]
 - `T`: Temperature [K]
@@ -130,8 +116,6 @@ This is a pure function of local thermodynamic state, suitable for:
 - `q_icl`: Cloud ice specific content [kg/kg]
 - `q_rai`: Rain specific content [kg/kg]
 - `q_sno`: Snow specific content [kg/kg]
-- `N_lcl`: Cloud droplet number concentration [1/m³], optional, default=0
-  When N_lcl > 0, uses 2M autoconversion; otherwise uses 1M
 
 # Returns
 `NamedTuple` with fields:
@@ -146,10 +130,13 @@ This is a pure function of local thermodynamic state, suitable for:
 # Notes
 - This function does NOT apply timestep-dependent limiters to prevent negative concentrations.
   Limiters depend on timestep `dt` and should be applied by the caller after computing tendencies.
+- The cloud liquid autoconversion variant (1M Kessler vs. VarTimescale 2M) is selected
+  via `mp.options.rain_autoconversion`. When `RainAutoconversionPrescribedNd` is selected,
+  the prescribed droplet concentration `mp.autoconv_2M.Nc` is used automatically.
 """
 @inline function bulk_microphysics_tendencies(
     ::Microphysics1Moment, mp::CMP.Microphysics1MParams, tps,
-    ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno, N_lcl = zero(ρ),
+    ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno,
 )
     # Clamp negative inputs to zero (robustness against numerical errors)
     ρ = UT.clamp_to_nonneg(ρ)
@@ -160,13 +147,6 @@ This is a pure function of local thermodynamic state, suitable for:
     q_sno = UT.clamp_to_nonneg(q_sno)
 
     # Unpack microphysics parameter container
-    lcl = mp.cloud.liquid
-    icl = mp.cloud.ice
-    rai = mp.precip.rain
-    sno = mp.precip.snow
-    ce = mp.collision
-    aps = mp.air_properties
-    vel = mp.terminal_velocity
     opts = mp.options
 
     # Construct state tuples (reused across all process calls)
@@ -192,13 +172,7 @@ This is a pure function of local thermodynamic state, suitable for:
     # --- Autoconversion (cloud → precipitation) ---
 
     # Cloud liquid → rain
-    S_acnv_1M = CM1.conv_q_lcl_to_q_rai(rai.acnv1M, q_lcl, true)
-    S_acnv_lcl = if opts.cloud_liquid_autoconversion isa CMP.LiquidAutoconv2M
-        S_acnv_2M = CM2.conv_q_lcl_to_q_rai(mp.autoconv_2M, q_lcl, ρ, N_lcl)
-        ifelse(N_lcl > zero(N_lcl), S_acnv_2M, S_acnv_1M)
-    else
-        S_acnv_1M
-    end
+    S_acnv_lcl = CM1.conv_q_lcl_to_q_rai(opts.rain_autoconversion, mp, tps, micro, thermo)
     dq_lcl_dt -= S_acnv_lcl
     dq_rai_dt += S_acnv_lcl
 
@@ -209,70 +183,56 @@ This is a pure function of local thermodynamic state, suitable for:
 
     # --- Accretion (collisions between species) ---
 
+    is_warm = T >= mp.precip.snow.T_freeze
+
     # Cloud liquid + rain → rain
-    S_accr_lcl_rai = CM1.accretion(lcl, rai, vel.rain, ce, q_lcl, q_rai, ρ)
+    S_accr_lcl_rai = CM1.accretion(opts.cloud_liquid_rain_accretion, mp, tps, micro, thermo)
     dq_lcl_dt -= S_accr_lcl_rai
     dq_rai_dt += S_accr_lcl_rai
 
-    # Cloud liquid + snow → snow (riming, cold) or rain + snow melt (warm)
-    # Use branchless ifelse for GPU compatibility
-    S_accr_lcl_sno = CM1.accretion(lcl, sno, vel.snow, ce, q_lcl, q_sno, ρ)
-    dq_lcl_dt -= S_accr_lcl_sno
+    # Cloud liquid + snow → snow (cold) or rain (warm) + thermal melt
+    (; S_accr, S_melt) = CM1.accretion(opts.cloud_liquid_snow_accretion, mp, tps, micro, thermo)
+    dq_lcl_dt -= S_accr
+    dq_sno_dt += ifelse(is_warm, zero(T), S_accr)
+    dq_rai_dt += ifelse(is_warm, S_accr, zero(T))
+    dq_sno_dt -= S_melt
+    dq_rai_dt += S_melt
 
-    is_warm = T >= sno.T_freeze
-    # Cold: riming → snow; Warm: shedding → rain
-    dq_sno_dt += ifelse(is_warm, zero(T), S_accr_lcl_sno)
-    dq_rai_dt += ifelse(is_warm, S_accr_lcl_sno, zero(T))
-    # Thermal melting (α=0 when cold, so these terms vanish)
-    # Physical consistency: melt is mass of snow melted, which is α * mass of warm liquid
-    α = warm_accretion_melt_factor(tps, sno, T)
-    S_accr_melt = α * S_accr_lcl_sno
-    dq_sno_dt -= S_accr_melt
-    dq_rai_dt += S_accr_melt
-
-    # Cloud ice + rain → snow
-    S_accr_icl_rai = CM1.accretion(icl, rai, vel.rain, ce, q_icl, q_rai, ρ)
+    # Cloud ice + rain → snow (ice-side sink); coupled rain-sink arm applied together
+    S_accr_icl_rai = CM1.accretion(opts.cloud_ice_rain_accretion, mp, tps, micro, thermo)
     dq_icl_dt -= S_accr_icl_rai
     dq_sno_dt += S_accr_icl_rai
 
-    # Cloud ice + snow → snow
-    S_accr_icl_sno = CM1.accretion(icl, sno, vel.snow, ce, q_icl, q_sno, ρ)
-    dq_icl_dt -= S_accr_icl_sno
-    dq_sno_dt += S_accr_icl_sno
-
-    # Rain + cloud ice → sink of rain (forms snow)
-    S_accr_rai_icl = CM1.accretion_rain_sink(rai, icl, vel.rain, ce, q_icl, q_rai, ρ)
+    # Rain + cloud ice → snow (rain sink): toggled by cloud_ice_rain_accretion
+    S_accr_rai_icl =
+        CM1.accretion_rain_sink(mp.precip.rain, mp.cloud.ice, mp.terminal_velocity.rain, mp.collision,
+            micro.q_icl, micro.q_rai, ρ) *
+        (opts.cloud_ice_rain_accretion isa CMP.CloudIceRainAccretion)
     dq_rai_dt -= S_accr_rai_icl
     dq_sno_dt += S_accr_rai_icl
 
-    # Rain + snow collisions (temperature dependent)
-    # Use branchless ifelse for GPU compatibility
-    # Cold: rain + snow → snow (rain freezes); Warm: snow + rain → rain (snow melts)
-    # Note: accretion_snow_rain arguments differ by case (collector vs collected swap)
-    S_accr_rai_sno = CM1.accretion_snow_rain(sno, rai, vel.snow, vel.rain, ce, q_sno, q_rai, ρ)
-    S_accr_sno_rai = CM1.accretion_snow_rain(rai, sno, vel.rain, vel.snow, ce, q_rai, q_sno, ρ)
+    # Cloud ice + snow → snow
+    S_accr_icl_sno = CM1.accretion(opts.cloud_ice_snow_accretion, mp, tps, micro, thermo)
+    dq_icl_dt -= S_accr_icl_sno
+    dq_sno_dt += S_accr_icl_sno
 
-    is_warm = T >= sno.T_freeze
-    # Cold pathway: rain → snow
-    dq_rai_dt -= ifelse(is_warm, zero(T), S_accr_rai_sno)
-    dq_sno_dt += ifelse(is_warm, zero(T), S_accr_rai_sno)
-    # Warm pathway: snow → rain
-    dq_sno_dt -= ifelse(is_warm, S_accr_sno_rai, zero(T))
-    dq_rai_dt += ifelse(is_warm, S_accr_sno_rai, zero(T))
-    # Thermal melting from warm rain (α=0 when cold)
-    # Physical consistency: melt is mass of snow melted, which is α * mass of warm rain
-    S_accr_melt = α * S_accr_rai_sno
-    dq_sno_dt -= ifelse(is_warm, S_accr_melt, zero(T))
-    dq_rai_dt += ifelse(is_warm, S_accr_melt, zero(T))
+    # Rain-snow collisions (temperature-dependent)
+    # Cold: rain → snow; Warm: snow → rain — combined per tendency variable
+    (; S_rai_sno, S_sno_rai, S_melt) = CM1.accretion_snow_rain(opts.rain_snow_accretion, mp, tps, micro, thermo)
+    dq_rai_dt += ifelse(is_warm, S_sno_rai, -S_rai_sno)
+    dq_sno_dt += ifelse(is_warm, -S_sno_rai, S_rai_sno)
+    # Thermal melting by warm rain (S_melt = α * S_rai_sno; α = 0 when cold)
+    dq_sno_dt -= ifelse(is_warm, S_melt, zero(T))
+    dq_rai_dt += ifelse(is_warm, S_melt, zero(T))
 
     # --- Evaporation and sublimation ---
 
     # Rain evaporation
-    S_evap_rai = CM1.conv_q_rai_to_q_vap(opts.rain_evaporation, mp, tps, micro, thermo)
+    S_evap_rai = CM1.conv_q_rai_to_q_vap(opts.rain_condensation_evaporation, mp, tps, micro, thermo)
     dq_rai_dt += S_evap_rai  # negative tendency (evaporation)
 
     # Snow sublimation (or sublimation + deposition, depending on option)
-    S_subl_sno = CM1.conv_q_sno_to_q_vap(opts.snow_sublimation, mp, tps, micro, thermo)
+    S_subl_sno = CM1.conv_q_sno_to_q_vap(opts.snow_deposition_sublimation, mp, tps, micro, thermo)
     dq_sno_dt += S_subl_sno
 
     # --- Melting ---
@@ -310,7 +270,7 @@ Returns a `NamedTuple` containing the nonzero entries of `M` and `e`.
 """
 @inline function _bulk_microphysics_linearized_operator(
     ::Microphysics1Moment, mp::CMP.Microphysics1MParams, tps,
-    ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno, N_lcl = zero(ρ),
+    ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno,
 )
     ρ = UT.clamp_to_nonneg(ρ)
     q_tot = UT.clamp_to_nonneg(q_tot)
@@ -319,13 +279,6 @@ Returns a `NamedTuple` containing the nonzero entries of `M` and `e`.
     q_rai = UT.clamp_to_nonneg(q_rai)
     q_sno = UT.clamp_to_nonneg(q_sno)
 
-    lcl = mp.cloud.liquid
-    icl = mp.cloud.ice
-    rai = mp.precip.rain
-    sno = mp.precip.snow
-    ce = mp.collision
-    aps = mp.air_properties
-    vel = mp.terminal_velocity
     opts = mp.options
 
     # Construct state tuples (reused across all process calls)
@@ -380,13 +333,7 @@ Returns a `NamedTuple` containing the nonzero entries of `M` and `e`.
     # ------------------------------------------------------------
     # Autoconversion: donor-based transfer
     # ------------------------------------------------------------
-    S_acnv_1M = CM1.conv_q_lcl_to_q_rai(rai.acnv1M, q_lcl, true)
-    S_acnv_lcl = if opts.cloud_liquid_autoconversion isa CMP.LiquidAutoconv2M
-        S_acnv_2M = CM2.conv_q_lcl_to_q_rai(mp.autoconv_2M, q_lcl, ρ, N_lcl)
-        ifelse(N_lcl > zero(N_lcl), S_acnv_2M, S_acnv_1M)
-    else
-        S_acnv_1M
-    end
+    S_acnv_lcl = CM1.conv_q_lcl_to_q_rai(opts.rain_autoconversion, mp, tps, micro, thermo)
     D = S_acnv_lcl / max(q_min, q_lcl)
     M11 -= D
     M31 += D
@@ -399,70 +346,70 @@ Returns a `NamedTuple` containing the nonzero entries of `M` and `e`.
     # ------------------------------------------------------------
     # Accretion: donor-based transfer
     # ------------------------------------------------------------
-    S_accr_lcl_rai = CM1.accretion(lcl, rai, vel.rain, ce, q_lcl, q_rai, ρ)
+    is_warm = T >= mp.precip.snow.T_freeze
+
+    S_accr_lcl_rai = CM1.accretion(opts.cloud_liquid_rain_accretion, mp, tps, micro, thermo)
     D = S_accr_lcl_rai / max(q_min, q_lcl)
     M11 -= D
     M31 += D
 
-    S_accr_lcl_sno = CM1.accretion(lcl, sno, vel.snow, ce, q_lcl, q_sno, ρ)
-    D = S_accr_lcl_sno / max(q_min, q_lcl)
+    (; S_accr, S_melt) = CM1.accretion(opts.cloud_liquid_snow_accretion, mp, tps, micro, thermo)
+    D = S_accr / max(q_min, q_lcl)
     M11 -= D
-    is_warm = T >= sno.T_freeze
     M31 += ifelse(is_warm, D, zero(FT))
     M41 += ifelse(is_warm, zero(FT), D)
 
-    α = warm_accretion_melt_factor(tps, sno, T)
-    S_accr_melt = α * S_accr_lcl_sno
-    # this is snow -> rain melt induced by warm collected liquid
-    # donor is snow
-    D = S_accr_melt / max(q_min, q_sno)
+    D = S_melt / max(q_min, q_sno)
     M44 -= D
     M34 += D
 
-    S_accr_icl_rai = CM1.accretion(icl, rai, vel.rain, ce, q_icl, q_rai, ρ)
+    S_accr_icl_rai = CM1.accretion(opts.cloud_ice_rain_accretion, mp, tps, micro, thermo)
     D = S_accr_icl_rai / max(q_min, q_icl)
     M22 -= D
     M42 += D
 
-    S_accr_icl_sno = CM1.accretion(icl, sno, vel.snow, ce, q_icl, q_sno, ρ)
+    S_accr_icl_sno = CM1.accretion(opts.cloud_ice_snow_accretion, mp, tps, micro, thermo)
     D = S_accr_icl_sno / max(q_min, q_icl)
     M22 -= D
     M42 += D
 
-    S_accr_rai_icl = CM1.accretion_rain_sink(rai, icl, vel.rain, ce, q_icl, q_rai, ρ)
+    # Rain sink arm: coupled to cloud_ice_rain_accretion
+    S_accr_rai_icl =
+        CM1.accretion_rain_sink(mp.precip.rain, mp.cloud.ice, mp.terminal_velocity.rain, mp.collision,
+            q_icl, q_rai, ρ) *
+        (opts.cloud_ice_rain_accretion isa CMP.CloudIceRainAccretion)
     D = S_accr_rai_icl / max(q_min, q_rai)
     M33 -= D
     M43 += D
 
-    S_accr_rai_sno = CM1.accretion_snow_rain(sno, rai, vel.snow, vel.rain, ce, q_sno, q_rai, ρ)
-    S_accr_sno_rai = CM1.accretion_snow_rain(rai, sno, vel.rain, vel.snow, ce, q_rai, q_sno, ρ)
+    (; S_rai_sno, S_sno_rai, S_melt) = CM1.accretion_snow_rain(opts.rain_snow_accretion, mp, tps, micro, thermo)
 
-    # snow -> rain
-    D = S_accr_sno_rai / max(q_min, q_sno)
+    # snow → rain (warm arm)
+    D = S_sno_rai / max(q_min, q_sno)
     M44 -= ifelse(is_warm, D, zero(FT))
     M34 += ifelse(is_warm, D, zero(FT))
 
-    S_accr_melt2 = α * S_accr_rai_sno
-    D = S_accr_melt2 / max(q_min, q_sno)
+    # thermal melt of snow by warm rain
+    D = S_melt / max(q_min, q_sno)
     M44 -= ifelse(is_warm, D, zero(FT))
     M34 += ifelse(is_warm, D, zero(FT))
 
-    # rain -> snow
-    D = S_accr_rai_sno / max(q_min, q_rai)
+    # rain → snow (cold arm)
+    D = S_rai_sno / max(q_min, q_rai)
     M33 -= ifelse(is_warm, zero(FT), D)
     M43 += ifelse(is_warm, zero(FT), D)
 
     # ------------------------------------------------------------
     # Rain evaporation: sink to vapor (always zero or negative)
     # ------------------------------------------------------------
-    S_evap_rai = CM1.conv_q_rai_to_q_vap(opts.rain_evaporation, mp, tps, micro, thermo)
+    S_evap_rai = CM1.conv_q_rai_to_q_vap(opts.rain_condensation_evaporation, mp, tps, micro, thermo)
     D = (-S_evap_rai) / max(q_min, q_rai)
     M33 -= D
 
     # ------------------------------------------------------------
     # Snow sublimation/deposition (generic: handles both options)
     # ------------------------------------------------------------
-    S_subl_sno = CM1.conv_q_sno_to_q_vap(opts.snow_sublimation, mp, tps, micro, thermo)
+    S_subl_sno = CM1.conv_q_sno_to_q_vap(opts.snow_deposition_sublimation, mp, tps, micro, thermo)
     D = S_subl_sno / max(q_min, q_sno)
     is_source = S_subl_sno >= zero(FT)
     e4 += ifelse(is_source, S_subl_sno, zero(FT))
@@ -503,14 +450,14 @@ exponential decays over the substep.
 """
 @inline function _average_bulk_microphysics_tendencies(
     ::Microphysics1Moment, mp::CMP.Microphysics1MParams, tps,
-    ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno, Δt, N_lcl = zero(ρ),
+    ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno, Δt,
 )
 
     FT = typeof(q_tot)
 
     lin = _bulk_microphysics_linearized_operator(
         Microphysics1Moment(), mp, tps,
-        ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno, N_lcl,
+        ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno,
     )
 
     invΔt = one(FT) / Δt
@@ -585,7 +532,6 @@ active microphysical processes, including regime changes near freezing.
     q_sno,
     Δt,
     nsub = 1,
-    N_lcl = zero(ρ),
 )
     FT = typeof(q_tot)
 
@@ -612,7 +558,6 @@ active microphysical processes, including regime changes near freezing.
             q_rai,
             q_sno,
             Δt_sub,
-            N_lcl,
         )
 
         q_lcl += rates.dq_lcl_dt * Δt_sub

--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -317,58 +317,78 @@ end
 end
 
 """
-    conv_q_lcl_to_q_rai(acnv::Acnv1M, q_lcl, smooth_transition)
+    conv_q_lcl_to_q_rai(::NoRainAutoconversion, mp, tps, micro, thermo)
+    conv_q_lcl_to_q_rai(::RainAutoconversion1M, mp, tps, micro, thermo)
+    conv_q_lcl_to_q_rai(::RainAutoconversionPrescribedNd, mp, tps, micro, thermo)
 
-Returns the rain tendency due to collisions between cloud droplets (autoconversion),
-parameterized following Kessler (1995), https://doi.org/10.1016/0169-8095(94)00090-Z.
+Returns the rain tendency due to autoconversion of cloud liquid, dispatching on
+the option stored in `Microphysics1MOptions`.
 
-When `smooth_transition = false`, uses a step function at the threshold.
-When `smooth_transition = true`, uses a logistic function to smooth the transition
-over the threshold, avoiding discontinuities in the tendency.
+**NoRainAutoconversion**: returns zero (autoconversion disabled).
+
+**RainAutoconversion1M**: Kessler (1995) 1-moment threshold autoconversion
+(smooth logistic transition), https://doi.org/10.1016/0169-8095(94)00090-Z.
+
+**RainAutoconversionPrescribedNd**: Variable-timescale autoconversion following Azimi (2023),
+using the prescribed cloud droplet number concentration `mp.autoconv_2M.Nc`.
 
 # Arguments
-- `acnv`: autoconversion parameters (contains `τ`, `q_threshold`, `k`)
-- `q_lcl`: cloud liquid water specific content [kg/kg]
-- `smooth_transition`: flag to switch on smoothing
+- `option`: `NoRainAutoconversion()`, `RainAutoconversion1M()`, or `RainAutoconversionPrescribedNd()`
+- `mp`: 1-moment microphysics parameters
+- `tps`: thermodynamics parameters (unused, kept for uniform interface)
+- `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
+- `thermo`: thermodynamic state `(; ρ, T)` (unused for 1M, kept for uniform interface)
 
 # Returns
 - Rain autoconversion rate [kg/kg/s]
 """
-@inline conv_q_lcl_to_q_rai(
-    (; τ, q_threshold, k)::CMP.Acnv1M{FT},
-    q_lcl::FT,
-    smooth_transition::Bool = false,
-) where {FT} =
-    smooth_transition ?
-    CO.logistic_function_integral(q_lcl, q_threshold, k) / τ :
-    max(0, q_lcl - q_threshold) / τ
+@inline conv_q_lcl_to_q_rai(::CMP.NoRainAutoconversion, mp, tps, micro, thermo) = zero(micro.q_lcl)
+
+@inline function conv_q_lcl_to_q_rai(::CMP.RainAutoconversion1M, mp, tps, micro, thermo)
+    q_lcl = micro.q_lcl
+    (; τ, q_threshold, k) = mp.precip.rain.acnv1M
+    return CO.logistic_function_integral(q_lcl, q_threshold, k) / τ
+end
+
+@inline function conv_q_lcl_to_q_rai(::CMP.RainAutoconversionPrescribedNd, mp, tps, micro, thermo)
+    q_lcl = micro.q_lcl
+    # Use the prescribed number concentration stored as a parameter
+    N_d = mp.autoconv_2M.Nc
+    (; τ, α) = mp.autoconv_2M
+    return max(0, q_lcl) / (τ * (N_d / 100_000_000)^α)
+end
 
 """
-    conv_q_icl_to_q_sno(::SnowAutoconvNoSupersat, mp, tps, micro, thermo)
-    conv_q_icl_to_q_sno(::SnowAutoconvWithSupersat, mp, tps, micro, thermo)
+    conv_q_icl_to_q_sno(::NoSnowAutoconversion, mp, tps, micro, thermo)
+    conv_q_icl_to_q_sno(::SnowAutoconversionNoSupersaturation, mp, tps, micro, thermo)
+    conv_q_icl_to_q_sno(::SnowAutoconversionWithSupersaturation, mp, tps, micro, thermo)
 
 Returns the snow tendency due to autoconversion from cloud ice.
 
-**SnowAutoconvNoSupersat**: Simplified Kessler-type threshold autoconversion,
+**NoSnowAutoconversion**: returns zero (snow autoconversion disabled).
+
+**SnowAutoconversionNoSupersaturation**: Simplified Kessler-type threshold autoconversion,
 for use in simulations without supersaturation (e.g., with saturation adjustment).
 
-**SnowAutoconvWithSupersat**: Supersaturation-dependent autoconversion following
+**SnowAutoconversionWithSupersaturation**: Supersaturation-dependent autoconversion following
 Harrington et al. (1995) and Kaul et al. (2015).
 
 # Arguments
-- `option`: `SnowAutoconvNoSupersat()` or `SnowAutoconvWithSupersat()`
+- `option`: `NoSnowAutoconversion()`, `SnowAutoconversionNoSupersaturation()`, or `SnowAutoconversionWithSupersaturation()`
 - `mp`: 1-moment microphysics parameters
 - `tps`: thermodynamics parameters
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
 - `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline function conv_q_icl_to_q_sno(::CMP.SnowAutoconvNoSupersat, mp, tps, micro, thermo)
+@inline conv_q_icl_to_q_sno(::CMP.NoSnowAutoconversion, mp, tps, micro, thermo) = zero(micro.q_icl)
+
+@inline function conv_q_icl_to_q_sno(::CMP.SnowAutoconversionNoSupersaturation, mp, tps, micro, thermo)
     (; τ, q_threshold, k) = mp.precip.snow.acnv1M
     q_icl = micro.q_icl
     return CO.logistic_function_integral(q_icl, q_threshold, k) / τ
 end
 
-@inline function conv_q_icl_to_q_sno(::CMP.SnowAutoconvWithSupersat, mp, tps, micro, thermo)
+@inline function conv_q_icl_to_q_sno(::CMP.SnowAutoconversionWithSupersaturation, mp, tps, micro, thermo)
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
     (; r_ice_snow, pdf, mass) = mp.cloud.ice
@@ -393,10 +413,34 @@ end
 end
 
 """
+    warm_accretion_melt_factor(tps, sno, T)
+
+Ratio of sensible heat from warm collected liquid to latent heat for melting:
+`α = cv_l / L_f × (T - T_freeze)`, returning 0 when `T ≤ T_freeze`.
+
+Used by `accretion(::CloudLiquidSnowAccretion, ...)` and
+`accretion_snow_rain(::RainSnowAccretion, ...)` to compute the thermal melt
+contribution of warm liquid on snow.
+"""
+@inline function warm_accretion_melt_factor(tps, sno, T)
+    L_f = TDI.Lf(tps, T)
+    cv_l = TDI.cv_l(tps)
+    ΔT = T - sno.T_freeze
+    is_cold = (T <= sno.T_freeze)
+    return ifelse(is_cold, zero(T), cv_l / L_f * ΔT)
+end
+
+"""
     accretion(cloud::CloudCondensateType, precip::PrecipitationType, vel, ce, q_clo, q_pre, ρ)
 
 Returns the source of precipitating water (rain or snow) due to collisions
 with cloud water (liquid or ice).
+
+!!! note "Internal use only"
+    This low-level positional-argument kernel is kept for internal dispatch.
+    Prefer the option-dispatched API:
+    `accretion(::CloudLiquidRainAccretion, mp, tps, micro, thermo)`,
+    `accretion(::CloudLiquidSnowAccretion, mp, tps, micro, thermo)`, etc.
 
 # Arguments
 - `cloud`: type for cloud water or cloud ice
@@ -438,21 +482,14 @@ with cloud water (liquid or ice).
     return accr_rate
 end
 
-"""
-    accretion_rain_sink(rain::Rain, ice::CloudIce, vel::Blk1MVelTypeRain, ce, q_icl, q_rai, ρ)
-
-Returns the sink of rain water (partial source of snow) due to collisions
-with cloud ice.
-
-# Arguments
-- `rain`: rain type parameters
-- `ice`: ice type parameters
-- `vel`: terminal velocity parameters for rain
-- `ce`: collision efficiency parameters
-- `q_icl`: cloud ice specific content
-- `q_rai`: rain water specific content
-- `ρ`: air density
-"""
+# accretion_rain_sink(rain, ice, vel, ce, q_icl, q_rai, ρ)
+#
+# Returns the sink of rain water (partial source of snow) due to collisions
+# with cloud ice.
+#
+# Internal use only: this low-level positional-argument kernel is kept for
+# internal dispatch. Prefer `accretion_rain_sink(::CloudIceRainAccretion,
+# mp, tps, micro, thermo)` (via BulkMicrophysicsTendencies).
 @inline function accretion_rain_sink(
     rain::CMP.Rain{FT},
     ice::CMP.CloudIce{FT},
@@ -496,6 +533,11 @@ Uses geometric collision kernel assumption: a(r_i, r_j) = π(r_i + r_j)², with
 a velocity dispersion correction that assumes that fall velocity standard 
 deviations are proportional to the mean fall velocities, with coefficient
 `ce.coeff_disp`.
+
+!!! note "Internal use only"
+    This low-level positional-argument kernel is kept for internal dispatch.
+    Prefer `accretion_snow_rain(::RainSnowAccretion, mp, tps, micro, thermo)`,
+    which calls both the cold and warm arms and returns `(; S_rai_sno, S_sno_rai, S_melt)`.
 
 # Arguments
 - `type_i`: snow (T < T_freeze) or rain (T > T_freeze)
@@ -552,21 +594,126 @@ deviations are proportional to the mean fall velocities, with coefficient
 end
 
 """
-    conv_q_rai_to_q_vap(::EvaporationOnly, mp, tps, micro, thermo)
+    accretion(::NoCloudLiquidRainAccretion, mp, tps, micro, thermo)
+    accretion(::CloudLiquidRainAccretion, mp, tps, micro, thermo)
+    accretion(::NoCloudLiquidSnowAccretion, mp, tps, micro, thermo)
+    accretion(::CloudLiquidSnowAccretion, mp, tps, micro, thermo)
+    accretion(::NoCloudIceRainAccretion, mp, tps, micro, thermo)
+    accretion(::CloudIceRainAccretion, mp, tps, micro, thermo)
+    accretion(::NoCloudIceSnowAccretion, mp, tps, micro, thermo)
+    accretion(::CloudIceSnowAccretion, mp, tps, micro, thermo)
+    accretion_snow_rain(::NoRainSnowAccretion, mp, tps, micro, thermo)
+    accretion_snow_rain(::RainSnowAccretion, mp, tps, micro, thermo)
 
+Option-dispatched accretion wrappers. All extract parameters from `mp` and
+delegate to the corresponding low-level Marshall-Palmer kernels.
+The `No*` variants return zero without computing anything.
+
+**`CloudLiquidRainAccretion`**: cloud liquid × rain → rain.  
+Returns a scalar rate [kg/kg/s].
+
+**`CloudLiquidSnowAccretion`**: cloud liquid × snow → snow (cold) or rain (warm).  
+Also computes the thermal melt contribution `α * S_accr` via
+`warm_accretion_melt_factor`.  
+Returns `(; S_accr, S_melt)` [kg/kg/s].
+
+**`CloudIceRainAccretion`**: cloud ice × rain → snow.  
+Also calls the coupled rain-sink kernel (rain + cloud ice → snow) internally;
+see `BulkMicrophysicsTendencies` for how both arms are applied.  
+Returns a scalar rate [kg/kg/s].
+
+**`CloudIceSnowAccretion`**: cloud ice × snow → snow.  
+Returns a scalar rate [kg/kg/s].
+
+**`RainSnowAccretion`**: both rain–snow collision arms plus thermal melt.  
+Cold arm: `S_rai_sno` (snow is collector, rain freezes → snow).  
+Warm arm: `S_sno_rai` (rain is collector, snow melts → rain).  
+Melt: `S_melt = α * S_rai_sno` (additional snow melt from warm rain).  
+Returns `(; S_rai_sno, S_sno_rai, S_melt)` [kg/kg/s].
+
+# Arguments
+- `option`: one of the option singletons above
+- `mp`: `Microphysics1MParams` (cloud, precip, collision, terminal_velocity, air_properties)
+- `tps`: thermodynamics parameters (used for `warm_accretion_melt_factor`)
+- `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
+- `thermo`: thermodynamic state `(; ρ, T)`
+"""
+@inline accretion(::CMP.NoCloudLiquidRainAccretion, mp, tps, micro, thermo) = zero(thermo.T)
+
+@inline function accretion(::CMP.CloudLiquidRainAccretion, mp, tps, micro, thermo)
+    q_lcl = micro.q_lcl
+    q_rai = micro.q_rai
+    ρ = thermo.ρ
+    return accretion(mp.cloud.liquid, mp.precip.rain, mp.terminal_velocity.rain, mp.collision, q_lcl, q_rai, ρ)
+end
+
+@inline accretion(::CMP.NoCloudLiquidSnowAccretion, mp, tps, micro, thermo) =
+    (; S_accr = zero(thermo.T), S_melt = zero(thermo.T))
+
+@inline function accretion(::CMP.CloudLiquidSnowAccretion, mp, tps, micro, thermo)
+    q_lcl = micro.q_lcl
+    q_sno = micro.q_sno
+    ρ = thermo.ρ
+    T = thermo.T
+    S = accretion(mp.cloud.liquid, mp.precip.snow, mp.terminal_velocity.snow, mp.collision, q_lcl, q_sno, ρ)
+    α = warm_accretion_melt_factor(tps, mp.precip.snow, T)
+    return (; S_accr = S, S_melt = α * S)
+end
+
+@inline accretion(::CMP.NoCloudIceRainAccretion, mp, tps, micro, thermo) = zero(thermo.T)
+
+@inline function accretion(::CMP.CloudIceRainAccretion, mp, tps, micro, thermo)
+    q_icl = micro.q_icl
+    q_rai = micro.q_rai
+    ρ = thermo.ρ
+    return accretion(mp.cloud.ice, mp.precip.rain, mp.terminal_velocity.rain, mp.collision, q_icl, q_rai, ρ)
+end
+
+@inline accretion(::CMP.NoCloudIceSnowAccretion, mp, tps, micro, thermo) = zero(thermo.T)
+
+@inline function accretion(::CMP.CloudIceSnowAccretion, mp, tps, micro, thermo)
+    q_icl = micro.q_icl
+    q_sno = micro.q_sno
+    ρ = thermo.ρ
+    return accretion(mp.cloud.ice, mp.precip.snow, mp.terminal_velocity.snow, mp.collision, q_icl, q_sno, ρ)
+end
+
+@inline accretion_snow_rain(::CMP.NoRainSnowAccretion, mp, tps, micro, thermo) =
+    (; S_rai_sno = zero(thermo.T), S_sno_rai = zero(thermo.T), S_melt = zero(thermo.T))
+
+@inline function accretion_snow_rain(::CMP.RainSnowAccretion, mp, tps, micro, thermo)
+    q_rai = micro.q_rai
+    q_sno = micro.q_sno
+    ρ = thermo.ρ
+    T = thermo.T
+    vel = mp.terminal_velocity
+    ce = mp.collision
+    sno = mp.precip.snow
+    rai = mp.precip.rain
+    # cold arm: snow is collector, rain freezes → snow
+    S_rai_sno = accretion_snow_rain(sno, rai, vel.snow, vel.rain, ce, q_sno, q_rai, ρ)
+    # warm arm: rain is collector, snow melts → rain
+    S_sno_rai = accretion_snow_rain(rai, sno, vel.rain, vel.snow, ce, q_rai, q_sno, ρ)
+    α = warm_accretion_melt_factor(tps, sno, T)
+    return (; S_rai_sno, S_sno_rai, S_melt = α * S_rai_sno)
+end
+
+"""
 Returns the tendency due to rain evaporation.
 Ventilation factor parameterization follows Seifert and Beheng (2006).
 
 Only evaporation is considered (sub-saturated over liquid); result is clamped ≤ 0.
 
 # Arguments
-- `option`: `EvaporationOnly()`
+- `option`: `NoRainCondensationEvaporation()` or `RainEvaporation()`
 - `mp`: 1-moment microphysics parameters
 - `tps`: thermodynamics parameters
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
 - `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline function conv_q_rai_to_q_vap(::CMP.EvaporationOnly, mp, tps, micro, thermo)
+@inline conv_q_rai_to_q_vap(::CMP.NoRainCondensationEvaporation, mp, tps, micro, thermo) = zero(thermo.T)
+
+@inline function conv_q_rai_to_q_vap(::CMP.RainEvaporation, mp, tps, micro, thermo)
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
     (; pdf, mass, vent) = mp.precip.rain
@@ -606,30 +753,35 @@ Only evaporation is considered (sub-saturated over liquid); result is clamped �
 end
 
 """
-    conv_q_sno_to_q_vap(::SublimationOnly, mp, tps, micro, thermo)
-    conv_q_sno_to_q_vap(::DepositionSublimation, mp, tps, micro, thermo)
+    conv_q_sno_to_q_vap(::NoSnowDepositionSublimation, mp, tps, micro, thermo)
+    conv_q_sno_to_q_vap(::SnowSublimation, mp, tps, micro, thermo)
+    conv_q_sno_to_q_vap(::SnowDepositionSublimation, mp, tps, micro, thermo)
 
 Returns the tendency due to snow sublimation or sublimation+deposition.
 Ventilation factor parameterization follows Seifert and Beheng (2006).
 
-**SublimationOnly**: only sublimation (S < 0 over ice) is computed;
+**NoSnowDepositionSublimation**: returns zero (process disabled).
+
+**SnowSublimation**: only sublimation (S < 0 over ice) is computed;
 deposition is handled separately by non-equilibrium relaxation.
 
-**DepositionSublimation**: both sublimation and deposition are computed
+**SnowDepositionSublimation**: both sublimation and deposition are computed
 in the Marshall-Palmer integral.
 
 # Arguments
-- `option`: `SublimationOnly()` or `DepositionSublimation()`
+- `option`: `NoSnowDepositionSublimation()`, `SnowSublimation()`, or `SnowDepositionSublimation()`
 - `mp`: 1-moment microphysics parameters
 - `tps`: thermodynamics parameters
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
 - `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline function conv_q_sno_to_q_vap(::CMP.SublimationOnly, mp, tps, micro, thermo)
+@inline conv_q_sno_to_q_vap(::CMP.NoSnowDepositionSublimation, mp, tps, micro, thermo) = zero(thermo.T)
+
+@inline function conv_q_sno_to_q_vap(::CMP.SnowSublimation, mp, tps, micro, thermo)
     return min(0, _snow_subl_dep_rate(mp, tps, micro, thermo))
 end
 
-@inline function conv_q_sno_to_q_vap(::CMP.DepositionSublimation, mp, tps, micro, thermo)
+@inline function conv_q_sno_to_q_vap(::CMP.SnowDepositionSublimation, mp, tps, micro, thermo)
     return _snow_subl_dep_rate(mp, tps, micro, thermo)
 end
 
@@ -673,17 +825,17 @@ end
 
 """
     conv_q_icl_to_q_lcl(::NoCloudIceMelt, mp, tps, micro, thermo)
-    conv_q_icl_to_q_lcl(::CloudIceMeltToLiquid, mp, tps, micro, thermo)
+    conv_q_icl_to_q_lcl(::CloudIceMelt, mp, tps, micro, thermo)
 
 Returns the tendency due to cloud ice melt.
 
 **NoCloudIceMelt**: returns zero (cloud ice melt disabled).
 
-**CloudIceMeltToLiquid**: melts cloud ice to cloud liquid above freezing,
+**CloudIceMelt**: melts cloud ice to cloud liquid above freezing,
 parameterized as diffusional growth of ice crystals.
 
 # Arguments
-- `option`: `NoCloudIceMelt()` or `CloudIceMeltToLiquid()`
+- `option`: `NoCloudIceMelt()` or `CloudIceMelt()`
 - `mp`: 1-moment microphysics parameters
 - `tps`: thermodynamics parameters
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
@@ -691,7 +843,7 @@ parameterized as diffusional growth of ice crystals.
 """
 @inline conv_q_icl_to_q_lcl(::CMP.NoCloudIceMelt, mp, tps, micro, thermo) = zero(thermo.T)
 
-@inline function conv_q_icl_to_q_lcl(::CMP.CloudIceMeltToLiquid, mp, tps, micro, thermo)
+@inline function conv_q_icl_to_q_lcl(::CMP.CloudIceMelt, mp, tps, micro, thermo)
     q_icl = micro.q_icl
     (; ρ, T) = thermo
     (; pdf, mass) = mp.cloud.ice
@@ -710,17 +862,24 @@ parameterized as diffusional growth of ice crystals.
 end
 
 """
+    conv_q_sno_to_q_rai(::NoSnowMelt, mp, tps, micro, thermo)
     conv_q_sno_to_q_rai(::SnowMelt, mp, tps, micro, thermo)
 
 Returns the tendency due to snow melt.
 
+**NoSnowMelt**: returns zero (snow melt disabled).
+
+**SnowMelt**: melts snow to rain above freezing.
+
 # Arguments
-- `option`: `SnowMelt()`
+- `option`: `NoSnowMelt()` or `SnowMelt()`
 - `mp`: 1-moment microphysics parameters
 - `tps`: thermodynamics parameters
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
 - `thermo`: thermodynamic state `(; ρ, T)`
 """
+@inline conv_q_sno_to_q_rai(::CMP.NoSnowMelt, mp, tps, micro, thermo) = zero(thermo.T)
+
 @inline function conv_q_sno_to_q_rai(::CMP.SnowMelt, mp, tps, micro, thermo)
     q_sno = micro.q_sno
     (; ρ, T) = thermo

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -952,9 +952,6 @@ function conv_q_lcl_to_q_rai(
         return E * (q_lcl * ρ)^3 / N_d / ρ * output
     end
 end
-conv_q_lcl_to_q_rai((; τ, α)::CMP.VarTimescaleAcnv, q_lcl, ρ, N_d) =
-    max(0, q_lcl) / (τ * (N_d / 100_000_000)^α)
-
 """
     accretion(accretion_scheme, q_lcl, q_rai, ρ)
 

--- a/src/parameters/Microphysics1M.jl
+++ b/src/parameters/Microphysics1M.jl
@@ -1,4 +1,4 @@
-export CloudLiquid, CloudIce, Rain, Snow, CollisionEff
+export CloudLiquid, CloudIce, Rain, Snow, CollisionEff, VarTimescaleAcnv
 
 """
     ParticlePDFSnow{FT}
@@ -423,4 +423,33 @@ function CollisionEff(td::CP.ParamDict)
     )
     parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
     return CollisionEff(; parameters...)
+end
+
+"""
+    VarTimescaleAcnv{FT}
+
+Parameters for the variable-timescale rain autoconversion scheme used in the 1-moment
+microphysics scheme, following Azimi et al. (2023).
+Active when `RainAutoconversionPrescribedNd` is selected in `Microphysics1MOptions`.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+@kwdef struct VarTimescaleAcnv{FT} <: Precipitation2MType
+    "Autoconversion timescale [s]"
+    τ::FT
+    "Powerlaw coefficient relating timescale to droplet number [-]"
+    α::FT
+    "Prescribed cloud droplet number concentration [1/m³]"
+    Nc::FT
+end
+
+function VarTimescaleAcnv(td::CP.ParamDict)
+    name_map = (;
+        :rain_autoconversion_timescale => :τ,
+        :Variable_time_scale_autoconversion_coeff_alpha => :α,
+        :prescribed_cloud_droplet_number_concentration => :Nc,
+    )
+    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    return VarTimescaleAcnv(; parameters...)
 end

--- a/src/parameters/Microphysics1MOptions.jl
+++ b/src/parameters/Microphysics1MOptions.jl
@@ -1,18 +1,35 @@
 export Microphysics1MOptions,
     MicrophysicsOption,
+    NoCloudLiquidFormation,
     ConstantTimescaleCloudLiquidFormation,
+    NoCloudIceFormation,
     ConstantTimescaleCloudIceFormation,
     TemperatureDependentCloudIceFormation,
     NoCloudIceMelt,
-    CloudIceMeltToLiquid,
-    LiquidAutoconv1M,
-    LiquidAutoconv2M,
-    SnowAutoconvNoSupersat,
-    SnowAutoconvWithSupersat,
-    EvaporationOnly,
-    SublimationOnly,
-    DepositionSublimation,
-    SnowMelt
+    CloudIceMelt,
+    NoRainAutoconversion,
+    RainAutoconversion1M,
+    RainAutoconversionPrescribedNd,
+    NoSnowAutoconversion,
+    SnowAutoconversionNoSupersaturation,
+    SnowAutoconversionWithSupersaturation,
+    NoRainCondensationEvaporation,
+    RainEvaporation,
+    NoSnowDepositionSublimation,
+    SnowSublimation,
+    SnowDepositionSublimation,
+    NoSnowMelt,
+    SnowMelt,
+    NoCloudLiquidRainAccretion,
+    CloudLiquidRainAccretion,
+    NoCloudLiquidSnowAccretion,
+    CloudLiquidSnowAccretion,
+    NoCloudIceRainAccretion,
+    CloudIceRainAccretion,
+    NoCloudIceSnowAccretion,
+    CloudIceSnowAccretion,
+    NoRainSnowAccretion,
+    RainSnowAccretion
 """
     MicrophysicsOption
 
@@ -20,8 +37,14 @@ Abstract type for all microphysics process options.
 """
 abstract type MicrophysicsOption end
 
+"""No cloud liquid condensation/evaporation."""
+struct NoCloudLiquidFormation <: MicrophysicsOption end
+
 """Use a constant relaxation timescale for liquid condensation and evaporation."""
 struct ConstantTimescaleCloudLiquidFormation <: MicrophysicsOption end
+
+"""No cloud ice deposition/sublimation."""
+struct NoCloudIceFormation <: MicrophysicsOption end
 
 """Use a constant relaxation timescale for ice deposition and sublimation."""
 struct ConstantTimescaleCloudIceFormation <: MicrophysicsOption end
@@ -34,37 +57,85 @@ struct TemperatureDependentCloudIceFormation <: MicrophysicsOption end
 struct NoCloudIceMelt <: MicrophysicsOption end
 
 """Cloud ice melts to cloud liquid above freezing."""
-struct CloudIceMeltToLiquid <: MicrophysicsOption end
+struct CloudIceMelt <: MicrophysicsOption end
 
-"""1-moment Kessler autoconversion only."""
-struct LiquidAutoconv1M <: MicrophysicsOption end
+"""No rain autoconversion."""
+struct NoRainAutoconversion <: MicrophysicsOption end
+
+"""1-moment Kessler autoconversion of cloud liquid to rain."""
+struct RainAutoconversion1M <: MicrophysicsOption end
 
 """Variable-timescale 2-moment autoconversion (uses prescribed Nc)."""
-struct LiquidAutoconv2M <: MicrophysicsOption end
+struct RainAutoconversionPrescribedNd <: MicrophysicsOption end
+
+"""No snow autoconversion."""
+struct NoSnowAutoconversion <: MicrophysicsOption end
 
 """Simplified autoconversion without supersaturation dependence."""
-struct SnowAutoconvNoSupersat <: MicrophysicsOption end
+struct SnowAutoconversionNoSupersaturation <: MicrophysicsOption end
 
 """Harrington/Kaul autoconversion with supersaturation dependence."""
-struct SnowAutoconvWithSupersat <: MicrophysicsOption end
+struct SnowAutoconversionWithSupersaturation <: MicrophysicsOption end
 
-"""Evaporation only (sub-saturated conditions over liquid)."""
-struct EvaporationOnly <: MicrophysicsOption end
+"""No rain condensation/evaporation."""
+struct NoRainCondensationEvaporation <: MicrophysicsOption end
 
-"""Only sublimation (S < 0); deposition handled separately by non-equilibrium."""
-struct SublimationOnly <: MicrophysicsOption end
+"""Rain evaporation (sub-saturated conditions over liquid)."""
+struct RainEvaporation <: MicrophysicsOption end
+
+"""No snow deposition or sublimation."""
+struct NoSnowDepositionSublimation <: MicrophysicsOption end
+
+"""Only sublimation (S < 0 over ice); deposition handled separately by non-equilibrium."""
+struct SnowSublimation <: MicrophysicsOption end
 
 """Both sublimation (S < 0) and deposition (S > 0) in the Marshall-Palmer integral."""
-struct DepositionSublimation <: MicrophysicsOption end
+struct SnowDepositionSublimation <: MicrophysicsOption end
+
+"""No snow melting."""
+struct NoSnowMelt <: MicrophysicsOption end
 
 """Snow melts to rain above freezing."""
 struct SnowMelt <: MicrophysicsOption end
 
+"""No cloud liquid + rain accretion."""
+struct NoCloudLiquidRainAccretion <: MicrophysicsOption end
+
+"""Cloud liquid + rain → rain (Marshall-Palmer kernel).
+Also triggers the coupled rain-sink arm of cloud ice + rain collisions."""
+struct CloudLiquidRainAccretion <: MicrophysicsOption end
+
+"""No cloud liquid + snow accretion."""
+struct NoCloudLiquidSnowAccretion <: MicrophysicsOption end
+
+"""Cloud liquid + snow → snow/rain depending on temperature (includes warm-rain melt contribution)."""
+struct CloudLiquidSnowAccretion <: MicrophysicsOption end
+
+"""No cloud ice + rain accretion."""
+struct NoCloudIceRainAccretion <: MicrophysicsOption end
+
+"""Cloud ice + rain → snow (Marshall-Palmer kernel).
+The coupled rain-sink arm (rain + cloud ice → snow) is toggled automatically."""
+struct CloudIceRainAccretion <: MicrophysicsOption end
+
+"""No cloud ice + snow accretion."""
+struct NoCloudIceSnowAccretion <: MicrophysicsOption end
+
+"""Cloud ice + snow → snow (Marshall-Palmer kernel)."""
+struct CloudIceSnowAccretion <: MicrophysicsOption end
+
+"""No rain-snow collisions."""
+struct NoRainSnowAccretion <: MicrophysicsOption end
+
+"""Snow-rain collisions: both temperature pathways (cold: rai→sno, warm: sno→rai) plus thermal melt."""
+struct RainSnowAccretion <: MicrophysicsOption end
+
 """
-    Microphysics1MOptions{CLF, CIF, CIM, CLA, SA, RE, SS, SM}
+    Microphysics1MOptions{CLF, CIF, CIM, RA, SA, RCE, SDS, SM, CLRA, CLSA, CIRA, CISA, RSA}
 
 Process configuration for 1-moment microphysics.
 Each field selects a variant for one microphysical process.
+The `No*` variants disable a process entirely (return zero tendency).
 
 Defaults match the baseline (old main branch) behavior.
 
@@ -78,12 +149,16 @@ using CloudMicrophysics.Parameters as CMP
 # Default (baseline) options:
 opts = CMP.Microphysics1MOptions()
 
-# New branch options (INP-dependent ice, cloud ice melt, deposition+sublimation):
+# Disable all accretion, enable INP-dependent ice and cloud ice melt:
 opts = CMP.Microphysics1MOptions(
-    cloud_liquid_formation  = CMP.ConstantTimescaleCloudLiquidFormation(),
-    cloud_ice_formation     = CMP.TemperatureDependentCloudIceFormation(),
-    cloud_ice_melt          = CMP.CloudIceMeltToLiquid(),
-    snow_sublimation    = CMP.DepositionSublimation(),
+    cloud_ice_formation           = CMP.TemperatureDependentCloudIceFormation(),
+    cloud_ice_melt                = CMP.CloudIceMelt(),
+    cloud_liquid_rain_accretion   = CMP.NoCloudLiquidRainAccretion(),
+    cloud_liquid_snow_accretion   = CMP.NoCloudLiquidSnowAccretion(),
+    cloud_ice_rain_accretion      = CMP.NoCloudIceRainAccretion(),
+    cloud_ice_snow_accretion      = CMP.NoCloudIceSnowAccretion(),
+    rain_snow_accretion           = CMP.NoRainSnowAccretion(),
+    snow_deposition_sublimation   = CMP.SnowDepositionSublimation(),
 )
 ```
 """
@@ -91,26 +166,41 @@ opts = CMP.Microphysics1MOptions(
     CLF <: MicrophysicsOption,
     CIF <: MicrophysicsOption,
     CIM <: MicrophysicsOption,
-    CLA <: MicrophysicsOption,
+    RA <: MicrophysicsOption,
     SA <: MicrophysicsOption,
-    RE <: MicrophysicsOption,
-    SS <: MicrophysicsOption,
+    RCE <: MicrophysicsOption,
+    SDS <: MicrophysicsOption,
     SM <: MicrophysicsOption,
+    CLRA <: MicrophysicsOption,
+    CLSA <: MicrophysicsOption,
+    CIRA <: MicrophysicsOption,
+    CISA <: MicrophysicsOption,
+    RSA <: MicrophysicsOption,
 } <: ParametersType
     "cloud liquid formation timescale option"
     cloud_liquid_formation::CLF = ConstantTimescaleCloudLiquidFormation()
     "cloud ice formation timescale option"
     cloud_ice_formation::CIF = ConstantTimescaleCloudIceFormation()
     "cloud ice melting option"
-    cloud_ice_melt::CIM = CloudIceMeltToLiquid()
-    "cloud liquid autoconversion option"
-    cloud_liquid_autoconversion::CLA = LiquidAutoconv1M()
+    cloud_ice_melt::CIM = CloudIceMelt()
+    "rain autoconversion option"
+    rain_autoconversion::RA = RainAutoconversion1M()
     "cloud ice to snow autoconversion option"
-    snow_autoconversion::SA = SnowAutoconvNoSupersat()
-    "rain evaporation option"
-    rain_evaporation::RE = EvaporationOnly()
+    snow_autoconversion::SA = SnowAutoconversionNoSupersaturation()
+    "rain condensation/evaporation option"
+    rain_condensation_evaporation::RCE = RainEvaporation()
     "snow sublimation/deposition option"
-    snow_sublimation::SS = DepositionSublimation()
+    snow_deposition_sublimation::SDS = SnowDepositionSublimation()
     "snow melting option"
     snow_melt::SM = SnowMelt()
+    "cloud liquid + rain accretion option"
+    cloud_liquid_rain_accretion::CLRA = CloudLiquidRainAccretion()
+    "cloud liquid + snow accretion option"
+    cloud_liquid_snow_accretion::CLSA = CloudLiquidSnowAccretion()
+    "cloud ice + rain accretion option (also toggles rain sink arm)"
+    cloud_ice_rain_accretion::CIRA = CloudIceRainAccretion()
+    "cloud ice + snow accretion option"
+    cloud_ice_snow_accretion::CISA = CloudIceSnowAccretion()
+    "rain-snow collisions option"
+    rain_snow_accretion::RSA = RainSnowAccretion()
 end

--- a/src/parameters/Microphysics1MParams.jl
+++ b/src/parameters/Microphysics1MParams.jl
@@ -35,7 +35,7 @@ Base.show(io::IO, mime::MIME"text/plain", x::PrecipPhaseParams1M) =
     ShowMethods.verbose_show_type_and_fields(io, mime, x)
 
 """
-    Microphysics1MParams{FT, OPT, CP, PP, CE, AP, VL, VA, FR}
+    Microphysics1MParams{OPT, CP, PP, CE, AP, VL, VA, FR}
 
 Unified parameter container for 1-moment bulk microphysics.
 
@@ -46,8 +46,7 @@ Unified parameter container for 1-moment bulk microphysics.
 - `collision::CE`: CollisionEff — collision efficiencies between species
 - `air_properties::AP`: AirProperties — air properties (diffusivities, thermal conductivity)
 - `terminal_velocity::VL`: Blk1MVelType — terminal velocity parameters for rain and snow
-- `autoconv_2M::VA`: VarTimescaleAcnv or Nothing — 2M autoconversion parameters (built when `LiquidAutoconv2M` is selected)
-- `prescribed_Nc::FT`: Prescribed cloud droplet number concentration [1/m³]
+- `autoconv_2M::VA`: VarTimescaleAcnv or Nothing — 2M autoconversion parameters including prescribed Nc (built when `RainAutoconversionPrescribedNd` is selected)
 - `frostenberg2023::FR`: Frostenberg 2023 INP parameters or Nothing (built when `INPDependentIceFormation` is selected)
 
 # Constructors
@@ -70,19 +69,19 @@ mp = CMP.Microphysics1MParams(Float64)
 mp = CMP.Microphysics1MParams(Float64;
     options = CMP.Microphysics1MOptions(
         cloud_ice_formation  = CMP.TemperatureDependentCloudIceFormation(),
-        cloud_ice_melt = CMP.CloudIceMeltToLiquid(),
+        cloud_ice_melt = CMP.CloudIceMelt(),
     ),
 )
 
 # Create with 2M autoconversion
 mp = CMP.Microphysics1MParams(Float64;
     options = CMP.Microphysics1MOptions(
-        cloud_liquid_autoconversion = CMP.LiquidAutoconv2M(),
+        rain_autoconversion = CMP.RainAutoconversionPrescribedNd(),
     ),
 )
 ```
 """
-@kwdef struct Microphysics1MParams{FT, OPT, CP, PP, CE, AP, VL, VA, FR} <: ParametersType
+@kwdef struct Microphysics1MParams{OPT, CP, PP, CE, AP, VL, VA, FR} <: ParametersType
     options::OPT
     cloud::CP
     precip::PP
@@ -90,7 +89,6 @@ mp = CMP.Microphysics1MParams(Float64;
     air_properties::AP
     terminal_velocity::VL
     autoconv_2M::VA
-    prescribed_Nc::FT
     frostenberg2023::FR
 end
 Base.show(io::IO, mime::MIME"text/plain", x::Microphysics1MParams) =
@@ -106,12 +104,10 @@ Create a `Microphysics1MParams` object from a ClimaParams TOML dictionary.
 - `options`: Process configuration (default: baseline behavior)
 """
 function Microphysics1MParams(toml_dict::CP.ParamDict; options = Microphysics1MOptions())
-    (; prescribed_cloud_droplet_number_concentration) = CP.get_parameter_values(
-        toml_dict, "prescribed_cloud_droplet_number_concentration", "CloudMicrophysics",
-    )
     # Conditional construction driven by options
-    autoconv_2M = options.cloud_liquid_autoconversion isa LiquidAutoconv2M ?
-                  VarTimescaleAcnv(toml_dict) : nothing
+    autoconv_2M =
+        options.rain_autoconversion isa RainAutoconversionPrescribedNd ?
+        VarTimescaleAcnv(toml_dict) : nothing
     frostenberg2023 =
         options.cloud_ice_formation isa TemperatureDependentCloudIceFormation ?
         Frostenberg2023(toml_dict) : nothing
@@ -135,8 +131,6 @@ function Microphysics1MParams(toml_dict::CP.ParamDict; options = Microphysics1MO
         terminal_velocity = Blk1MVelType(toml_dict),
         # Conditionally built parameters
         autoconv_2M,
-        # Prescribed cloud droplet number concentration
-        prescribed_Nc = prescribed_cloud_droplet_number_concentration,
         frostenberg2023,
     )
 end

--- a/src/parameters/Microphysics2M.jl
+++ b/src/parameters/Microphysics2M.jl
@@ -1,4 +1,4 @@
-export KK2000, B1994, TC1980, LD2004, VarTimescaleAcnv, SB2006
+export KK2000, B1994, TC1980, LD2004, SB2006
 
 """
     AcnvKK2000
@@ -275,31 +275,6 @@ function LD2004(td::CP.ParamDict)
     )
     parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
     return LD2004(; parameters...)
-end
-
-"""
-    VarTimescaleAcnv
-
-The type for 2-moment precipitation formation based on the
-1-moment parameterization with variable time scale Azimi et al (2023)
-
-# Fields
-$(DocStringExtensions.FIELDS)
-"""
-@kwdef struct VarTimescaleAcnv{FT} <: Precipitation2MType
-    "Timescale [s]"
-    τ::FT
-    "Powerlaw coefficient [-]"
-    α::FT
-end
-
-function VarTimescaleAcnv(td::CP.ParamDict)
-    name_map = (;
-        :rain_autoconversion_timescale => :τ,
-        :Variable_time_scale_autoconversion_coeff_alpha => :α,
-    )
-    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
-    return VarTimescaleAcnv(; parameters...)
 end
 
 """

--- a/test/bulk_tendencies_tests.jl
+++ b/test/bulk_tendencies_tests.jl
@@ -222,14 +222,49 @@ function test_bulk_microphysics_1m_tendencies(FT)
             ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno,
         )
 
-        # Compute autoconversion separately
-        S_acnv_lcl = CM1.conv_q_lcl_to_q_rai(rain.acnv1M, q_lcl, true)
+        # Compute autoconversion separately using the same option-dispatched function
+        micro_acnv = (; q_tot, q_lcl, q_icl, q_rai, q_sno)
+        thermo_acnv = (; ρ, T)
+        S_acnv_lcl = CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversion1M(), mp, tps, micro_acnv, thermo_acnv)
 
         # Rain tendency should be positive and include autoconversion
         @test tendencies.dq_rai_dt > FT(0)
         # Autoconversion should be a major component of rain formation
         # (in the absence of rain, there's no accretion, so it should be close)
         @test abs(tendencies.dq_rai_dt - S_acnv_lcl) / S_acnv_lcl < FT(0.1)
+    end
+
+    @testset "BulkMicrophysicsTendencies - Autoconversion component (PrescribedNd)" begin
+        # Same check as above but using the variable-timescale 2M autoconversion option
+        # (RainAutoconversionPrescribedNd), which uses mp.autoconv_2M.{τ,α,Nc}.
+        mp_2m = CMP.Microphysics1MParams(FT;
+            options = CMP.Microphysics1MOptions(
+                rain_autoconversion = CMP.RainAutoconversionPrescribedNd(),
+            ),
+        )
+
+        ρ = FT(1.2)
+        T = T_freeze + FT(10)  # warm, no ice processes
+        q_tot = FT(0.015)
+        q_lcl = FT(2e-3)
+        q_icl = FT(0)
+        q_rai = FT(0)
+        q_sno = FT(0)
+
+        tendencies_2m = BMT.bulk_microphysics_tendencies(
+            BMT.Microphysics1Moment(),
+            mp_2m, tps,
+            ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno,
+        )
+
+        # Compute autoconversion separately using the option-dispatched function
+        micro_acnv = (; q_tot, q_lcl, q_icl, q_rai, q_sno)
+        thermo_acnv = (; ρ, T)
+        S_acnv_2m = CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversionPrescribedNd(), mp_2m, tps, micro_acnv, thermo_acnv)
+
+        # Rain tendency should be positive and dominated by autoconversion
+        @test tendencies_2m.dq_rai_dt > FT(0)
+        @test abs(tendencies_2m.dq_rai_dt - S_acnv_2m) / S_acnv_2m < FT(0.1)
     end
 
     @testset "BulkMicrophysicsTendencies - Subsaturated evaporation" begin
@@ -557,7 +592,7 @@ function test_bulk_microphysics_1m_tendencies(FT)
         micro_s = (; q_tot, q_lcl, q_icl = FT(0), q_rai = FT(0), q_sno)
         thermo_s = (; ρ, T)
         S_melt = CM1.conv_q_sno_to_q_rai(CMP.SnowMelt(), mp, tps, micro_s, thermo_s)
-        S_subl = CM1.conv_q_sno_to_q_vap(CMP.DepositionSublimation(), mp, tps, micro_s, thermo_s)
+        S_subl = CM1.conv_q_sno_to_q_vap(CMP.SnowDepositionSublimation(), mp, tps, micro_s, thermo_s)
 
         # Calculate α
         T_frz = TDI.T_freeze(tps)

--- a/test/gpu_tests.jl
+++ b/test/gpu_tests.jl
@@ -133,9 +133,18 @@ end
     output[i] = (; ∂S_pr_qc0, ∂S_pr_qc0_ref, ∂S_pr_S0, ∂S_pr_S0_ref)
 end
 
-@kernel inbounds = true function test_1_moment_micro_acnv_kernel!(output, acnv1M, ql)
+@kernel inbounds = true function test_1_moment_micro_acnv_kernel!(mp, tps, output, ql)
     i = @index(Global, Linear)
-    output[i] = CM1.conv_q_lcl_to_q_rai(acnv1M, ql[i], false)
+    micro = (; q_tot = zero(ql[i]), q_lcl = ql[i], q_icl = zero(ql[i]), q_rai = zero(ql[i]), q_sno = zero(ql[i]))
+    thermo = (; ρ = zero(ql[i]), T = zero(ql[i]))
+    output[i] = CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversion1M(), mp, tps, micro, thermo)
+end
+
+@kernel inbounds = true function test_1_moment_micro_acnv2M_kernel!(mp, tps, output, ql)
+    i = @index(Global, Linear)
+    micro = (; q_tot = zero(ql[i]), q_lcl = ql[i], q_icl = zero(ql[i]), q_rai = zero(ql[i]), q_sno = zero(ql[i]))
+    thermo = (; ρ = zero(ql[i]), T = zero(ql[i]))
+    output[i] = CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversionPrescribedNd(), mp, tps, micro, thermo)
 end
 
 @kernel inbounds = true function test_1_moment_micro_accretion_kernel!(
@@ -156,6 +165,24 @@ end
     output[i] = (; liq_rai, ice_sno, liq_sno, ice_rai, rai_sink, sno_rai, rai_sno)
 end
 
+@kernel inbounds = true function test_1_moment_micro_accretion_opt_kernel!(
+    mp, tps, output, ρ, T, qi, qs, ql, qr,
+)
+    i = @index(Global, Linear)
+    micro = (; q_tot = zero(ρ[i]), q_lcl = ql[i], q_icl = qi[i], q_rai = qr[i], q_sno = qs[i])
+    thermo = (; ρ = ρ[i], T = T[i])
+    liq_rai = CM1.accretion(CMP.CloudLiquidRainAccretion(), mp, tps, micro, thermo)
+    liq_sno = CM1.accretion(CMP.CloudLiquidSnowAccretion(), mp, tps, micro, thermo).S_accr
+    ice_rai = CM1.accretion(CMP.CloudIceRainAccretion(), mp, tps, micro, thermo)
+    ice_sno = CM1.accretion(CMP.CloudIceSnowAccretion(), mp, tps, micro, thermo)
+    # rain-sink is now internal (coupled to CloudIceRainAccretion), so use low-level kernel directly
+    rai_sink = CM1.accretion_rain_sink(mp.precip.rain, mp.cloud.ice, mp.terminal_velocity.rain, mp.collision,
+        micro.q_icl, micro.q_rai, ρ[i])
+    r_sr = CM1.accretion_snow_rain(CMP.RainSnowAccretion(), mp, tps, micro, thermo)
+    output[i] = (; liq_rai, ice_sno, liq_sno, ice_rai, rai_sink,
+        sno_rai = r_sr.S_rai_sno, rai_sno = r_sr.S_sno_rai)
+end
+
 @kernel inbounds = true function test_1_moment_micro_snow_melt_kernel!(
     mp, tps, output, ρ, T, qs)
     i = @index(Global, Linear)
@@ -165,15 +192,14 @@ end
 end
 
 @kernel inbounds = true function test_2_moment_acnv_kernel!(
-    KK2000, B1994, TC1980, LD2004, VarTSc, output, ql, ρ, Nd,
+    KK2000, B1994, TC1980, LD2004, output, ql, ρ, Nd,
 )
     i = @index(Global, Linear)
-    S_VarTSc = CM2.conv_q_lcl_to_q_rai(VarTSc, ql[i], ρ[i], Nd[i])
     S_LD2004 = CM2.conv_q_lcl_to_q_rai(LD2004, ql[i], ρ[i], Nd[i])
     S_TC1980 = CM2.conv_q_lcl_to_q_rai(TC1980, ql[i], ρ[i], Nd[i])
     S_B1994 = CM2.conv_q_lcl_to_q_rai(B1994, ql[i], ρ[i], Nd[i])
     S_KK2000 = CM2.conv_q_lcl_to_q_rai(KK2000, ql[i], ρ[i], Nd[i])
-    output[i] = (; S_VarTSc, S_LD2004, S_TC1980, S_B1994, S_KK2000)
+    output[i] = (; S_LD2004, S_TC1980, S_B1994, S_KK2000)
 end
 
 @kernel inbounds = true function test_2_moment_accr_kernel!(
@@ -444,6 +470,11 @@ function test_gpu(FT)
     # Bulk microphysics parameters
     mp_0m = CMP.Microphysics0MParams(FT)
     mp_1m = CMP.Microphysics1MParams(FT)
+    mp_1m_2M = CMP.Microphysics1MParams(FT;
+        options = CMP.Microphysics1MOptions(
+            rain_autoconversion = CMP.RainAutoconversionPrescribedNd(),
+        ),
+    )
     mp_2m_warm = CMP.Microphysics2MParams(FT; with_ice = false)
     mp_2m_p3 = CMP.Microphysics2MParams(FT; with_ice = true)
 
@@ -572,13 +603,31 @@ function test_gpu(FT)
         ql = ArrayType([FT(1e-3), FT(5e-4)])
 
         kernel! = test_1_moment_micro_acnv_kernel!(backend, work_groups)
-        kernel!(output, rain.acnv1M, ql; ndrange)
+        kernel!(mp_1m, tps, output, ql; ndrange)
         out = Array(output)
 
         # Sanity checks for the GPU KernelAbstractions workflow
         # See https://github.com/CliMA/SurfaceFluxes.jl/issues/142
         TT.@test !any(isequal(out, FT(bad_value)))
-        TT.@test out == FT[5e-7, 0]
+        # Both inputs are above threshold so both should give positive autoconversion
+        TT.@test all(x -> x > 0, out)
+
+        # RainAutoconversionPrescribedNd: variable-timescale autoconversion
+        bad_value = -99999.99
+        (; output, ndrange) = setup_output(2, FT, bad_value)
+        ql = ArrayType([FT(2e-3), FT(0)])
+
+        kernel! = test_1_moment_micro_acnv2M_kernel!(backend, work_groups)
+        kernel!(mp_1m_2M, tps, output, ql; ndrange)
+        out = Array(output)
+
+        # Sanity checks
+        TT.@test !any(isequal(out, FT(bad_value)))
+        # q_lcl = 2e-3 → positive rate; q_lcl = 0 → zero rate
+        TT.@test out[1] > FT(0)
+        TT.@test out[2] == FT(0)
+        # Regression: q_lcl = 2e-3 with default autoconv_2M.Nc ≈ 1e8 → ≈ 2e-6
+        TT.@test out[1] ≈ FT(2e-6) rtol = 1e-3
 
         DT = @NamedTuple{
             liq_rai::FT, ice_sno::FT, liq_sno::FT, ice_rai::FT,
@@ -606,6 +655,27 @@ function test_gpu(FT)
         TT.@test out1.sno_rai ≈ FT(2.466313958248222e-4)
         TT.@test out1.rai_sno ≈ FT(6.830957197816771e-5)
 
+        # Option-dispatched wrappers must give identical values on GPU
+        DT_opt = @NamedTuple{
+            liq_rai::FT, ice_sno::FT, liq_sno::FT, ice_rai::FT,
+            rai_sink::FT, sno_rai::FT, rai_sno::FT,
+        }
+        (; output, ndrange) = setup_output(2, DT_opt)
+        T_arr = ArrayType([FT(290), FT(290)])
+
+        kernel_opt! = test_1_moment_micro_accretion_opt_kernel!(backend, work_groups)
+        kernel_opt!(mp_1m, tps, output, ρ, T_arr, qi, qs, ql, qr; ndrange)
+        out0_opt, out1_opt = Array(output)
+
+        TT.@test all(iszero, out0_opt)
+        TT.@test out1_opt.liq_rai ≈ FT(1.4150106417043544e-6)
+        TT.@test out1_opt.ice_sno ≈ FT(2.453070979562392e-7)
+        TT.@test out1_opt.liq_sno ≈ FT(2.453070979562392e-7)
+        TT.@test out1_opt.ice_rai ≈ FT(1.768763302130443e-6)
+        TT.@test out1_opt.rai_sink ≈ FT(3.590060148920767e-5)
+        TT.@test out1_opt.sno_rai ≈ FT(2.466313958248222e-4)
+        TT.@test out1_opt.rai_sno ≈ FT(6.830957197816771e-5)
+
         (; output, ndrange) = setup_output(3, FT)
 
         T_freeze = FT(273.15)
@@ -624,7 +694,7 @@ function test_gpu(FT)
     TT.@testset "2-moment microphysics kernels" begin
 
         TT.@testset "autoconversion" begin
-            DT = @NamedTuple{S_VarTSc::FT, S_LD2004::FT, S_TC1980::FT, S_B1994::FT, S_KK2000::FT}
+            DT = @NamedTuple{S_LD2004::FT, S_TC1980::FT, S_B1994::FT, S_KK2000::FT}
             (; output, ndrange) = setup_output(10, DT)
 
             ql = constant_data(FT(2e-3); ndrange)
@@ -632,12 +702,11 @@ function test_gpu(FT)
             Nd = constant_data(FT(1e8); ndrange)
 
             kernel! = test_2_moment_acnv_kernel!(backend, work_groups)
-            kernel!(KK2000, B1994, TC1980, LD2004, VarTSc, output, ql, ρ, Nd; ndrange)
+            kernel!(KK2000, B1994, TC1980, LD2004, output, ql, ρ, Nd; ndrange)
             out = Array(output)
 
             TT.@test allequal(out)
-            (; S_VarTSc, S_LD2004, S_TC1980, S_B1994, S_KK2000) = out[1]
-            TT.@test S_VarTSc ≈ FT(2e-6)
+            (; S_LD2004, S_TC1980, S_B1994, S_KK2000) = out[1]
             TT.@test S_LD2004 ≈ FT(1.6963072465911614e-6)
             TT.@test S_TC1980 ≈ FT(3.5482867084128596e-6)
             TT.@test S_B1994 ≈ FT(9.825462758968215e-7)

--- a/test/microphysics1M_tests.jl
+++ b/test/microphysics1M_tests.jl
@@ -169,7 +169,7 @@ function test_microphysics1M(FT)
         # Rain evaporates, rate should be negative
         micro = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
         thermo = (; ρ, T)
-        evap_rate = CM1.conv_q_rai_to_q_vap(CMP.EvaporationOnly(), mp, tps, micro, thermo)
+        evap_rate = CM1.conv_q_rai_to_q_vap(CMP.RainEvaporation(), mp, tps, micro, thermo)
         TT.@test evap_rate < 0
     end
 
@@ -193,7 +193,7 @@ function test_microphysics1M(FT)
         # Snow sublimation rate should be negative (losing mass)
         micro = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
         thermo = (; ρ, T)
-        subl_rate = CM1.conv_q_sno_to_q_vap(CMP.SublimationOnly(), mp, tps, micro, thermo)
+        subl_rate = CM1.conv_q_sno_to_q_vap(CMP.SnowSublimation(), mp, tps, micro, thermo)
         TT.@test subl_rate < 0
     end
 
@@ -202,19 +202,62 @@ function test_microphysics1M(FT)
         q_lcl_threshold = rain.acnv1M.q_threshold
         τ_acnv_rai = rain.acnv1M.τ
 
-        q_lcl_small = FT(0.5) * q_lcl_threshold
-        TT.@test CM1.conv_q_lcl_to_q_rai(rain.acnv1M, q_lcl_small) == FT(0)
+        micro_s = (; q_tot = FT(0), q_lcl = FT(0.5) * q_lcl_threshold,
+            q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
+        micro_b = (; q_tot = FT(0), q_lcl = FT(1.5) * q_lcl_threshold,
+            q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
+        thermo = (; ρ = FT(1), T = FT(280))
 
-        TT.@test CM1.conv_q_lcl_to_q_rai(rain.acnv1M, q_lcl_small, true) ≈
+        # Below threshold → near zero (smooth logistic)
+        TT.@test CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversion1M(), mp, tps, micro_s, thermo) ≈
                  FT(0.0) atol = 0.15 * q_lcl_threshold / τ_acnv_rai
 
-        q_lcl_big = FT(1.5) * q_lcl_threshold
-        TT.@test CM1.conv_q_lcl_to_q_rai(rain.acnv1M, q_lcl_big) ≈
-                 FT(0.5) * q_lcl_threshold / τ_acnv_rai
-
-        TT.@test CM1.conv_q_lcl_to_q_rai(rain.acnv1M, q_lcl_big, true) ≈
+        # Above threshold → ≈ 0.5 * q_threshold / τ (smooth logistic)
+        TT.@test CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversion1M(), mp, tps, micro_b, thermo) ≈
                  FT(0.5) * q_lcl_threshold / τ_acnv_rai atol =
             FT(0.15) * q_lcl_threshold / τ_acnv_rai
+
+    end
+
+    TT.@testset "RainAutoconversion2M" begin
+        # Variable-timescale autoconversion (RainAutoconversionPrescribedNd)
+        mp_2m = CMP.Microphysics1MParams(FT;
+            options = CMP.Microphysics1MOptions(
+                rain_autoconversion = CMP.RainAutoconversionPrescribedNd(),
+            ),
+        )
+        thermo = (; ρ = FT(1), T = FT(280))
+
+        # Zero cloud liquid → zero rate
+        micro_0 = (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
+        TT.@test CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversionPrescribedNd(), mp_2m, tps, micro_0, thermo) == FT(0)
+
+        # Negative cloud liquid → zero rate (max(0, q_lcl))
+        micro_neg = (; q_tot = FT(0), q_lcl = FT(-1e-4), q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
+        TT.@test CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversionPrescribedNd(), mp_2m, tps, micro_neg, thermo) == FT(0)
+
+        # Positive cloud liquid → positive rate
+        q_lcl = FT(2e-3)
+        N_d = mp_2m.autoconv_2M.Nc
+        (; τ, α) = mp_2m.autoconv_2M
+        micro = (; q_tot = FT(0), q_lcl, q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
+        rate = CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversionPrescribedNd(), mp_2m, tps, micro, thermo)
+        TT.@test rate > FT(0)
+        # Rate should match the formula: q_lcl / (τ * (N_d / 1e8)^α)
+        TT.@test rate ≈ q_lcl / (τ * (N_d / 100_000_000)^α)
+
+        # Higher N_d → slower autoconversion (more droplets → longer timescale)
+        # We test this via the formula directly: smaller N_d → larger rate
+        q_lcl_test = FT(1e-3)
+        N_d_low = FT(1e7)
+        N_d_high = FT(1e9)
+        rate_low_N = q_lcl_test / (τ * (N_d_low / 100_000_000)^α)
+        rate_high_N = q_lcl_test / (τ * (N_d_high / 100_000_000)^α)
+        TT.@test rate_low_N > rate_high_N
+
+        # Regression: keep result constant when code changes
+        # q_lcl = 2e-3, default autoconv_2M.Nc ~1e8
+        TT.@test rate ≈ FT(2e-6) rtol = 1e-3
 
     end
 
@@ -228,14 +271,14 @@ function test_microphysics1M(FT)
         micro_s = (; q_tot = FT(0), q_lcl = FT(0), q_icl = q_icl_small, q_rai = FT(0), q_sno = FT(0))
         thermo_s = (; ρ = FT(1), T = FT(250))
         TT.@test CM1.conv_q_icl_to_q_sno(
-            CMP.SnowAutoconvNoSupersat(), mp, tps, micro_s, thermo_s,
+            CMP.SnowAutoconversionNoSupersaturation(), mp, tps, micro_s, thermo_s,
         ) ≈ FT(0.0) atol = FT(0.15) * q_icl_threshold / τ_acnv_sno
 
         # Above threshold → positive rate
         q_icl_big = FT(1.5) * q_icl_threshold
         micro_b = (; q_tot = FT(0), q_lcl = FT(0), q_icl = q_icl_big, q_rai = FT(0), q_sno = FT(0))
         TT.@test CM1.conv_q_icl_to_q_sno(
-            CMP.SnowAutoconvNoSupersat(), mp, tps, micro_b, thermo_s,
+            CMP.SnowAutoconversionNoSupersaturation(), mp, tps, micro_b, thermo_s,
         ) ≈ FT(0.5) * q_icl_threshold / τ_acnv_sno atol =
             FT(0.15) * q_icl_threshold / τ_acnv_sno
 
@@ -248,9 +291,9 @@ function test_microphysics1M(FT)
         qₛ = FT(1e-4)
         T_freeze = TDI.TD.Parameters.T_freeze(tps)
 
-        # Use mp with SnowAutoconvWithSupersat
+        # Use mp with SnowAutoconversionWithSupersaturation
         mp_ss = CMP.Microphysics1MParams(FT;
-            options = CMP.Microphysics1MOptions(snow_autoconversion = CMP.SnowAutoconvWithSupersat()),
+            options = CMP.Microphysics1MOptions(snow_autoconversion = CMP.SnowAutoconversionWithSupersaturation()),
         )
 
         # above freezing temperatures -> no snow
@@ -261,7 +304,8 @@ function test_microphysics1M(FT)
         T = T_freeze + FT(30)
         micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
         thermo = (; ρ, T)
-        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconvWithSupersat(), mp_ss, tps, micro, thermo) == FT(0)
+        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconversionWithSupersaturation(), mp_ss, tps, micro, thermo) ==
+                 FT(0)
 
         # no cloud ice -> no snow
         qᵢ = FT(0)
@@ -269,7 +313,8 @@ function test_microphysics1M(FT)
         T = T_freeze - FT(30)
         micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
         thermo = (; ρ, T)
-        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconvWithSupersat(), mp_ss, tps, micro, thermo) == FT(0)
+        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconversionWithSupersaturation(), mp_ss, tps, micro, thermo) ==
+                 FT(0)
 
         # no supersaturation -> no snow
         T = T_freeze - FT(5)
@@ -278,7 +323,7 @@ function test_microphysics1M(FT)
         qₜ = q_sat_ice
         micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
         thermo = (; ρ, T)
-        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconvWithSupersat(), mp_ss, tps, micro, thermo) ≈ FT(0)
+        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconversionWithSupersaturation(), mp_ss, tps, micro, thermo) ≈ FT(0)
 
         # Regression test: keep result constant when code changes
         T = T_freeze - FT(10)
@@ -289,7 +334,7 @@ function test_microphysics1M(FT)
         ref = FT(2.5408135723057333e-9)
         micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
         thermo = (; ρ, T)
-        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconvWithSupersat(), mp_ss, tps, micro, thermo) ≈ ref
+        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconversionWithSupersaturation(), mp_ss, tps, micro, thermo) ≈ ref
     end
 
     TT.@testset "RainLiquidAccretion" begin
@@ -400,6 +445,77 @@ function test_microphysics1M(FT)
         ) ≈ FT(6.830957197816771e-5) # Includes velocity dispersion correction
     end
 
+    TT.@testset "AccretionOptionAPI" begin
+        # Verify that the option-dispatched wrappers return the same values
+        # as the internal low-level kernels (regression values from "Accretion" testset)
+        ρ = FT(1.2)
+        q_tot = FT(20e-3)
+        q_liq = FT(5e-4)
+        q_ice = FT(5e-4)
+        q_sno = FT(5e-4)
+        q_rai = FT(5e-4)
+        T_warm = snow.T_freeze + FT(5)   # above freezing
+        T_cold = snow.T_freeze - FT(5)   # below freezing
+
+        micro = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
+        thermo_warm = (; ρ, T = T_warm)
+        thermo_cold = (; ρ, T = T_cold)
+
+        # CloudLiquidRainAccretion: scalar, matches internal kernel
+        TT.@test CM1.accretion(CMP.CloudLiquidRainAccretion(), mp, tps, micro, thermo_warm) ≈
+                 FT(1.4150106417043544e-6)
+
+        # CloudIceRainAccretion: scalar, matches internal kernel
+        TT.@test CM1.accretion(CMP.CloudIceRainAccretion(), mp, tps, micro, thermo_warm) ≈
+                 FT(1.768763302130443e-6)
+
+        # CloudIceSnowAccretion: scalar, matches internal kernel
+        TT.@test CM1.accretion(CMP.CloudIceSnowAccretion(), mp, tps, micro, thermo_warm) ≈
+                 FT(2.453070979562392e-7)
+
+        # CloudLiquidSnowAccretion: NamedTuple (; S_accr, S_melt)
+        # S_accr matches the internal lcl×sno kernel; S_melt = α * S_accr (α > 0 warm)
+        (; S_accr, S_melt) = CM1.accretion(CMP.CloudLiquidSnowAccretion(), mp, tps, micro, thermo_warm)
+        TT.@test S_accr ≈ FT(2.453070979562392e-7)
+        TT.@test S_melt >= FT(0)      # α >= 0
+        TT.@test S_melt <= S_accr     # melt ≤ S_accr (α ≤ 1 for reasonable ΔT)
+
+        # Cold: melt should be zero (T < T_freeze → α = 0)
+        let r = CM1.accretion(CMP.CloudLiquidSnowAccretion(), mp, tps, micro, thermo_cold)
+            TT.@test r.S_accr ≈ FT(2.453070979562392e-7)
+            TT.@test r.S_melt == FT(0)
+        end
+
+        # RainSnowAccretion: NamedTuple (; S_rai_sno, S_sno_rai, S_melt)
+        # cold arm S_rai_sno matches internal (sno, rai) call
+        # warm arm S_sno_rai matches internal (rai, sno) call
+        let r = CM1.accretion_snow_rain(CMP.RainSnowAccretion(), mp, tps, micro, thermo_warm)
+            TT.@test r.S_rai_sno ≈ FT(2.466313958248222e-4)
+            TT.@test r.S_sno_rai ≈ FT(6.830957197816771e-5)
+            TT.@test r.S_melt >= FT(0)
+        end
+        # Cold: S_melt = 0 (α = 0 below freezing)
+        let r = CM1.accretion_snow_rain(CMP.RainSnowAccretion(), mp, tps, micro, thermo_cold)
+            TT.@test r.S_melt == FT(0)
+        end
+
+        # No* variants return zero
+        micro_zero = (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
+        TT.@test CM1.accretion(CMP.NoCloudLiquidRainAccretion(), mp, tps, micro_zero, thermo_warm) == FT(0)
+        TT.@test CM1.accretion(CMP.NoCloudIceRainAccretion(), mp, tps, micro_zero, thermo_warm) == FT(0)
+        TT.@test CM1.accretion(CMP.NoCloudIceSnowAccretion(), mp, tps, micro_zero, thermo_warm) == FT(0)
+        TT.@test CM1.accretion(CMP.NoCloudLiquidSnowAccretion(), mp, tps, micro_zero, thermo_warm).S_accr == FT(0)
+        TT.@test CM1.accretion_snow_rain(CMP.NoRainSnowAccretion(), mp, tps, micro_zero, thermo_warm).S_rai_sno == FT(0)
+        TT.@test CM1.accretion_snow_rain(CMP.NoRainSnowAccretion(), mp, tps, micro_zero, thermo_warm).S_sno_rai == FT(0)
+        # Active variants: zero inputs → zero rates
+        TT.@test CM1.accretion(CMP.CloudLiquidRainAccretion(), mp, tps, micro_zero, thermo_warm) == FT(0)
+        TT.@test CM1.accretion(CMP.CloudIceRainAccretion(), mp, tps, micro_zero, thermo_warm) == FT(0)
+        TT.@test CM1.accretion(CMP.CloudIceSnowAccretion(), mp, tps, micro_zero, thermo_warm) == FT(0)
+        TT.@test CM1.accretion(CMP.CloudLiquidSnowAccretion(), mp, tps, micro_zero, thermo_warm).S_accr == FT(0)
+        TT.@test CM1.accretion_snow_rain(CMP.RainSnowAccretion(), mp, tps, micro_zero, thermo_warm).S_rai_sno == FT(0)
+        TT.@test CM1.accretion_snow_rain(CMP.RainSnowAccretion(), mp, tps, micro_zero, thermo_warm).S_sno_rai == FT(0)
+    end
+
     TT.@testset "RainEvaporation" begin
 
         # eq. 5c in [Grabowski1996](@cite)
@@ -447,7 +563,7 @@ function test_microphysics1M(FT)
 
             micro = (; q_tot, q_lcl, q_icl = FT(0), q_rai, q_sno = FT(0))
             thermo = (; ρ, T)
-            tmp1 = CM1.conv_q_rai_to_q_vap(CMP.EvaporationOnly(), mp, tps, micro, thermo)
+            tmp1 = CM1.conv_q_rai_to_q_vap(CMP.RainEvaporation(), mp, tps, micro, thermo)
             tmp2 = rain_evap_empir(tps, q_rai, q_tot, q_lcl, FT(0), T, p, ρ)
 
             TT.@test tmp1 ≈ tmp2 atol = 1e-6
@@ -469,7 +585,7 @@ function test_microphysics1M(FT)
 
         micro = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
         thermo = (; ρ, T)
-        TT.@test CM1.conv_q_rai_to_q_vap(CMP.EvaporationOnly(), mp, tps, micro, thermo) ≈ FT(0)
+        TT.@test CM1.conv_q_rai_to_q_vap(CMP.RainEvaporation(), mp, tps, micro, thermo) ≈ FT(0)
 
     end
 
@@ -505,7 +621,7 @@ function test_microphysics1M(FT)
 
                 micro = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
                 thermo = (; ρ, T)
-                tmp1 = CM1.conv_q_sno_to_q_vap(CMP.SublimationOnly(), mp, tps, micro, thermo)
+                tmp1 = CM1.conv_q_sno_to_q_vap(CMP.SnowSublimation(), mp, tps, micro, thermo)
                 TT.@test tmp1 ≈ ref_val[cnt] rtol = 1e-2
             end
         end
@@ -543,7 +659,7 @@ function test_microphysics1M(FT)
 
                 micro = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
                 thermo = (; ρ, T)
-                tmp1 = CM1.conv_q_sno_to_q_vap(CMP.DepositionSublimation(), mp, tps, micro, thermo)
+                tmp1 = CM1.conv_q_sno_to_q_vap(CMP.SnowDepositionSublimation(), mp, tps, micro, thermo)
                 TT.@test tmp1 ≈ ref_val[cnt] rtol = 1e-2
             end
         end
@@ -589,34 +705,34 @@ function test_microphysics1M(FT)
         ρ = FT(1.2)
         q_icl = FT(1e-4)
         mp_melt = CMP.Microphysics1MParams(FT;
-            options = CMP.Microphysics1MOptions(cloud_ice_melt = CMP.CloudIceMeltToLiquid()),
+            options = CMP.Microphysics1MOptions(cloud_ice_melt = CMP.CloudIceMelt()),
         )
         micro = (; q_tot = FT(0), q_lcl = FT(0), q_icl, q_rai = FT(0), q_sno = FT(0))
         thermo = (; ρ, T)
-        melt_rate = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMeltToLiquid(), mp_melt, tps, micro, thermo)
+        melt_rate = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMelt(), mp_melt, tps, micro, thermo)
         TT.@test melt_rate > 0
 
         # no cloud ice → no melt
         micro_0 = (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
-        TT.@test CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMeltToLiquid(), mp_melt, tps, micro_0, thermo) ≈ FT(0)
+        TT.@test CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMelt(), mp_melt, tps, micro_0, thermo) ≈ FT(0)
 
         # T < T_freeze → no melt
         thermo_cold = (; ρ, T = T_freeze - FT(2))
-        TT.@test CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMeltToLiquid(), mp_melt, tps, micro, thermo_cold) ≈ FT(0)
+        TT.@test CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMelt(), mp_melt, tps, micro, thermo_cold) ≈ FT(0)
 
         # more ice → higher melt rate
         thermo_warm = (; ρ, T = T_freeze + FT(5))
         micro_s = (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(1e-5), q_rai = FT(0), q_sno = FT(0))
         micro_l = (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(1e-3), q_rai = FT(0), q_sno = FT(0))
-        rate_small = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMeltToLiquid(), mp_melt, tps, micro_s, thermo_warm)
-        rate_large = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMeltToLiquid(), mp_melt, tps, micro_l, thermo_warm)
+        rate_small = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMelt(), mp_melt, tps, micro_s, thermo_warm)
+        rate_large = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMelt(), mp_melt, tps, micro_l, thermo_warm)
         TT.@test rate_large > rate_small
 
         # warmer T → higher melt rate
         thermo_w = (; ρ, T = T_freeze + FT(10))
         thermo_c = (; ρ, T = T_freeze + FT(1))
-        rate_warm = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMeltToLiquid(), mp_melt, tps, micro, thermo_w)
-        rate_cool = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMeltToLiquid(), mp_melt, tps, micro, thermo_c)
+        rate_warm = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMelt(), mp_melt, tps, micro, thermo_w)
+        rate_cool = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMelt(), mp_melt, tps, micro, thermo_c)
         TT.@test rate_warm > rate_cool
 
         # NoCloudIceMelt returns zero

--- a/test/microphysics2M_tests.jl
+++ b/test/microphysics2M_tests.jl
@@ -51,13 +51,11 @@ function test_microphysics2M(FT)
         TT.@test CM2.accretion(KK2000, q_lcl, q_rai, ρ) != NaN
         TT.@test CM2.accretion(B1994, q_lcl, q_rai, ρ) != NaN
         TT.@test CM2.accretion(TC1980, q_lcl, q_rai) != NaN
-        TT.@test CM2.conv_q_lcl_to_q_rai(VarTSc, q_lcl, ρ, N_d) != NaN
 
         # output should be zero if either q_liq or q_rai are zero
         q_lcl = FT(0)
         q_rai = FT(1e-6)
 
-        TT.@test CM2.conv_q_lcl_to_q_rai(VarTSc, q_lcl, ρ, N_d) == FT(0)
         TT.@test CM2.conv_q_lcl_to_q_rai(KK2000, q_lcl, ρ, N_d) == FT(0)
         TT.@test CM2.conv_q_lcl_to_q_rai(B1994, q_lcl, ρ, N_d) == FT(0)
         TT.@test CM2.conv_q_lcl_to_q_rai(TC1980, q_lcl, ρ, N_d) == FT(0)
@@ -71,9 +69,6 @@ function test_microphysics2M(FT)
         TT.@test CM2.accretion(KK2000, q_lcl, q_rai, ρ) == FT(0)
         TT.@test CM2.accretion(B1994, q_lcl, q_rai, ρ) == FT(0)
         TT.@test CM2.accretion(TC1980, q_lcl, q_rai) == FT(0)
-
-        TT.@test CM2.conv_q_lcl_to_q_rai(VarTSc, q_lcl, ρ, N_d) >
-                 CM2.conv_q_lcl_to_q_rai(VarTSc, q_lcl, ρ, 10 * N_d)
 
         # far from threshold points, autoconversion with and without smooth transition should
         # be approximately equal

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -123,6 +123,14 @@ function benchmark_test(FT)
     wtr = CMP.WaterProperties(FT)
     tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
 
+    # 1-moment microphysics unified params (both liquid autoconversion flavours)
+    mp_1m = CMP.Microphysics1MParams(FT)
+    mp_1m_2M = CMP.Microphysics1MParams(FT;
+        options = CMP.Microphysics1MOptions(
+            rain_autoconversion = CMP.RainAutoconversionPrescribedNd(),
+        ),
+    )
+
     ρ_air = FT(1.2)
     T_air = FT(280)
     T_air_2 = FT(250)
@@ -235,7 +243,34 @@ function benchmark_test(FT)
     bench_press(FT, CM0.∂remove_precipitation_∂q_tot, (p0m, q_liq, q_ice), 12)
 
     @info "1-Moment Scheme"
+    micro_1m = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
+    thermo_1m = (; ρ = ρ_air, T = T_air)
+    bench_press(
+        FT, CM1.conv_q_lcl_to_q_rai,
+        (CMP.RainAutoconversion1M(), mp_1m, tps, micro_1m, thermo_1m),
+        500,
+    )
+    bench_press(
+        FT, CM1.conv_q_lcl_to_q_rai,
+        (CMP.RainAutoconversionPrescribedNd(), mp_1m_2M, tps, micro_1m, thermo_1m),
+        500,
+    )
     bench_press(FT, CM1.accretion, (liquid, rain, blk1mvel.rain, ce, q_liq, q_rai, ρ_air), 360)
+    bench_press(FT, CM1.accretion, (CMP.CloudLiquidRainAccretion(), mp_1m, tps, micro_1m, thermo_1m), 360)
+    bench_press(
+        @NamedTuple{S_accr::FT, S_melt::FT},
+        CM1.accretion,
+        (CMP.CloudLiquidSnowAccretion(), mp_1m, tps, micro_1m, thermo_1m),
+        360,
+    )
+    bench_press(FT, CM1.accretion, (CMP.CloudIceRainAccretion(), mp_1m, tps, micro_1m, thermo_1m), 360)
+    bench_press(FT, CM1.accretion, (CMP.CloudIceSnowAccretion(), mp_1m, tps, micro_1m, thermo_1m), 360)
+    bench_press(
+        @NamedTuple{S_rai_sno::FT, S_sno_rai::FT, S_melt::FT},
+        CM1.accretion_snow_rain,
+        (CMP.RainSnowAccretion(), mp_1m, tps, micro_1m, thermo_1m),
+        1200,
+    )
     bench_press(FT, CMD.radar_reflectivity_1M, (rain, q_rai, ρ_air), 300)
 
     @info "2-Moment Scheme"


### PR DESCRIPTION
# Refactor 1-moment microphysics process options

## Summary

This PR refactors how individual microphysical processes are enabled and disabled in the 1-moment scheme. Every process now has an explicit `No*` option that returns zero tendency, and each process is addressed individually via option dispatch. Accretion processes are added to the options struct for the first time. The `VarTimescaleAcnv` option has been moved from CM2 to CM1 module and its parameters are consolidated into the 1M parameter tree. All callers — bulk tendencies, tests, docs — are updated.

## Changes

### `src/parameters/Microphysics1MOptions.jl`

- Added `No*` option singletons for every process so each one can be individually disabled: `NoCloudLiquidFormation`, `NoCloudIceFormation`, `NoRainAutoconversion`, `NoSnowAutoconversion`, `NoRainCondensationEvaporation`, `NoSnowDepositionSublimation`, `NoSnowMelt`, and one for each accretion pair.
- Renamed options for clarity and consistency:
  - `CloudIceMeltToLiquid` → `CloudIceMelt`
  - `LiquidAutoconv1M` → `RainAutoconversion1M`
  - `LiquidAutoconv2M` → `RainAutoconversionPrescribedNd`
  - `SnowAutoconvNoSupersat/WithSupersat` → `SnowAutoconversionNoSupersaturation/WithSupersaturation`
  - `EvaporationOnly` → `RainEvaporation`
  - `SublimationOnly` → `SnowSublimation`
  - `DepositionSublimation` → `SnowDepositionSublimation`
  - Field `rain_evaporation` → `rain_condensation_evaporation`
  - Field `snow_sublimation` → `snow_deposition_sublimation`
  - Field `cloud_liquid_autoconversion` → `rain_autoconversion`
- Added accretion processes to `Microphysics1MOptions`: `CloudLiquidRainAccretion`, `CloudLiquidSnowAccretion`, `CloudIceRainAccretion`, `CloudIceSnowAccretion`, `RainSnowAccretion` (each with a corresponding `No*` variant).
- Removed `RainIceAccretion` (previously an undifferentiated accretion flag).

### `src/parameters/Microphysics1MParams.jl`

- Removed the top-level `prescribed_Nc` field; droplet number concentration is now stored inside `VarTimescaleAcnv.Nc`.
- Removed the `FT` type parameter from `Microphysics1MParams`.

### `src/parameters/Microphysics1M.jl`

- Added `VarTimescaleAcnv` export and definition (moved from `Microphysics2M.jl`). It now holds `τ`, `α`, and `Nc` as a single struct.

### `src/parameters/Microphysics2M.jl`

- Removed `VarTimescaleAcnv` struct, constructor, and export (moved to `Microphysics1M.jl`).

### `src/Microphysics1M.jl`

- Converted `conv_q_lcl_to_q_rai` from a direct `Acnv1M`-struct-based call to option dispatch: `conv_q_lcl_to_q_rai(::NoRainAutoconversion | ::RainAutoconversion1M | ::RainAutoconversionPrescribedNd, mp, tps, micro, thermo)`.
- Converted `accretion` wrappers to option dispatch for all four cloud-precip pairs (`CloudLiquidRainAccretion`, `CloudLiquidSnowAccretion`, `CloudIceRainAccretion`, `CloudIceSnowAccretion`).
- Added high-level `accretion_snow_rain(::NoRainSnowAccretion | ::RainSnowAccretion, mp, tps, micro, thermo)` that calls both the cold and warm collision arms and returns `(; S_rai_sno, S_sno_rai, S_melt)`.
- Removed the `accretion_rain_sink` public docstring (it is now an internal-only low-level kernel).

### `src/BulkMicrophysicsTendencies.jl`

- Updated the 1M tendency function to dispatch on all new accretion options from `Microphysics1MOptions`, passing the full `mp` struct through to each process wrapper.


