### PR TITLE
Address comments from previos PR

### DIFF
--- a/docs/src/guides/Parameters.jl
+++ b/docs/src/guides/Parameters.jl
@@ -30,7 +30,7 @@ nothing #hide
 # of the parameter we are changing. In a typical application, this step would be done
 # via the calibration algorithm searching for optimal parameters values.
 # We create a second struct with changed parameters based on the `override_dict.toml` file.
-const default = CMP.Rain(FT)
+const default_mp = CMP.Microphysics1MParams(FT)
 
 override_file = joinpath("override_dict.toml")
 open(override_file, "w") do io
@@ -40,7 +40,7 @@ open(override_file, "w") do io
 end
 toml_dict = CP.create_toml_dict(FT; override_file)
 isfile(override_file) && rm(override_file; force = true)
-const overwrite = CMP.Rain(toml_dict)
+const overwrite_mp = CMP.Microphysics1MParams(toml_dict)
 
 nothing #hide
 
@@ -52,22 +52,28 @@ override_file = Dict(
         Dict("value" => 13, "type" => "float"),
 )
 toml_dict2 = CP.create_toml_dict(FT; override_file)
-const overwrite2 = CMP.Rain(toml_dict2)
+const overwrite2_mp = CMP.Microphysics1MParams(toml_dict2)
 
 nothing #hide
 
 # Finally we check the values of the rain autoconversion timescales
 # and the corresponding rain formation rates.
+# The autoconversion parameters now live in the option types inside `Microphysics1MParams`.
 qₗ = FT(1e-3)
-default_acnv = CO.logistic_function_integral(qₗ, default.acnv1M.q_threshold, default.acnv1M.k) / default.acnv1M.τ # Rain autoconversion rate
-overwrite_acnv =
-    CO.logistic_function_integral(qₗ, overwrite.acnv1M.q_threshold, overwrite.acnv1M.k) / overwrite.acnv1M.τ # Rain autoconversion rate
-overwrite_acnv2 =
-    CO.logistic_function_integral(qₗ, overwrite2.acnv1M.q_threshold, overwrite2.acnv1M.k) / overwrite2.acnv1M.τ # Rain autoconversion rate
+default_acnv_p = default_mp.options.rain_autoconversion.acnv1M
+default_acnv = CO.logistic_function_integral(qₗ, default_acnv_p.q_threshold, default_acnv_p.k) / default_acnv_p.τ
 
-@info("Default:", default.acnv1M.τ, default_acnv)
-@info("Overwrite:", overwrite.acnv1M.τ, overwrite_acnv)
-@info("Overwrite from dict:", overwrite2.acnv1M.τ, overwrite_acnv2)
+overwrite_acnv_p = overwrite_mp.options.rain_autoconversion.acnv1M
+overwrite_acnv =
+    CO.logistic_function_integral(qₗ, overwrite_acnv_p.q_threshold, overwrite_acnv_p.k) / overwrite_acnv_p.τ
+
+overwrite2_acnv_p = overwrite2_mp.options.rain_autoconversion.acnv1M
+overwrite_acnv2 =
+    CO.logistic_function_integral(qₗ, overwrite2_acnv_p.q_threshold, overwrite2_acnv_p.k) / overwrite2_acnv_p.τ
+
+@info("Default:", default_acnv_p.τ, default_acnv)
+@info("Overwrite:", overwrite_acnv_p.τ, overwrite_acnv)
+@info("Overwrite from dict:", overwrite2_acnv_p.τ, overwrite_acnv2)
 
 # ## Dispatching over parameter types
 

--- a/docs/src/guides/SimpleModel.jl
+++ b/docs/src/guides/SimpleModel.jl
@@ -20,14 +20,15 @@ nothing #hide
 # about the solver interface.
 function rain_formation(dY, Y, p, t)
     FT = eltype(Y) # Floating point precision type
-    (; ρₐ, rain, liquid, ce, v_term) = p # Additional parameters passed through p
+    (; ρₐ, mp, liquid, rain, v_term) = p # Additional parameters passed through p
 
     qₗ = Y[1] # Cloud water specific content
     qᵣ = Y[2] # Rain water specific content
 
-    (; τ, q_threshold, k) = rain.acnv1M
+    E = mp.options.cloud_liquid_rain_accretion.e  # Collision efficiency
+    (; τ, q_threshold, k) = mp.options.rain_autoconversion.acnv1M
     acnv = CO.logistic_function_integral(qₗ, q_threshold, k) / τ # Rain autoconversion rate
-    accr = CM1.accretion(liquid, rain, v_term.rain, ce, qₗ, qᵣ, ρₐ) # Rain accretion rate
+    accr = CM1.accretion(liquid, rain, v_term.rain, E, qₗ, qᵣ, ρₐ) # Rain accretion rate
 
     dY[1] = -acnv - accr # Add the tendecies for cloud water
     dY[2] = acnv + accr  # and rain
@@ -41,10 +42,10 @@ FT = Float32
 
 rain = CMP.Rain(FT) # Rain drop parameters for the 1-moment scheme
 liquid = CMP.CloudLiquid(FT) # Cloud droplet parameters for the 1-moment scheme
-ce = CMP.CollisionEff(FT) # Collision efficiencies
+mp = CMP.Microphysics1MParams(FT) # 1-moment microphysics parameters (includes options)
 v_term = CMP.Blk1MVelType(FT) # Terminal velocity parameters
 ρₐ = FT(1) # Air density
-p = (; ρₐ, rain, liquid, ce, v_term)
+p = (; ρₐ, mp, liquid, rain, v_term)
 
 nothing #hide
 

--- a/docs/src/plots/MarshallPalmer_distribution.jl
+++ b/docs/src/plots/MarshallPalmer_distribution.jl
@@ -10,7 +10,7 @@ import CloudMicrophysics.Microphysics1M as CM1
 FT = Float64
 
 function Marshall_Palmer_distribution(
-    (; pdf, mass)::CMP.Rain{FT},
+    (; pdf, mass)::CMP.Rain,
     q::FT,
     ρ::FT,
     r::FT,

--- a/docs/src/plots/Microphysics1M_plots.jl
+++ b/docs/src/plots/Microphysics1M_plots.jl
@@ -16,7 +16,8 @@ rain = CMP.Rain(FT)
 snow = CMP.Snow(FT)
 Chen2022 = CMP.Chen2022VelType(FT)
 Blk1MVel = CMP.Blk1MVelType(FT)
-ce = CMP.CollisionEff(FT)
+import ClimaParams
+
 mp = CMP.Microphysics1MParams(FT)
 
 # eq. 5b in [Grabowski1996](@cite)
@@ -68,20 +69,20 @@ T = 273.15
 fig = MK.Figure()
 ax = MK.Axis(fig[1, 1]; xlabel = "q_lcl or q_icl [g/kg]", ylabel = "autoconversion rate [1/s]", limits)
 mp_ss = CMP.Microphysics1MParams(FT;
-    options = CMP.Microphysics1MOptions(snow_autoconversion = CMP.SnowAutoconversionWithSupersaturation()),
+    snow_autoconversion = CMP.WithSupersaturation(ClimaParams.create_toml_dict(FT)),
 )
 q_icl_to_q_sno_rate = function (T)
     map(q_icl_range) do q_icl
         micro = (; q_tot, q_lcl = FT(0), q_icl, q_rai, q_sno)
         thermo = (; ρ = ρ_air, T)
-        CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconversionWithSupersaturation(), mp_ss, tps, micro, thermo)
+        CM1.conv_q_icl_to_q_sno(mp_ss.options.snow_autoconversion, mp_ss, tps, micro, thermo)
     end
 end
 MK.lines!(
     q_lcl_range * 1e3,
     [
         CM1.conv_q_lcl_to_q_rai(
-            CMP.RainAutoconversion1M(), mp, tps,
+            mp.options.rain_autoconversion, mp, tps,
             (; q_tot, q_lcl = q, q_icl, q_rai, q_sno),
             (; ρ = ρ_air, T),
         ) for q in q_lcl_range
@@ -101,7 +102,7 @@ MK.lines!(
     q_rain_range * 1e3,
     [
         CM1.accretion(
-            CMP.CloudLiquidRainAccretion(), mp, tps,
+            mp.options.cloud_liquid_rain_accretion, mp, tps,
             (; q_tot, q_lcl, q_icl, q_rai = q_rai_val, q_sno),
             (; ρ = ρ_air, T),
         ) for q_rai_val in q_rain_range
@@ -112,7 +113,7 @@ MK.lines!(
     q_rain_range * 1e3,
     [
         CM1.accretion(
-            CMP.CloudIceRainAccretion(), mp, tps,
+            mp.options.cloud_ice_rain_accretion, mp, tps,
             (; q_tot, q_lcl, q_icl, q_rai = q_rai_val, q_sno),
             (; ρ = ρ_air, T),
         ) for q_rai_val in q_rain_range
@@ -122,7 +123,7 @@ MK.lines!(
 MK.lines!(
     q_snow_range * 1e3,
     [
-        CM1.accretion(CMP.CloudLiquidSnowAccretion(), mp, tps,
+        CM1.accretion(mp.options.cloud_liquid_snow_accretion, mp, tps,
             (; q_tot, q_lcl, q_icl, q_rai, q_sno = q_sno_val),
             (; ρ = ρ_air, T),
         ).S_accr for q_sno_val in q_snow_range
@@ -132,7 +133,7 @@ MK.lines!(
 MK.lines!(
     q_snow_range * 1e3,
     [
-        CM1.accretion(CMP.CloudIceSnowAccretion(), mp, tps,
+        CM1.accretion(mp.options.cloud_ice_snow_accretion, mp, tps,
             (; q_tot, q_lcl, q_icl, q_rai, q_sno = q_sno_val),
             (; ρ = ρ_air, T),
         ) for q_sno_val in q_snow_range
@@ -151,8 +152,9 @@ fig = MK.Figure()
 ax = MK.Axis(fig[1, 1]; xlabel = "q_rain or q_snow [g/kg]", ylabel = "accretion rain sink rate [1/s]", limits)
 _accr_rain_sink(q_icl_val) = [
     CM1.accretion_rain_sink(
-        mp.precip.rain, mp.cloud.ice, mp.terminal_velocity.rain, mp.collision,
-        q_icl_val, q_rai_val, ρ_air,
+        mp.options.cloud_ice_rain_accretion, mp, tps,
+        (; q_tot, q_lcl, q_icl = q_icl_val, q_rai = q_rai_val, q_sno),
+        (; ρ = ρ_air, T),
     ) for q_rai_val in q_rain_range
 ] # hide
 MK.lines!(q_rain_range * 1e3, _accr_rain_sink(1e-6), label = "q_icl = 1e-6")
@@ -166,7 +168,7 @@ fig = MK.Figure()
 ax = MK.Axis(fig[1, 1]; xlabel = "q_rain [g/kg]", ylabel = "snow-rain accretion rate [1/s] T>0", limits)
 _accr_snow_rain_warm(q_sno_val) = [
     CM1.accretion_snow_rain(
-        CMP.RainSnowAccretion(), mp, tps,
+        mp.options.rain_snow_accretion, mp, tps,
         (; q_tot, q_lcl, q_icl, q_rai = q_rai_val, q_sno = q_sno_val),
         (; ρ = ρ_air, T),
     ).S_sno_rai for q_rai_val in q_rain_range
@@ -182,7 +184,7 @@ fig = MK.Figure()
 ax = MK.Axis(fig[1, 1]; xlabel = "q_snow [g/kg]", ylabel = "snow-rain accretion rate [1/s] T<0", limits)
 _accr_snow_rain_cold(q_sno_val) = [
     CM1.accretion_snow_rain(
-        CMP.RainSnowAccretion(), mp, tps,
+        mp.options.rain_snow_accretion, mp, tps,
         (; q_tot, q_lcl, q_icl, q_rai, q_sno = q_sno_val),
         (; ρ = ρ_air, T),
     ).S_rai_sno for q_rai_val in q_snow_range
@@ -214,7 +216,7 @@ MK.lines!(
     q_rain_range * 1e3,
     (
         q_rai -> CM1.conv_q_rai_to_q_vap(
-            CMP.RainEvaporation(), mp, tps,
+            mp.options.rain_condensation_evaporation, mp, tps,
             (; q_tot, q_lcl = q_lcl - q_rai, q_icl, q_rai, q_sno),
             (; ρ, T),
         )
@@ -248,7 +250,7 @@ R = TDI.Rₘ(tps, q_tot, q_lcl + q_rai, q_icl)
 rate =
     (
         q_sno -> CM1.conv_q_sno_to_q_vap(
-            CMP.SnowDepositionSublimation(), mp, tps,
+            mp.options.snow_deposition_sublimation, mp, tps,
             (; q_tot, q_lcl, q_icl = q_icl - q_sno, q_rai, q_sno),
             (; ρ, T),
         )
@@ -273,7 +275,7 @@ R = TDI.Rₘ(tps, q_tot, q_lcl + q_rai, q_icl)
 rate =
     (
         q_sno -> CM1.conv_q_sno_to_q_vap(
-            CMP.SnowDepositionSublimation(), mp, tps,
+            mp.options.snow_deposition_sublimation, mp, tps,
             (; q_tot, q_lcl, q_icl = q_icl - q_sno, q_rai, q_sno),
             (; ρ, T),
         )
@@ -291,7 +293,7 @@ ax = MK.Axis(fig[1, 1]; xlabel = "q_snow [g/kg]", ylabel = "snow melt rate [1/s]
 T = 273.15
 _snow_melt(ΔT) = map(
     q_sno -> CM1.conv_q_sno_to_q_rai(
-        CMP.SnowMelt(),
+        mp.options.snow_melt,
         mp,
         tps,
         (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno),

--- a/docs/src/plots/Microphysics2M_plots.jl
+++ b/docs/src/plots/Microphysics2M_plots.jl
@@ -20,7 +20,7 @@ const SB2006 = CMP.SB2006(FT)
 
 const mp_1m = CMP.Microphysics1MParams(FT)
 
-const ce = CMP.CollisionEff(FT)
+const E_lcl_rai = mp_1m.options.cloud_liquid_rain_accretion.e
 
 const liquid = CMP.CloudLiquid(FT)
 const rain = CMP.Rain(FT)
@@ -65,7 +65,7 @@ q_lcl_SB2006 = [
 ]
 q_lcl_K1969 = [
     CM1.conv_q_lcl_to_q_rai(
-        CMP.RainAutoconversion1M(), mp_1m, nothing,
+        CMP.Kessler1M(ClimaParams.create_toml_dict(FT)), mp_1m, nothing,
         (; q_tot = FT(0), q_lcl = q, q_icl = FT(0), q_rai = FT(0), q_sno = FT(0)),
         nothing,
     ) for q in q_lcl_range
@@ -103,7 +103,7 @@ accSB2006_q_lcl = [
     q_lcl in q_lcl_range
 ]
 accK1969_q_lcl = [
-    CM1.accretion(liquid, rain, blk1mvel.rain, ce, q_lcl, q_rai, ρ_air) for
+    CM1.accretion(liquid, rain, blk1mvel.rain, E_lcl_rai, q_lcl, q_rai, ρ_air) for
     q_lcl in q_lcl_range
 ]
 
@@ -117,7 +117,7 @@ accSB2006_q_rai = [
     q_rai in q_rai_range
 ]
 accK1969_q_rai = [
-    CM1.accretion(liquid, rain, blk1mvel.rain, ce, q_lcl, q_rai, ρ_air) for
+    CM1.accretion(liquid, rain, blk1mvel.rain, E_lcl_rai, q_lcl, q_rai, ρ_air) for
     q_rai in q_rai_range
 ]
 

--- a/docs/src/plots/NonEqCondEvapRate.jl
+++ b/docs/src/plots/NonEqCondEvapRate.jl
@@ -52,11 +52,11 @@ function generate_cond_evap_rate(::HydrostaticBalance_qₗ_z)
     dt = 1; title *= "dt=$(dt)s, "
     τ_relax = 1; title *= "τ_relax=$(τ_relax)s, "
     cm_params = CM.Parameters.CloudLiquid(FT)
-    cm_params = CM.Parameters.CloudLiquid(FT(τ_relax), cm_params.ρw, cm_params.r_eff, cm_params.N_0) # overwrite τ_relax
+    clf = CMP.CloudLiquidFormation(FT(τ_relax))
 
     data = broadcast(qₗ, T) do q_lcl, temp
         CMNe.conv_q_vap_to_q_lcl(
-            CMP.ConstantTimescaleCloudLiquidFormation(),
+            clf,
             (; cloud = (; liquid = cm_params)),
             thp,
             (; q_tot = qₜ, q_lcl, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ),
@@ -92,11 +92,11 @@ function generate_cond_evap_rate(::Range_qₗ_T)
     dt = 1; title *= "dt=$(dt)s, "
     τ_relax = 1; title *= "τ_relax=$(τ_relax)s, "
     cm_params = CM.Parameters.CloudLiquid(FT)
-    cm_params = CM.Parameters.CloudLiquid(FT(τ_relax), cm_params.ρw, cm_params.r_eff, cm_params.N_0) # overwrite τ_relax
+    clf = CMP.CloudLiquidFormation(FT(τ_relax))
 
     data = broadcast(qₗ, T') do q_lcl, temp
         CMNe.conv_q_vap_to_q_lcl(
-            CMP.ConstantTimescaleCloudLiquidFormation(),
+            clf,
             (; cloud = (; liquid = cm_params)),
             thp,
             (; q_tot = qₜ, q_lcl, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ),

--- a/docs/src/plots/Thersholds_transitions.jl
+++ b/docs/src/plots/Thersholds_transitions.jl
@@ -40,13 +40,16 @@ N_d_range = range(1e7, stop = 1e9, length = 1000)
 ρ_air = 1.0 # kg m^-3
 N_d = 1e8
 
+mp = CMP.Microphysics1MParams(CP.create_toml_dict(FT))
+acnv = mp.options.rain_autoconversion.acnv1M
+
 q_lcl_K1969 = [
-    max(0, q_lcl - rain[1].acnv1M.q_threshold) / rain[1].acnv1M.τ
+    max(0, q_lcl - acnv.q_threshold) / acnv.τ
     for q_lcl in q_lcl_range
 ]
 q_lcl_K1969_s = [
-    CO.logistic_function_integral(q_lcl, rain[1].acnv1M.q_threshold, rain[1].acnv1M.k) /
-    rain[1].acnv1M.τ
+    CO.logistic_function_integral(q_lcl, acnv.q_threshold, acnv.k) /
+    acnv.τ
     for q_lcl in q_lcl_range
 ]
 

--- a/docs/src/plots/plotting_tau_relax_frostenberg.jl
+++ b/docs/src/plots/plotting_tau_relax_frostenberg.jl
@@ -25,8 +25,10 @@ q_icl_labels = ["0", "10⁻⁸", "10⁻⁶", "10⁻⁴", "10⁻²"]
 # Air density (representative value for mid-troposphere)
 ρ = FT(0.8)
 
-# Sublimation timescale (constant)
-τ_sub = CMNe.τ_relax(ice)
+import ClimaParams as CP
+
+# Sublimation timescale (constant, from ClimaParams defaults)
+τ_sub = CMP.ConstantTimescale(CP.create_toml_dict(FT)).τ_relax
 
 # Compute the effective timescale used in conv_q_vap_to_q_icl:
 #   T < T_freeze (deposition):  τ_dep × Γᵢ  (Frostenberg τ with thermodynamic correction)

--- a/parcel/ParcelTendencies.jl
+++ b/parcel/ParcelTendencies.jl
@@ -258,7 +258,7 @@ function condensation(params::NonEqCondParams, PSD, state, ρ_air)
         micro_mock = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = FT(0), q_sno = FT(0))
         thermo_mock = (; ρ = ρ_air, T = T)
         cond_rate = MNE.conv_q_vap_to_q_lcl(
-            CMP.ConstantTimescaleCloudLiquidFormation(), mp_mock, tps, micro_mock, thermo_mock,
+            CMP.CloudLiquidFormation(CMP.CP.create_toml_dict(FT)), mp_mock, tps, micro_mock, thermo_mock,
         )
 
         # Using same limiter as ClimaAtmos for now
@@ -321,7 +321,7 @@ function deposition(params::NonEqDepParams, PSD, state, ρ_air)
         micro_mock = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = FT(0), q_sno = FT(0))
         thermo_mock = (; ρ = ρ_air, T = T)
         dep_rate = MNE.conv_q_vap_to_q_icl(
-            CMP.TemperatureDependentCloudIceFormation(), mp_mock, tps, micro_mock, thermo_mock,
+            CMP.TemperatureDependent(CMP.CP.create_toml_dict(FT)), mp_mock, tps, micro_mock, thermo_mock,
         )
 
         # Using same limiter as ClimaAtmos for now

--- a/src/BulkMicrophysicsTendencies.jl
+++ b/src/BulkMicrophysicsTendencies.jl
@@ -123,6 +123,11 @@ This is the **single source of truth** for which microphysical processes are
 called and with what arguments. Both the raw tendency aggregation and the
 linearized operator construction consume this output.
 
+Constructs two `NamedTuple`s that are passed to all process functions
+(see `Microphysics1M` module docs for the full convention):
+- `micro = (; q_tot, q_lcl, q_icl, q_rai, q_sno)` — specific humidities (kg/kg)
+- `thermo = (; ρ, T)` — air density (kg/m³) and temperature (K)
+
 Naming convention: `S_process_species1_species2`
  - process: physical mechanism (phase_change, acnv, accr, melt, accr_melt, accr_freeze)
  - species1, species2: interacting pair (not from/to)
@@ -159,7 +164,7 @@ processes are pre-routed by temperature, so consumers never need `is_warm`.
     S_acnv_icl_sno = CM1.conv_q_icl_to_q_sno(opts.snow_autoconversion, mp, tps, micro, thermo)
 
     # --- Accretion (collisions between species) ---
-    is_warm = T >= mp.precip.snow.T_freeze
+    is_warm = T >= TDI.T_freeze(tps)
 
     # Cloud liquid + rain → rain
     S_accr_lcl_rai = CM1.accretion(opts.cloud_liquid_rain_accretion, mp, tps, micro, thermo)
@@ -174,10 +179,7 @@ processes are pre-routed by temperature, so consumers never need `is_warm`.
     S_accr_icl_rai = CM1.accretion(opts.cloud_ice_rain_accretion, mp, tps, micro, thermo)
 
     # Rain frozen in cloud ice + rain collision → snow (rain sink)
-    S_accr_freeze_icl_rai =
-        CM1.accretion_rain_sink(mp.precip.rain, mp.cloud.ice, mp.terminal_velocity.rain, mp.collision,
-            q_icl, q_rai, ρ) *
-        (opts.cloud_ice_rain_accretion isa CMP.CloudIceRainAccretion)
+    S_accr_freeze_icl_rai = CM1.accretion_rain_sink(opts.cloud_ice_rain_accretion, mp, tps, micro, thermo)
 
     # Cloud ice + snow → snow
     S_accr_icl_sno = CM1.accretion(opts.cloud_ice_snow_accretion, mp, tps, micro, thermo)
@@ -701,11 +703,10 @@ Used by both warm-only and warm+ice dispatch methods to reduce code duplication.
     dn_rai_dt = zero(FT)
 
     # --- Condensation of vapor / evaporation of cloud liquid water ---
-    mp_mock = (; cloud = (; liquid = condevap))
     micro_mock = (; q_tot, q_lcl, q_icl = q_ice, q_rai, q_sno = zero(q_ice))
     thermo_mock = (; ρ, T)
     ∂ₜq_lcl_cond = CMNonEq.conv_q_vap_to_q_lcl(
-        CMP.ConstantTimescaleCloudLiquidFormation(), mp_mock, tps, micro_mock, thermo_mock,
+        CMP.CloudLiquidFormation(condevap.τ_relax), nothing, tps, micro_mock, thermo_mock,
     )
     ∂ₜn_lcl_cond = zero(∂ₜq_lcl_cond)  # neglect number change from condensation/evaporation
     dq_lcl_dt += ∂ₜq_lcl_cond

--- a/src/CloudDiagnostics.jl
+++ b/src/CloudDiagnostics.jl
@@ -28,7 +28,7 @@ Normalized by the reflectivty of 1 millimiter drop in a volume of 1m3.
 The values are clipped at -150 dBZ.
 """
 function radar_reflectivity_1M(
-    (; pdf, mass)::CMP.Rain{FT},
+    (; pdf, mass)::CMP.Rain,
     q::FT,
     ρ::FT,
 ) where {FT}

--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -15,6 +15,27 @@ distribution. Microphysical process rates are derived by integrating particle-sc
 physics (terminal velocities, collision kernels, mass transfer) over these assumed
 distributions.
 
+# Common argument conventions
+
+All option-dispatched process functions share the signature
+`process(opt, mp, tps, micro, thermo)`, where:
+
+- `opt`: process option type (dispatches which parameterization to use)
+- `mp`: `Microphysics1MParams` — unified parameter container
+- `tps`: thermodynamics parameters (from Thermodynamics.jl)
+- `micro`: `NamedTuple` of specific humidities (kg/kg):
+  - `q_tot` — total water specific humidity
+  - `q_lcl` — cloud liquid water specific humidity
+  - `q_icl` — cloud ice specific humidity
+  - `q_rai` — rain specific humidity
+  - `q_sno` — snow specific humidity
+- `thermo`: `NamedTuple` of thermodynamic state:
+  - `ρ` — air density (kg/m³)
+  - `T` — temperature (K)
+
+Not all processes use every field; each extracts only the fields it needs.
+When a process is disabled (option = `nothing`), it returns zero.
+
 Based on:
   - Kessler (1995) - https://doi.org/10.1016/0169-8095(94)00090-Z
   - Grabowski (1998) - https://doi.org/10.1175/1520-0469(1998)055<3283:TCRMOL>2.0.CO;2
@@ -46,25 +67,6 @@ abstract type AbstractSnowShape end
 struct Oblate <: AbstractSnowShape end
 struct Prolate <: AbstractSnowShape end
 
-"""
-    Ec(type_1, type_2, ce)
-
-Returns the collision efficiency (Ec) for two colliding species.
-
-Collision efficiency represents the fraction of geometric collisions that result
-in coalescence (0 ≤ Ec ≤ 1). A value of 1 means all collisions lead to merging,
-while lower values account for particles bouncing apart.
-
-# Arguments
-- `type_1`, `type_2`: types of colliding species (CloudLiquid, CloudIce, Rain, Snow)
-- `ce`: collision efficiency parameters struct
-"""
-@inline Ec(::CMP.CloudLiquid, ::CMP.Rain, (; e_lcl_rai)::CMP.CollisionEff) = e_lcl_rai
-@inline Ec(::CMP.CloudLiquid, ::CMP.Snow, (; e_lcl_sno)::CMP.CollisionEff) = e_lcl_sno
-@inline Ec(::CMP.CloudIce, ::CMP.Rain, (; e_icl_rai)::CMP.CollisionEff) = e_icl_rai
-@inline Ec(::CMP.CloudIce, ::CMP.Snow, (; e_icl_sno)::CMP.CollisionEff) = e_icl_sno
-@inline Ec(::CMP.Rain, ::CMP.Snow, (; e_rai_sno)::CMP.CollisionEff) = e_rai_sno
-@inline Ec(::CMP.Snow, ::CMP.Rain, (; e_rai_sno)::CMP.CollisionEff) = e_rai_sno
 
 """
     get_n0(pdf::ParticlePDFSnow, q_sno, ρ)
@@ -210,7 +212,7 @@ Fall velocity of individual particles is parameterized:
 - Mass-weighted terminal velocity [m/s]
 """
 @inline function terminal_velocity(
-    (; pdf, mass)::Union{CMP.Rain{FT}, CMP.Snow{FT}},
+    (; pdf, mass)::Union{CMP.Rain, CMP.Snow},
     vel::Union{CMP.Blk1MVelTypeRain{FT}, CMP.Blk1MVelTypeSnow{FT}},
     ρ::FT,
     q::FT,
@@ -233,7 +235,7 @@ Fall velocity of individual particles is parameterized:
 end
 
 @inline function terminal_velocity(
-    (; pdf, mass)::CMP.Rain{FT},
+    (; pdf, mass)::CMP.Rain,
     vel::CMP.Chen2022VelTypeRain{FT},
     ρₐ::FT,
     q::FT,
@@ -257,7 +259,7 @@ end
 end
 
 @inline function terminal_velocity(
-    (; pdf, mass, area, ρᵢ, aspr)::CMP.Snow{FT},
+    (; pdf, mass, area, ρᵢ, aspr)::CMP.Snow,
     vel::CMP.Chen2022VelTypeLargeIce{FT},
     ρₐ::FT,
     q::FT,
@@ -287,7 +289,7 @@ end
 end
 
 @inline function terminal_velocity(
-    (; pdf, mass, area, ρᵢ, gamma_aspect_oblate, gamma_aspect_prolate)::CMP.Snow{FT},
+    (; pdf, mass, area, ρᵢ, gamma_aspect_oblate, gamma_aspect_prolate)::CMP.Snow,
     vel::CMP.Chen2022VelTypeLargeIce{FT},
     ρₐ::FT,
     q::FT,
@@ -317,23 +319,23 @@ end
 end
 
 """
-    conv_q_lcl_to_q_rai(::NoRainAutoconversion, mp, tps, micro, thermo)
-    conv_q_lcl_to_q_rai(::RainAutoconversion1M, mp, tps, micro, thermo)
-    conv_q_lcl_to_q_rai(::RainAutoconversionPrescribedNd, mp, tps, micro, thermo)
+    conv_q_lcl_to_q_rai(::Nothing, mp, tps, micro, thermo)
+    conv_q_lcl_to_q_rai(::Kessler1M, mp, tps, micro, thermo)
+    conv_q_lcl_to_q_rai(::PrescribedNd, mp, tps, micro, thermo)
 
 Returns the rain tendency due to autoconversion of cloud liquid, dispatching on
 the option stored in `Microphysics1MOptions`.
 
-**NoRainAutoconversion**: returns zero (autoconversion disabled).
+**Nothing**: returns zero (autoconversion disabled).
 
-**RainAutoconversion1M**: Kessler (1995) 1-moment threshold autoconversion
+**Kessler1M**: Kessler (1995) 1-moment threshold autoconversion
 (smooth logistic transition), https://doi.org/10.1016/0169-8095(94)00090-Z.
 
-**RainAutoconversionPrescribedNd**: Variable-timescale autoconversion following Azimi (2023),
-using the prescribed cloud droplet number concentration `mp.autoconv_2M.Nc`.
+**PrescribedNd**: Variable-timescale autoconversion following Azimi (2023),
+using the prescribed cloud droplet number concentration.
 
 # Arguments
-- `option`: `NoRainAutoconversion()`, `RainAutoconversion1M()`, or `RainAutoconversionPrescribedNd()`
+- `option`: `nothing`, `Kessler1M(...)`, or `PrescribedNd(...)`
 - `mp`: 1-moment microphysics parameters
 - `tps`: thermodynamics parameters (unused, kept for uniform interface)
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
@@ -342,56 +344,55 @@ using the prescribed cloud droplet number concentration `mp.autoconv_2M.Nc`.
 # Returns
 - Rain autoconversion rate [kg/kg/s]
 """
-@inline conv_q_lcl_to_q_rai(::CMP.NoRainAutoconversion, mp, tps, micro, thermo) = zero(micro.q_lcl)
+@inline conv_q_lcl_to_q_rai(::Nothing, mp, tps, micro, thermo) = zero(micro.q_lcl)
 
-@inline function conv_q_lcl_to_q_rai(::CMP.RainAutoconversion1M, mp, tps, micro, thermo)
+@inline function conv_q_lcl_to_q_rai(opt::CMP.Kessler1M, mp, tps, micro, thermo)
     q_lcl = micro.q_lcl
-    (; τ, q_threshold, k) = mp.precip.rain.acnv1M
+    (; τ, q_threshold, k) = opt.acnv1M
     return CO.logistic_function_integral(q_lcl, q_threshold, k) / τ
 end
 
-@inline function conv_q_lcl_to_q_rai(::CMP.RainAutoconversionPrescribedNd, mp, tps, micro, thermo)
+@inline function conv_q_lcl_to_q_rai(opt::CMP.PrescribedNd, mp, tps, micro, thermo)
     q_lcl = micro.q_lcl
-    # Use the prescribed number concentration stored as a parameter
-    N_d = mp.autoconv_2M.Nc
-    (; τ, α) = mp.autoconv_2M
-    return max(0, q_lcl) / (τ * (N_d / 100_000_000)^α)
+    (; τ, α, Nc) = opt.autoconv
+    return max(0, q_lcl) / (τ * (Nc / 100_000_000)^α)
 end
 
 """
-    conv_q_icl_to_q_sno(::NoSnowAutoconversion, mp, tps, micro, thermo)
-    conv_q_icl_to_q_sno(::SnowAutoconversionNoSupersaturation, mp, tps, micro, thermo)
-    conv_q_icl_to_q_sno(::SnowAutoconversionWithSupersaturation, mp, tps, micro, thermo)
+    conv_q_icl_to_q_sno(::Nothing, mp, tps, micro, thermo)
+    conv_q_icl_to_q_sno(opt::NoSupersaturation, mp, tps, micro, thermo)
+    conv_q_icl_to_q_sno(opt::WithSupersaturation, mp, tps, micro, thermo)
 
 Returns the snow tendency due to autoconversion from cloud ice.
 
-**NoSnowAutoconversion**: returns zero (snow autoconversion disabled).
+**Nothing**: returns zero (snow autoconversion disabled).
 
-**SnowAutoconversionNoSupersaturation**: Simplified Kessler-type threshold autoconversion,
+**NoSupersaturation**: Simplified Kessler-type threshold autoconversion,
 for use in simulations without supersaturation (e.g., with saturation adjustment).
 
-**SnowAutoconversionWithSupersaturation**: Supersaturation-dependent autoconversion following
+**WithSupersaturation**: Supersaturation-dependent autoconversion following
 Harrington et al. (1995) and Kaul et al. (2015).
 
 # Arguments
-- `option`: `NoSnowAutoconversion()`, `SnowAutoconversionNoSupersaturation()`, or `SnowAutoconversionWithSupersaturation()`
+- `opt`: `nothing`, `NoSupersaturation(...)`, or `WithSupersaturation(...)`
 - `mp`: 1-moment microphysics parameters
 - `tps`: thermodynamics parameters
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
 - `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline conv_q_icl_to_q_sno(::CMP.NoSnowAutoconversion, mp, tps, micro, thermo) = zero(micro.q_icl)
+@inline conv_q_icl_to_q_sno(::Nothing, mp, tps, micro, thermo) = zero(micro.q_icl)
 
-@inline function conv_q_icl_to_q_sno(::CMP.SnowAutoconversionNoSupersaturation, mp, tps, micro, thermo)
-    (; τ, q_threshold, k) = mp.precip.snow.acnv1M
+@inline function conv_q_icl_to_q_sno(opt::CMP.NoSupersaturation, mp, tps, micro, thermo)
+    (; τ, q_threshold, k) = opt.acnv1M
     q_icl = micro.q_icl
     return CO.logistic_function_integral(q_icl, q_threshold, k) / τ
 end
 
-@inline function conv_q_icl_to_q_sno(::CMP.SnowAutoconversionWithSupersaturation, mp, tps, micro, thermo)
+@inline function conv_q_icl_to_q_sno(opt::CMP.WithSupersaturation, mp, tps, micro, thermo)
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
-    (; r_ice_snow, pdf, mass) = mp.cloud.ice
+    r_ice_snow = opt.r_ice_snow
+    (; pdf, mass) = mp.cloud.ice
     aps = mp.air_properties
     FT = eltype(ρ)
     acnv_rate = FT(0)
@@ -413,7 +414,7 @@ end
 end
 
 """
-    warm_accretion_melt_factor(tps, sno, T)
+    warm_accretion_melt_factor(tps, T)
 
 Ratio of sensible heat from warm collected liquid to latent heat for melting:
 `α = cv_l / L_f × (T - T_freeze)`, returning 0 when `T ≤ T_freeze`.
@@ -422,31 +423,28 @@ Used by `accretion(::CloudLiquidSnowAccretion, ...)` and
 `accretion_snow_rain(::RainSnowAccretion, ...)` to compute the thermal melt
 contribution of warm liquid on snow.
 """
-@inline function warm_accretion_melt_factor(tps, sno, T)
+@inline function warm_accretion_melt_factor(tps, T)
     L_f = TDI.Lf(tps, T)
     cv_l = TDI.cv_l(tps)
-    ΔT = T - sno.T_freeze
-    is_cold = (T <= sno.T_freeze)
+    T_freeze = TDI.T_freeze(tps)
+    ΔT = T - T_freeze
+    is_cold = (T <= T_freeze)
     return ifelse(is_cold, zero(T), cv_l / L_f * ΔT)
 end
 
 """
-    accretion(cloud::CloudCondensateType, precip::PrecipitationType, vel, ce, q_clo, q_pre, ρ)
+    accretion(cloud, precip, vel, E, q_clo, q_pre, ρ)
 
 Returns the source of precipitating water (rain or snow) due to collisions
 with cloud water (liquid or ice).
 
-!!! note "Internal use only"
-    This low-level positional-argument kernel is kept for internal dispatch.
-    Prefer the option-dispatched API:
-    `accretion(::CloudLiquidRainAccretion, mp, tps, micro, thermo)`,
-    `accretion(::CloudLiquidSnowAccretion, mp, tps, micro, thermo)`, etc.
+Internal low-level kernel. Prefer the option-dispatched API.
 
 # Arguments
 - `cloud`: type for cloud water or cloud ice
 - `precip`: type for rain or snow
-- `vel`: terminal velocity parameters (Blk1MVelTypeRain or Blk1MVelTypeSnow, contains `gamma_accr`)
-- `ce`: collision efficiency parameters
+- `vel`: terminal velocity parameters
+- `E`: collision efficiency
 - `q_clo`: cloud liquid water or cloud ice specific content
 - `q_pre`: rain or snow specific content
 - `ρ`: air density
@@ -455,7 +453,7 @@ with cloud water (liquid or ice).
     cloud::CMP.CloudCondensateType,
     precip::CMP.PrecipitationType,
     vel::Union{CMP.Blk1MVelTypeRain{FT}, CMP.Blk1MVelTypeSnow{FT}},
-    ce::CMP.CollisionEff,
+    E::FT,
     q_clo::FT,
     q_pre::FT,
     ρ::FT,
@@ -472,7 +470,6 @@ with cloud water (liquid or ice).
         (; a0, ae, χa, Δa) = precip.area
 
         λ_inv = lambda_inverse(precip.pdf, precip.mass, q_pre, ρ)
-        E = Ec(cloud, precip, ce)
 
         # gamma_accr = SF.gamma(ae + ve + Δa + Δv + 1) (pre-computed in vel)
         accr_rate =
@@ -482,19 +479,15 @@ with cloud water (liquid or ice).
     return accr_rate
 end
 
-# accretion_rain_sink(rain, ice, vel, ce, q_icl, q_rai, ρ)
+# accretion_rain_sink(rain, ice, vel, E, q_icl, q_rai, ρ)
 #
 # Returns the sink of rain water (partial source of snow) due to collisions
 # with cloud ice.
-#
-# Internal use only: this low-level positional-argument kernel is kept for
-# internal dispatch. Prefer `accretion_rain_sink(::CloudIceRainAccretion,
-# mp, tps, micro, thermo)` (via BulkMicrophysicsTendencies).
 @inline function accretion_rain_sink(
-    rain::CMP.Rain{FT},
-    ice::CMP.CloudIce{FT},
+    rain::CMP.Rain,
+    ice::CMP.CloudIce,
     vel::CMP.Blk1MVelTypeRain{FT},
-    ce::CMP.CollisionEff,
+    E::FT,
     q_icl::FT,
     q_rai::FT,
     ρ::FT,
@@ -510,8 +503,6 @@ end
         (; r0, m0, me, Δm, χm) = rain.mass
         (; χv, ve, Δv) = vel
         (; a0, ae, χa, Δa) = rain.area
-
-        E = Ec(ice, rain, ce)
 
         λ_inv = lambda_inverse(rain.pdf, rain.mass, q_rai, ρ)
 
@@ -550,9 +541,10 @@ deviations are proportional to the mean fall velocities, with coefficient
 @inline function accretion_snow_rain(
     type_i::CMP.PrecipitationType,
     type_j::CMP.PrecipitationType,
-    blk1mveltype_ti::Union{CMP.Blk1MVelTypeRain{FT}, CMP.Blk1MVelTypeSnow{FT}},
-    blk1mveltype_tj::Union{CMP.Blk1MVelTypeRain{FT}, CMP.Blk1MVelTypeSnow{FT}},
-    ce::CMP.CollisionEff,
+    blk1mveltype_ti,
+    blk1mveltype_tj,
+    E_ij::FT,
+    coeff_disp::FT,
     q_i::FT,
     q_j::FT,
     ρ::FT,
@@ -567,8 +559,6 @@ deviations are proportional to the mean fall velocities, with coefficient
         (; r0, m0, me, Δm, χm, gamma_coeff) = type_j.mass
         δ = me + Δm
 
-        E_ij = Ec(type_i, type_j, ce)
-
         λ_i_inv = lambda_inverse(type_i.pdf, type_i.mass, q_i, ρ)
         λ_j_inv = lambda_inverse(type_j.pdf, type_j.mass, q_j, ρ)
 
@@ -577,8 +567,8 @@ deviations are proportional to the mean fall velocities, with coefficient
 
         # Add simple parameterization for velocity dispersion, assuming that fall velocity 
         # standard deviations are proportional to the mean fall velocities, with coefficient 
-        # ce.coeff_disp
-        Δv_eff = sqrt((v_ti - v_tj)^2 + ce.coeff_disp * (v_ti^2 + v_tj^2))
+        # coeff_disp
+        Δv_eff = sqrt((v_ti - v_tj)^2 + coeff_disp * (v_ti^2 + v_tj^2))
 
         # We use the recurrence relation Γ(x+1) = xΓ(x) to simplify gamma terms.
         # gamma_coeff = Γ(δ + 1) is pre-computed.
@@ -594,124 +584,109 @@ deviations are proportional to the mean fall velocities, with coefficient
 end
 
 """
-    accretion(::NoCloudLiquidRainAccretion, mp, tps, micro, thermo)
-    accretion(::CloudLiquidRainAccretion, mp, tps, micro, thermo)
-    accretion(::NoCloudLiquidSnowAccretion, mp, tps, micro, thermo)
-    accretion(::CloudLiquidSnowAccretion, mp, tps, micro, thermo)
-    accretion(::NoCloudIceRainAccretion, mp, tps, micro, thermo)
-    accretion(::CloudIceRainAccretion, mp, tps, micro, thermo)
-    accretion(::NoCloudIceSnowAccretion, mp, tps, micro, thermo)
-    accretion(::CloudIceSnowAccretion, mp, tps, micro, thermo)
-    accretion_snow_rain(::NoRainSnowAccretion, mp, tps, micro, thermo)
-    accretion_snow_rain(::RainSnowAccretion, mp, tps, micro, thermo)
+    accretion(::Nothing, mp, tps, micro, thermo)
+    accretion(opt::CloudLiquidRainAccretion, mp, tps, micro, thermo)
+    accretion(opt::CloudLiquidSnowAccretion, mp, tps, micro, thermo)
+    accretion(opt::CloudIceRainAccretion, mp, tps, micro, thermo)
+    accretion(opt::CloudIceSnowAccretion, mp, tps, micro, thermo)
+    accretion_snow_rain(::Nothing, mp, tps, micro, thermo)
+    accretion_snow_rain(opt::RainSnowAccretion, mp, tps, micro, thermo)
 
 Option-dispatched accretion wrappers. All extract parameters from `mp` and
 delegate to the corresponding low-level Marshall-Palmer kernels.
-The `No*` variants return zero without computing anything.
-
-**`CloudLiquidRainAccretion`**: cloud liquid × rain → rain.  
-Returns a scalar rate [kg/kg/s].
-
-**`CloudLiquidSnowAccretion`**: cloud liquid × snow → snow (cold) or rain (warm).  
-Also computes the thermal melt contribution `α * S_accr` via
-`warm_accretion_melt_factor`.  
-Returns `(; S_accr, S_melt)` [kg/kg/s].
-
-**`CloudIceRainAccretion`**: cloud ice × rain → snow.  
-Also calls the coupled rain-sink kernel (rain + cloud ice → snow) internally;
-see `BulkMicrophysicsTendencies` for how both arms are applied.  
-Returns a scalar rate [kg/kg/s].
-
-**`CloudIceSnowAccretion`**: cloud ice × snow → snow.  
-Returns a scalar rate [kg/kg/s].
-
-**`RainSnowAccretion`**: both rain–snow collision arms plus thermal melt.  
-Cold arm: `S_rai_sno` (snow is collector, rain freezes → snow).  
-Warm arm: `S_sno_rai` (rain is collector, snow melts → rain).  
-Melt: `S_melt = α * S_rai_sno` (additional snow melt from warm rain).  
-Returns `(; S_rai_sno, S_sno_rai, S_melt)` [kg/kg/s].
+`nothing` variants return zero without computing anything.
 
 # Arguments
-- `option`: one of the option singletons above
-- `mp`: `Microphysics1MParams` (cloud, precip, collision, terminal_velocity, air_properties)
-- `tps`: thermodynamics parameters (used for `warm_accretion_melt_factor`)
+- `opt`: accretion option type (carries collision efficiency) or `nothing`
+- `mp`: `Microphysics1MParams`
+- `tps`: thermodynamics parameters
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
 - `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline accretion(::CMP.NoCloudLiquidRainAccretion, mp, tps, micro, thermo) = zero(thermo.T)
+# Nothing dispatch: scalar zero for simple accretion, NamedTuple for processes
+# that return NamedTuple shapes. Since `nothing` is a singleton, we can't dispatch
+# differently on it by process. BMT calls accretion() for scalar-result processes
+# and directly destructures for NamedTuple processes. We provide the scalar zero
+# here; NamedTuple-returning processes are handled in BMT by checking `nothing` directly.
+@inline accretion(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
 
-@inline function accretion(::CMP.CloudLiquidRainAccretion, mp, tps, micro, thermo)
+@inline function accretion(opt::CMP.CloudLiquidRainAccretion, mp, tps, micro, thermo)
     q_lcl = micro.q_lcl
     q_rai = micro.q_rai
     ρ = thermo.ρ
-    return accretion(mp.cloud.liquid, mp.precip.rain, mp.terminal_velocity.rain, mp.collision, q_lcl, q_rai, ρ)
+    return accretion(mp.cloud.liquid, mp.precip.rain, mp.terminal_velocity.rain, opt.e, q_lcl, q_rai, ρ)
 end
 
-@inline accretion(::CMP.NoCloudLiquidSnowAccretion, mp, tps, micro, thermo) =
-    (; S_accr = zero(thermo.T), S_melt = zero(thermo.T))
-
-@inline function accretion(::CMP.CloudLiquidSnowAccretion, mp, tps, micro, thermo)
+@inline function accretion(opt::CMP.CloudLiquidSnowAccretion, mp, tps, micro, thermo)
     q_lcl = micro.q_lcl
     q_sno = micro.q_sno
     ρ = thermo.ρ
     T = thermo.T
-    S = accretion(mp.cloud.liquid, mp.precip.snow, mp.terminal_velocity.snow, mp.collision, q_lcl, q_sno, ρ)
-    α = warm_accretion_melt_factor(tps, mp.precip.snow, T)
+    S = accretion(mp.cloud.liquid, mp.precip.snow, mp.terminal_velocity.snow, opt.e, q_lcl, q_sno, ρ)
+    α = warm_accretion_melt_factor(tps, T)
     return (; S_accr = S, S_melt = α * S)
 end
 
-@inline accretion(::CMP.NoCloudIceRainAccretion, mp, tps, micro, thermo) = zero(thermo.T)
-
-@inline function accretion(::CMP.CloudIceRainAccretion, mp, tps, micro, thermo)
+@inline function accretion(opt::CMP.CloudIceRainAccretion, mp, tps, micro, thermo)
     q_icl = micro.q_icl
     q_rai = micro.q_rai
     ρ = thermo.ρ
-    return accretion(mp.cloud.ice, mp.precip.rain, mp.terminal_velocity.rain, mp.collision, q_icl, q_rai, ρ)
+    return accretion(mp.cloud.ice, mp.precip.rain, mp.terminal_velocity.rain, opt.e, q_icl, q_rai, ρ)
 end
 
-@inline accretion(::CMP.NoCloudIceSnowAccretion, mp, tps, micro, thermo) = zero(thermo.T)
-
-@inline function accretion(::CMP.CloudIceSnowAccretion, mp, tps, micro, thermo)
+@inline function accretion(opt::CMP.CloudIceSnowAccretion, mp, tps, micro, thermo)
     q_icl = micro.q_icl
     q_sno = micro.q_sno
     ρ = thermo.ρ
-    return accretion(mp.cloud.ice, mp.precip.snow, mp.terminal_velocity.snow, mp.collision, q_icl, q_sno, ρ)
+    return accretion(mp.cloud.ice, mp.precip.snow, mp.terminal_velocity.snow, opt.e, q_icl, q_sno, ρ)
 end
 
-@inline accretion_snow_rain(::CMP.NoRainSnowAccretion, mp, tps, micro, thermo) =
+@inline accretion_snow_rain(::Nothing, mp, tps, micro, thermo) =
     (; S_rai_sno = zero(thermo.T), S_sno_rai = zero(thermo.T), S_melt = zero(thermo.T))
 
-@inline function accretion_snow_rain(::CMP.RainSnowAccretion, mp, tps, micro, thermo)
+@inline function accretion_snow_rain(opt::CMP.RainSnowAccretion, mp, tps, micro, thermo)
     q_rai = micro.q_rai
     q_sno = micro.q_sno
     ρ = thermo.ρ
     T = thermo.T
     vel = mp.terminal_velocity
-    ce = mp.collision
     sno = mp.precip.snow
     rai = mp.precip.rain
     # cold arm: snow is collector, rain freezes → snow
-    S_rai_sno = accretion_snow_rain(sno, rai, vel.snow, vel.rain, ce, q_sno, q_rai, ρ)
+    S_rai_sno = accretion_snow_rain(sno, rai, vel.snow, vel.rain, opt.e, opt.coeff_disp, q_sno, q_rai, ρ)
     # warm arm: rain is collector, snow melts → rain
-    S_sno_rai = accretion_snow_rain(rai, sno, vel.rain, vel.snow, ce, q_rai, q_sno, ρ)
-    α = warm_accretion_melt_factor(tps, sno, T)
+    S_sno_rai = accretion_snow_rain(rai, sno, vel.rain, vel.snow, opt.e, opt.coeff_disp, q_rai, q_sno, ρ)
+    α = warm_accretion_melt_factor(tps, T)
     return (; S_rai_sno, S_sno_rai, S_melt = α * S_rai_sno)
+end
+
+# Rain sink arm of cloud ice + rain accretion
+@inline accretion_rain_sink(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
+
+@inline function accretion_rain_sink(opt::CMP.CloudIceRainAccretion, mp, tps, micro, thermo)
+    q_icl = micro.q_icl
+    q_rai = micro.q_rai
+    ρ = thermo.ρ
+    return accretion_rain_sink(mp.precip.rain, mp.cloud.ice, mp.terminal_velocity.rain, opt.e, q_icl, q_rai, ρ)
 end
 
 """
 Returns the tendency due to rain evaporation.
 Ventilation factor parameterization follows Seifert and Beheng (2006).
 
+Returns the tendency due to rain evaporation.
+Ventilation factor parameterization follows Seifert and Beheng (2006).
+
 Only evaporation is considered (sub-saturated over liquid); result is clamped ≤ 0.
 
 # Arguments
-- `option`: `NoRainCondensationEvaporation()` or `RainEvaporation()`
+- `opt`: `RainEvaporation()` or `nothing`
 - `mp`: 1-moment microphysics parameters
 - `tps`: thermodynamics parameters
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
 - `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline conv_q_rai_to_q_vap(::CMP.NoRainCondensationEvaporation, mp, tps, micro, thermo) = zero(thermo.T)
+@inline conv_q_rai_to_q_vap(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
 
 @inline function conv_q_rai_to_q_vap(::CMP.RainEvaporation, mp, tps, micro, thermo)
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
@@ -753,35 +728,27 @@ Only evaporation is considered (sub-saturated over liquid); result is clamped �
 end
 
 """
-    conv_q_sno_to_q_vap(::NoSnowDepositionSublimation, mp, tps, micro, thermo)
-    conv_q_sno_to_q_vap(::SnowSublimation, mp, tps, micro, thermo)
-    conv_q_sno_to_q_vap(::SnowDepositionSublimation, mp, tps, micro, thermo)
+    conv_q_sno_to_q_vap(::Nothing, mp, tps, micro, thermo)
+    conv_q_sno_to_q_vap(::SublimationOnly, mp, tps, micro, thermo)
+    conv_q_sno_to_q_vap(::DepositionAndSublimation, mp, tps, micro, thermo)
 
 Returns the tendency due to snow sublimation or sublimation+deposition.
 Ventilation factor parameterization follows Seifert and Beheng (2006).
 
-**NoSnowDepositionSublimation**: returns zero (process disabled).
-
-**SnowSublimation**: only sublimation (S < 0 over ice) is computed;
-deposition is handled separately by non-equilibrium relaxation.
-
-**SnowDepositionSublimation**: both sublimation and deposition are computed
-in the Marshall-Palmer integral.
-
 # Arguments
-- `option`: `NoSnowDepositionSublimation()`, `SnowSublimation()`, or `SnowDepositionSublimation()`
+- `opt`: `nothing`, `SublimationOnly()`, or `DepositionAndSublimation()`
 - `mp`: 1-moment microphysics parameters
 - `tps`: thermodynamics parameters
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
 - `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline conv_q_sno_to_q_vap(::CMP.NoSnowDepositionSublimation, mp, tps, micro, thermo) = zero(thermo.T)
+@inline conv_q_sno_to_q_vap(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
 
-@inline function conv_q_sno_to_q_vap(::CMP.SnowSublimation, mp, tps, micro, thermo)
+@inline function conv_q_sno_to_q_vap(::CMP.SublimationOnly, mp, tps, micro, thermo)
     return min(0, _snow_subl_dep_rate(mp, tps, micro, thermo))
 end
 
-@inline function conv_q_sno_to_q_vap(::CMP.SnowDepositionSublimation, mp, tps, micro, thermo)
+@inline function conv_q_sno_to_q_vap(::CMP.DepositionAndSublimation, mp, tps, micro, thermo)
     return _snow_subl_dep_rate(mp, tps, micro, thermo)
 end
 
@@ -824,24 +791,19 @@ end
 
 
 """
-    conv_q_icl_to_q_lcl(::NoCloudIceMelt, mp, tps, micro, thermo)
+    conv_q_icl_to_q_lcl(::Nothing, mp, tps, micro, thermo)
     conv_q_icl_to_q_lcl(::CloudIceMelt, mp, tps, micro, thermo)
 
 Returns the tendency due to cloud ice melt.
 
-**NoCloudIceMelt**: returns zero (cloud ice melt disabled).
-
-**CloudIceMelt**: melts cloud ice to cloud liquid above freezing,
-parameterized as diffusional growth of ice crystals.
-
 # Arguments
-- `option`: `NoCloudIceMelt()` or `CloudIceMelt()`
+- `opt`: `CloudIceMelt()` or `nothing`
 - `mp`: 1-moment microphysics parameters
 - `tps`: thermodynamics parameters
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
 - `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline conv_q_icl_to_q_lcl(::CMP.NoCloudIceMelt, mp, tps, micro, thermo) = zero(thermo.T)
+@inline conv_q_icl_to_q_lcl(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
 
 @inline function conv_q_icl_to_q_lcl(::CMP.CloudIceMelt, mp, tps, micro, thermo)
     q_icl = micro.q_icl
@@ -862,32 +824,29 @@ parameterized as diffusional growth of ice crystals.
 end
 
 """
-    conv_q_sno_to_q_rai(::NoSnowMelt, mp, tps, micro, thermo)
+    conv_q_sno_to_q_rai(::Nothing, mp, tps, micro, thermo)
     conv_q_sno_to_q_rai(::SnowMelt, mp, tps, micro, thermo)
 
 Returns the tendency due to snow melt.
 
-**NoSnowMelt**: returns zero (snow melt disabled).
-
-**SnowMelt**: melts snow to rain above freezing.
-
 # Arguments
-- `option`: `NoSnowMelt()` or `SnowMelt()`
+- `opt`: `SnowMelt()` or `nothing`
 - `mp`: 1-moment microphysics parameters
 - `tps`: thermodynamics parameters
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
 - `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline conv_q_sno_to_q_rai(::CMP.NoSnowMelt, mp, tps, micro, thermo) = zero(thermo.T)
+@inline conv_q_sno_to_q_rai(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
 
 @inline function conv_q_sno_to_q_rai(::CMP.SnowMelt, mp, tps, micro, thermo)
     q_sno = micro.q_sno
     (; ρ, T) = thermo
-    (; T_freeze, pdf, mass, vent) = mp.precip.snow
+    (; pdf, mass, vent) = mp.precip.snow
     vel = mp.terminal_velocity.snow
     aps = mp.air_properties
     FT = eltype(ρ)
     snow_melt_rate = FT(0)
+    T_freeze = TDI.T_freeze(tps)
 
     if (q_sno > UT.ϵ_numerics(FT) && T > T_freeze)
         (; ν_air, D_vapor, K_therm) = aps

--- a/src/MicrophysicsNonEq.jl
+++ b/src/MicrophysicsNonEq.jl
@@ -22,28 +22,13 @@ export INP_limiter
 export dqcld_dT
 export gamma_helper
 
-const CondEvap = Union{CMP.CloudLiquid, CMP.CondEvap2M}
-const SubDep = Union{CMP.CloudIce, CMP.SubDep2M}
-
 """
-    τ_relax(liquid::CloudLiquid)
-    τ_relax(ice::CloudIce)
+    τ_relax(ice, air_properties, frostenberg, q_icl, T)
 
-Returns the relaxation timescale for phase change processes.
-
-# Arguments
-- `liquid::CloudLiquid` or `ice::CloudIce` - cloud condensate parameters struct
-
-# Returns
-- Relaxation timescale [s] for condensation/evaporation (liquid) or
-  deposition/sublimation (ice)
-
-an option to calculate ice relaxation timescale through
-the Frostenberg et al., (2023). See DOI: 10.5194/acp-23-10883-2023
-parameterization that approximates ice droplet number from temperature.
+Computes the deposition relaxation timescale through
+the Frostenberg et al., (2023) parameterization.
+See DOI: 10.5194/acp-23-10883-2023
 """
-@inline τ_relax(p::CondEvap) = p.τ_relax
-@inline τ_relax(p::SubDep) = p.τ_relax
 @inline function τ_relax(
     (; ρᵢ)::CMP.CloudIce, (; D_vapor)::CMP.AirProperties,
     ip::CMP.Frostenberg2023, q_icl, T,
@@ -51,13 +36,6 @@ parameterization that approximates ice droplet number from temperature.
     FT = eltype(ρᵢ)
     # Get the estimated number of INPs
     N_icl = exp(IN.INP_concentration_mean(ip, T))
-
-    # TODO - edge cases
-    # q_icl is zero, but we still want to compute a timescale
-    # assume some sort of minimal crystal size?
-
-    # q_icl is not zero but N_icl is zero
-    # Get N from q_icl by assuming minimal crystal size
 
     # Compute the radius assuming spherical particles and
     # mono-modal distribution
@@ -111,14 +89,15 @@ Computes the thermodynamic adjustment factor Γ.
 end
 
 """
-    conv_q_vap_to_q_lcl(::ConstantTimescaleCloudLiquidFormation, mp, tps, micro, thermo)
+    conv_q_vap_to_q_lcl(opt::CloudLiquidFormation, mp, tps, micro, thermo)
+    conv_q_vap_to_q_lcl(::Nothing, mp, tps, micro, thermo)
 
 Computes cloud liquid tendency from condensation and evaporation using the formulation from
 Morrison & Grabowski (2008), https://doi.org/10.1175/2007JAS2374.1, and
 Morrison & Milbrandt (2015), https://doi.org/10.1175/JAS-D-14-0065.1.
 
 # Arguments
-- `option`: `ConstantTimescaleCloudLiquidFormation()`
+- `opt`: `CloudLiquidFormation(...)` or `nothing` (disabled)
 - `mp`: 1-moment microphysics parameters
 - `tps`: thermodynamics parameters
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
@@ -127,12 +106,13 @@ Morrison & Milbrandt (2015), https://doi.org/10.1175/JAS-D-14-0065.1.
 # Returns
 - Cloud condensate tendency [kg/kg/s]
 """
+@inline conv_q_vap_to_q_lcl(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
 function conv_q_vap_to_q_lcl(
-    ::CMP.ConstantTimescaleCloudLiquidFormation, mp, tps::TDI.PS, micro, thermo,
+    opt::CMP.CloudLiquidFormation, mp, tps::TDI.PS, micro, thermo,
 )
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
-    τ = τ_relax(mp.cloud.liquid)
+    τ = opt.τ_relax
 
     Rᵥ = TDI.Rᵥ(tps)
     Lᵥ = TDI.Lᵥ(tps, T)
@@ -156,15 +136,16 @@ function conv_q_vap_to_q_lcl(
 end
 
 """
-    conv_q_vap_to_q_icl(::ConstantTimescaleCloudIceFormation, mp, tps, micro, thermo)
-    conv_q_vap_to_q_icl(::TemperatureDependentCloudIceFormation, mp, tps, micro, thermo)
+    conv_q_vap_to_q_icl(opt::ConstantTimescale, mp, tps, micro, thermo)
+    conv_q_vap_to_q_icl(opt::TemperatureDependent, mp, tps, micro, thermo)
+    conv_q_vap_to_q_icl(::Nothing, mp, tps, micro, thermo)
 
 Computes cloud ice tendency from deposition and sublimation using the formulation from
 Morrison & Grabowski (2008), https://doi.org/10.1175/2007JAS2374.1, and
 Morrison & Milbrandt (2015), https://doi.org/10.1175/JAS-D-14-0065.1.
 
 # Arguments
-- `option`: `ConstantTimescaleCloudIceFormation()` or `TemperatureDependentCloudIceFormation()`
+- `opt`: `ConstantTimescale(...)`, `TemperatureDependent(...)`, or `nothing` (disabled)
 - `mp`: 1-moment microphysics parameters
 - `tps`: thermodynamics parameters
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
@@ -173,12 +154,13 @@ Morrison & Milbrandt (2015), https://doi.org/10.1175/JAS-D-14-0065.1.
 # Returns
 - Cloud condensate tendency [kg/kg/s]
 """
+@inline conv_q_vap_to_q_icl(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
 function conv_q_vap_to_q_icl(
-    ::CMP.ConstantTimescaleCloudIceFormation, mp, tps::TDI.PS, micro, thermo,
+    opt::CMP.ConstantTimescale, mp, tps::TDI.PS, micro, thermo,
 )
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
-    τ = τ_relax(mp.cloud.ice)
+    τ = opt.τ_relax
 
     Rᵥ = TDI.Rᵥ(tps)
     Lₛ = TDI.Lₛ(tps, T)
@@ -203,12 +185,12 @@ function conv_q_vap_to_q_icl(
     return ifelse(limiter, zero(tendency), tendency)
 end
 function conv_q_vap_to_q_icl(
-    ::CMP.TemperatureDependentCloudIceFormation, mp, tps::TDI.PS, micro, thermo,
+    opt::CMP.TemperatureDependent, mp, tps::TDI.PS, micro, thermo,
 )
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
-    τ_sub = τ_relax(mp.cloud.ice)
-    τ_dep = τ_relax(mp.cloud.ice, mp.air_properties, mp.frostenberg2023, q_icl, T)
+    τ_sub = opt.τ_relax
+    τ_dep = τ_relax(mp.cloud.ice, mp.air_properties, opt.frostenberg, q_icl, T)
 
     Rᵥ = TDI.Rᵥ(tps)
     Lₛ = TDI.Lₛ(tps, T)

--- a/src/parameters/Microphysics1M.jl
+++ b/src/parameters/Microphysics1M.jl
@@ -1,4 +1,4 @@
-export CloudLiquid, CloudIce, Rain, Snow, CollisionEff, VarTimescaleAcnv
+export CloudLiquid, CloudIce, Rain, Snow, VarTimescaleAcnv
 
 """
     ParticlePDFSnow{FT}
@@ -133,8 +133,6 @@ The parameters and type for cloud liquid water condensate
 $(DocStringExtensions.FIELDS)
 """
 @kwdef struct CloudLiquid{FT} <: CloudCondensateType
-    "condensation evaporation non_equil microphysics relaxation timescale [s]"
-    τ_relax::FT
     "water density [kg/m³]"
     ρw::FT
     "effective radius [m]"
@@ -143,11 +141,10 @@ $(DocStringExtensions.FIELDS)
     N_0::FT
 end
 ShowMethods.field_units(::CloudLiquid) =
-    (; τ_relax = "s", ρw = "kg/m³", r_eff = "m", N_0 = "1/m³")
+    (; ρw = "kg/m³", r_eff = "m", N_0 = "1/m³")
 
 function CloudLiquid(toml_dict::CP.ParamDict)
     name_map = (;
-        :condensation_evaporation_timescale => :τ_relax,
         :density_liquid_water => :ρw,
         :liquid_cloud_effective_radius => :r_eff,
         :cloud_liquid_sedimentation_number_concentration => :N_0,
@@ -157,7 +154,7 @@ function CloudLiquid(toml_dict::CP.ParamDict)
 end
 
 """
-    CloudIce{FT, MS}
+    CloudIce{FT, PD, MS}
 
 The parameters and type for cloud ice condensate
 
@@ -169,12 +166,6 @@ $(DocStringExtensions.FIELDS)
     pdf::PD
     "a struct with mass size relation parameters"
     mass::MS
-    "particle length scale [m]"
-    r0::FT
-    "ice snow threshold radius [m]"
-    r_ice_snow::FT
-    "deposition sublimation non_equil microphysics relaxation timescale [s]"
-    τ_relax::FT
     "cloud ice apparent density [kg/m³]"
     ρᵢ::FT
     "effective radius [m]"
@@ -183,23 +174,19 @@ $(DocStringExtensions.FIELDS)
     N_0::FT
 end
 ShowMethods.field_units(::CloudIce) =
-    (; r0 = "m", r_ice_snow = "m", τ_relax = "s", ρᵢ = "kg/m³", r_eff = "m", N_0 = "1/m³")
+    (; ρᵢ = "kg/m³", r_eff = "m", N_0 = "1/m³")
 
 function CloudIce(toml_dict::CP.ParamDict)
     name_map = (;
         :cloud_ice_apparent_density => :ρᵢ,
-        :cloud_ice_crystals_length_scale => :r0,
         :cloud_ice_size_distribution_coefficient_n0 => :n0,
-        :cloud_ice_mass_size_relation_coefficient_me => :me,
-        :ice_snow_threshold_radius => :r_ice_snow,
-        :sublimation_deposition_timescale => :τ_relax,
         :ice_cloud_effective_radius => :r_eff,
         :cloud_ice_sedimentation_number_concentration => :N_0,
     )
     p = CP.get_parameter_values(toml_dict, name_map, "CloudMicrophysics")
     mass = ParticleMass(CloudIce, toml_dict)
     pdf = ParticlePDFIceRain(p.n0)
-    return CloudIce(; pdf, mass, p.r0, p.r_ice_snow, p.τ_relax, p.ρᵢ, p.r_eff, p.N_0)
+    return CloudIce(; pdf, mass, p.ρᵢ, p.r_eff, p.N_0)
 end
 
 function ParticleMass(::Type{CloudIce}, td::CP.ParamDict)
@@ -217,39 +204,27 @@ function ParticleMass(::Type{CloudIce}, td::CP.ParamDict)
 end
 
 """
-    Rain{FT, MS, AR, VT, AC}
+    Rain{FT, PD, MS, AR, VT}
 
 The parameters and type for rain
 
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-@kwdef struct Rain{FT, PD, MS, AR, VT, AC} <: PrecipitationType
+@kwdef struct Rain{PD, MS, AR, VT} <: PrecipitationType
     "a struct with size distribution parameters"
     pdf::PD
     "a struct with mass size relation parameters"
     mass::MS
-    "a struct with cross section size relation parameers"
+    "a struct with cross section size relation parameters"
     area::AR
     "a struct with ventilation coefficients"
     vent::VT
-    "a struct with cloud water to rain autoconversion parameters"
-    acnv1M::AC
-    "particle length scale [m]"
-    r0::FT
 end
-ShowMethods.field_units(::Rain) = (; r0 = "m")
 
 function Rain(toml_dict::CP.ParamDict)
     name_map = (;
-        :density_liquid_water => :ρ,
-        :rain_drop_length_scale => :r0,
         :rain_drop_size_distribution_coefficient_n0 => :n0,
-        :rain_mass_size_relation_coefficient_me => :me,
-        :rain_cross_section_size_relation_coefficient_ae => :ae,
-        :rain_autoconversion_timescale => :τ,
-        :cloud_liquid_water_specific_humidity_autoconversion_threshold => :q_threshold,
-        :threshold_smooth_transition_steepness => :k,
         :rain_ventilation_coefficient_a => :a,
         :rain_ventilation_coefficient_b => :b,
     )
@@ -259,8 +234,6 @@ function Rain(toml_dict::CP.ParamDict)
         area = ParticleArea(Rain, toml_dict),
         pdf = ParticlePDFIceRain(p.n0),
         vent = Ventilation(p.a, p.b),
-        acnv1M = Acnv1M(p.τ, p.q_threshold, p.k),
-        p.r0,
     )
 end
 
@@ -291,30 +264,24 @@ function ParticleArea(::Type{Rain}, td::CP.ParamDict)
 end
 
 """
-    Snow{FT, PD, MS, AR, VT, AP, AC}
+    Snow{FT, PD, MS, AR, VT, AP}
 
 The parameters and type for snow
 
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-@kwdef struct Snow{FT, PD, MS, AR, VT, AP, AC} <: PrecipitationType
+@kwdef struct Snow{FT, PD, MS, AR, VT, AP} <: PrecipitationType
     "a struct with size distribution parameters"
     pdf::PD
     "a struct with mass size relation parameters"
     mass::MS
-    "a struct with cross section size relation parameers"
+    "a struct with cross section size relation parameters"
     area::AR
     "a struct with ventilation coefficients"
     vent::VT
     "a struct with aspect ratio parameters"
     aspr::AP
-    "a struct with ice to snow autoconversion parameters"
-    acnv1M::AC
-    "particle length scale [m]"
-    r0::FT
-    "freezing temperature of water [K]"
-    T_freeze::FT
     "snow apparent density [kg/m3]"
     ρᵢ::FT
     "pre-computed gamma(α+4)/6 for oblate aspect ratio [-]"
@@ -325,12 +292,7 @@ end
 
 function Snow(toml_dict::CP.ParamDict)
     name_map = (;
-        :cloud_ice_crystals_length_scale => :r0,
         :snow_apparent_density => :ρᵢ,
-        :snow_autoconversion_timescale => :τ,
-        :cloud_ice_specific_humidity_autoconversion_threshold => :q_threshold,
-        :threshold_smooth_transition_steepness => :k,
-        :temperature_water_freeze => :T_freeze,
         :snow_flake_size_distribution_coefficient_mu => :μ,
         :snow_flake_size_distribution_coefficient_nu => :ν,
         :snow_ventilation_coefficient_a => :a,
@@ -356,8 +318,7 @@ function Snow(toml_dict::CP.ParamDict)
         area,
         vent = Ventilation(p.a, p.b),
         aspr = SnowAspectRatio(p.ϕ, p.κ),
-        acnv1M = Acnv1M(p.τ, p.q_threshold, p.k),
-        p.r0, p.T_freeze, p.ρᵢ,
+        p.ρᵢ,
         gamma_aspect_oblate = SF.gamma(α_oblate + 4) / SF.gamma(FT(4)),
         gamma_aspect_prolate = SF.gamma(α_prolate + 4) / SF.gamma(FT(4)),
     )
@@ -389,41 +350,7 @@ function ParticleArea(::Type{Snow}, toml_dict::CP.ParamDict)
     return ParticleArea(; a0, p.ae, p.Δa, p.χa)
 end
 
-"""
-    CollisionEff{FT}
 
-Collision efficiency parameters for the 1-moment scheme
-
-# Fields
-$(DocStringExtensions.FIELDS)
-"""
-@kwdef struct CollisionEff{FT} <: ParametersType
-    "cloud liquid-rain collision efficiency [-]"
-    e_lcl_rai::FT
-    "cloud liquid-snow collision efficiency [-]"
-    e_lcl_sno::FT
-    "cloud ice-rain collision efficiency [-]"
-    e_icl_rai::FT
-    "cloud ice-snow collision efficiency [-]"
-    e_icl_sno::FT
-    "rain-snow collision efficiency [-]"
-    e_rai_sno::FT
-    "rain-snow velocity dispersion coefficient [-]"
-    coeff_disp::FT
-end
-
-function CollisionEff(td::CP.ParamDict)
-    name_map = (;
-        :cloud_liquid_rain_collision_efficiency => :e_lcl_rai,
-        :cloud_liquid_snow_collision_efficiency => :e_lcl_sno,
-        :cloud_ice_rain_collision_efficiency => :e_icl_rai,
-        :cloud_ice_snow_collision_efficiency => :e_icl_sno,
-        :rain_snow_collision_efficiency => :e_rai_sno,
-        :rain_snow_velocity_dispersion_coefficient => :coeff_disp,
-    )
-    parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
-    return CollisionEff(; parameters...)
-end
 
 """
     VarTimescaleAcnv{FT}

--- a/src/parameters/Microphysics1MOptions.jl
+++ b/src/parameters/Microphysics1MOptions.jl
@@ -1,35 +1,27 @@
 export Microphysics1MOptions,
     MicrophysicsOption,
-    NoCloudLiquidFormation,
-    ConstantTimescaleCloudLiquidFormation,
-    NoCloudIceFormation,
-    ConstantTimescaleCloudIceFormation,
-    TemperatureDependentCloudIceFormation,
-    NoCloudIceMelt,
+    CloudLiquidFormation,
+    CloudIceFormation,
+    ConstantTimescale,
+    TemperatureDependent,
     CloudIceMelt,
-    NoRainAutoconversion,
-    RainAutoconversion1M,
-    RainAutoconversionPrescribedNd,
-    NoSnowAutoconversion,
-    SnowAutoconversionNoSupersaturation,
-    SnowAutoconversionWithSupersaturation,
-    NoRainCondensationEvaporation,
+    RainAutoconversion,
+    Kessler1M,
+    PrescribedNd,
+    SnowAutoconversion,
+    NoSupersaturation,
+    WithSupersaturation,
     RainEvaporation,
-    NoSnowDepositionSublimation,
-    SnowSublimation,
     SnowDepositionSublimation,
-    NoSnowMelt,
+    SublimationOnly,
+    DepositionAndSublimation,
     SnowMelt,
-    NoCloudLiquidRainAccretion,
     CloudLiquidRainAccretion,
-    NoCloudLiquidSnowAccretion,
     CloudLiquidSnowAccretion,
-    NoCloudIceRainAccretion,
     CloudIceRainAccretion,
-    NoCloudIceSnowAccretion,
     CloudIceSnowAccretion,
-    NoRainSnowAccretion,
     RainSnowAccretion
+
 """
     MicrophysicsOption
 
@@ -37,107 +29,340 @@ Abstract type for all microphysics process options.
 """
 abstract type MicrophysicsOption end
 
-"""No cloud liquid condensation/evaporation."""
-struct NoCloudLiquidFormation <: MicrophysicsOption end
+# ═══════════════════════════════════════════════════════════════════
+# Multi-variant processes: abstract type + concrete subtypes
+# ═══════════════════════════════════════════════════════════════════
 
-"""Use a constant relaxation timescale for liquid condensation and evaporation."""
-struct ConstantTimescaleCloudLiquidFormation <: MicrophysicsOption end
+"""
+    CloudIceFormation <: MicrophysicsOption
 
-"""No cloud ice deposition/sublimation."""
-struct NoCloudIceFormation <: MicrophysicsOption end
+Abstract type for cloud ice formation (deposition/sublimation) methods.
+See subtypes: [`ConstantTimescale`](@ref), [`TemperatureDependent`](@ref).
+"""
+abstract type CloudIceFormation <: MicrophysicsOption end
 
-"""Use a constant relaxation timescale for ice deposition and sublimation."""
-struct ConstantTimescaleCloudIceFormation <: MicrophysicsOption end
+"""
+    RainAutoconversion <: MicrophysicsOption
 
-"""Use the INP-dependent Frostenberg (2023) timescale for deposition,
-   with constant timescale for sublimation."""
-struct TemperatureDependentCloudIceFormation <: MicrophysicsOption end
+Abstract type for rain autoconversion methods.
+See subtypes: [`Kessler1M`](@ref), [`PrescribedNd`](@ref).
+"""
+abstract type RainAutoconversion <: MicrophysicsOption end
 
-"""No cloud ice melting process."""
-struct NoCloudIceMelt <: MicrophysicsOption end
+"""
+    SnowAutoconversion <: MicrophysicsOption
 
-"""Cloud ice melts to cloud liquid above freezing."""
-struct CloudIceMelt <: MicrophysicsOption end
+Abstract type for snow autoconversion methods.
+See subtypes: [`NoSupersaturation`](@ref), [`WithSupersaturation`](@ref).
+"""
+abstract type SnowAutoconversion <: MicrophysicsOption end
 
-"""No rain autoconversion."""
-struct NoRainAutoconversion <: MicrophysicsOption end
+"""
+    SnowDepositionSublimation <: MicrophysicsOption
 
-"""1-moment Kessler autoconversion of cloud liquid to rain."""
-struct RainAutoconversion1M <: MicrophysicsOption end
+Abstract type for snow deposition/sublimation methods.
+See subtypes: [`SublimationOnly`](@ref), [`DepositionAndSublimation`](@ref).
+"""
+abstract type SnowDepositionSublimation <: MicrophysicsOption end
 
-"""Variable-timescale 2-moment autoconversion (uses prescribed Nc)."""
-struct RainAutoconversionPrescribedNd <: MicrophysicsOption end
+# ═══════════════════════════════════════════════════════════════════
+# Cloud liquid formation (single variant → concrete type = process name)
+# ═══════════════════════════════════════════════════════════════════
 
-"""No snow autoconversion."""
-struct NoSnowAutoconversion <: MicrophysicsOption end
+"""
+    CloudLiquidFormation{FT} <: MicrophysicsOption
 
-"""Simplified autoconversion without supersaturation dependence."""
-struct SnowAutoconversionNoSupersaturation <: MicrophysicsOption end
+Constant relaxation timescale for liquid condensation and evaporation.
 
-"""Harrington/Kaul autoconversion with supersaturation dependence."""
-struct SnowAutoconversionWithSupersaturation <: MicrophysicsOption end
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct CloudLiquidFormation{FT} <: MicrophysicsOption
+    "condensation/evaporation non-equilibrium relaxation timescale [s]"
+    τ_relax::FT
+end
 
-"""No rain condensation/evaporation."""
-struct NoRainCondensationEvaporation <: MicrophysicsOption end
+function CloudLiquidFormation(td::CP.ParamDict)
+    name_map = (; :condensation_evaporation_timescale => :τ_relax)
+    p = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    return CloudLiquidFormation(p.τ_relax)
+end
+
+# ═══════════════════════════════════════════════════════════════════
+# Cloud ice formation variants
+# ═══════════════════════════════════════════════════════════════════
+
+"""
+    ConstantTimescale{FT} <: CloudIceFormation
+
+Constant relaxation timescale for ice deposition and sublimation.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct ConstantTimescale{FT} <: CloudIceFormation
+    "deposition/sublimation non-equilibrium relaxation timescale [s]"
+    τ_relax::FT
+end
+
+function ConstantTimescale(td::CP.ParamDict)
+    name_map = (; :sublimation_deposition_timescale => :τ_relax)
+    p = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    return ConstantTimescale(p.τ_relax)
+end
+
+"""
+    TemperatureDependent{FT, FR} <: CloudIceFormation
+
+INP-dependent Frostenberg (2023) timescale for deposition,
+with constant timescale for sublimation.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct TemperatureDependent{FT, FR} <: CloudIceFormation
+    "sublimation arm: constant relaxation timescale [s]"
+    τ_relax::FT
+    "Frostenberg (2023) INP parameters for deposition"
+    frostenberg::FR
+end
+
+function TemperatureDependent(td::CP.ParamDict)
+    name_map = (; :sublimation_deposition_timescale => :τ_relax)
+    p = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    return TemperatureDependent(p.τ_relax, Frostenberg2023(td))
+end
+
+# ═══════════════════════════════════════════════════════════════════
+# Rain autoconversion variants
+# ═══════════════════════════════════════════════════════════════════
+
+"""
+    Kessler1M{AC} <: RainAutoconversion
+
+1-moment Kessler autoconversion of cloud liquid to rain.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct Kessler1M{AC} <: RainAutoconversion
+    "autoconversion parameters (τ, q_threshold, k)"
+    acnv1M::AC
+end
+
+function Kessler1M(td::CP.ParamDict)
+    name_map = (;
+        :rain_autoconversion_timescale => :τ,
+        :cloud_liquid_water_specific_humidity_autoconversion_threshold => :q_threshold,
+        :threshold_smooth_transition_steepness => :k,
+    )
+    p = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    return Kessler1M(Acnv1M(p.τ, p.q_threshold, p.k))
+end
+
+"""
+    PrescribedNd{VA} <: RainAutoconversion
+
+Variable-timescale autoconversion using prescribed cloud droplet number Nc.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct PrescribedNd{VA} <: RainAutoconversion
+    "variable-timescale autoconversion parameters (τ, α, Nc)"
+    autoconv::VA
+end
+
+function PrescribedNd(td::CP.ParamDict)
+    return PrescribedNd(VarTimescaleAcnv(td))
+end
+
+# ═══════════════════════════════════════════════════════════════════
+# Snow autoconversion variants
+# ═══════════════════════════════════════════════════════════════════
+
+"""
+    NoSupersaturation{AC} <: SnowAutoconversion
+
+Simplified autoconversion of cloud ice to snow without supersaturation dependence.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct NoSupersaturation{AC} <: SnowAutoconversion
+    "autoconversion parameters (τ, q_threshold, k)"
+    acnv1M::AC
+end
+
+function NoSupersaturation(td::CP.ParamDict)
+    name_map = (;
+        :snow_autoconversion_timescale => :τ,
+        :cloud_ice_specific_humidity_autoconversion_threshold => :q_threshold,
+        :threshold_smooth_transition_steepness => :k,
+    )
+    p = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    return NoSupersaturation(Acnv1M(p.τ, p.q_threshold, p.k))
+end
+
+"""
+    WithSupersaturation{FT} <: SnowAutoconversion
+
+Harrington/Kaul autoconversion of cloud ice to snow with supersaturation dependence.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct WithSupersaturation{FT} <: SnowAutoconversion
+    "ice-snow threshold radius [m]"
+    r_ice_snow::FT
+end
+
+function WithSupersaturation(td::CP.ParamDict)
+    name_map = (; :ice_snow_threshold_radius => :r_ice_snow)
+    p = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    return WithSupersaturation(p.r_ice_snow)
+end
+
+# ═══════════════════════════════════════════════════════════════════
+# Accretion (single variant each → concrete type = process name)
+# ═══════════════════════════════════════════════════════════════════
+
+"""
+    CloudLiquidRainAccretion{FT} <: MicrophysicsOption
+
+Cloud liquid + rain → rain (Marshall-Palmer kernel).
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct CloudLiquidRainAccretion{FT} <: MicrophysicsOption
+    "collision efficiency [-]"
+    e::FT
+end
+
+function CloudLiquidRainAccretion(td::CP.ParamDict)
+    name_map = (; :cloud_liquid_rain_collision_efficiency => :e)
+    p = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    return CloudLiquidRainAccretion(p.e)
+end
+
+"""
+    CloudLiquidSnowAccretion{FT} <: MicrophysicsOption
+
+Cloud liquid + snow → snow/rain depending on temperature
+(includes warm-rain melt contribution).
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct CloudLiquidSnowAccretion{FT} <: MicrophysicsOption
+    "collision efficiency [-]"
+    e::FT
+end
+
+function CloudLiquidSnowAccretion(td::CP.ParamDict)
+    name_map = (; :cloud_liquid_snow_collision_efficiency => :e)
+    p = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    return CloudLiquidSnowAccretion(p.e)
+end
+
+"""
+    CloudIceRainAccretion{FT} <: MicrophysicsOption
+
+Cloud ice + rain → snow (Marshall-Palmer kernel).
+The coupled rain-sink arm (rain + cloud ice → snow) is toggled automatically.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct CloudIceRainAccretion{FT} <: MicrophysicsOption
+    "collision efficiency [-]"
+    e::FT
+end
+
+function CloudIceRainAccretion(td::CP.ParamDict)
+    name_map = (; :cloud_ice_rain_collision_efficiency => :e)
+    p = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    return CloudIceRainAccretion(p.e)
+end
+
+"""
+    CloudIceSnowAccretion{FT} <: MicrophysicsOption
+
+Cloud ice + snow → snow (Marshall-Palmer kernel).
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct CloudIceSnowAccretion{FT} <: MicrophysicsOption
+    "collision efficiency [-]"
+    e::FT
+end
+
+function CloudIceSnowAccretion(td::CP.ParamDict)
+    name_map = (; :cloud_ice_snow_collision_efficiency => :e)
+    p = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    return CloudIceSnowAccretion(p.e)
+end
+
+"""
+    RainSnowAccretion{FT} <: MicrophysicsOption
+
+Snow-rain collisions: both temperature pathways
+(cold: rain→snow, warm: snow→rain) plus thermal melt.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct RainSnowAccretion{FT} <: MicrophysicsOption
+    "collision efficiency [-]"
+    e::FT
+    "velocity dispersion coefficient [-]"
+    coeff_disp::FT
+end
+
+function RainSnowAccretion(td::CP.ParamDict)
+    name_map = (;
+        :rain_snow_collision_efficiency => :e,
+        :rain_snow_velocity_dispersion_coefficient => :coeff_disp,
+    )
+    p = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
+    return RainSnowAccretion(p.e, p.coeff_disp)
+end
+
+# ═══════════════════════════════════════════════════════════════════
+# Snow deposition/sublimation variants
+# ═══════════════════════════════════════════════════════════════════
+
+"""Only sublimation (S < 0 over ice); deposition handled separately by non-equilibrium."""
+struct SublimationOnly <: SnowDepositionSublimation end
+
+"""Both sublimation (S < 0) and deposition (S > 0) in the Marshall-Palmer integral."""
+struct DepositionAndSublimation <: SnowDepositionSublimation end
+
+# ═══════════════════════════════════════════════════════════════════
+# Single-variant on/off processes (concrete type = process name)
+# ═══════════════════════════════════════════════════════════════════
 
 """Rain evaporation (sub-saturated conditions over liquid)."""
 struct RainEvaporation <: MicrophysicsOption end
 
-"""No snow deposition or sublimation."""
-struct NoSnowDepositionSublimation <: MicrophysicsOption end
-
-"""Only sublimation (S < 0 over ice); deposition handled separately by non-equilibrium."""
-struct SnowSublimation <: MicrophysicsOption end
-
-"""Both sublimation (S < 0) and deposition (S > 0) in the Marshall-Palmer integral."""
-struct SnowDepositionSublimation <: MicrophysicsOption end
-
-"""No snow melting."""
-struct NoSnowMelt <: MicrophysicsOption end
+"""Cloud ice melts to cloud liquid above freezing."""
+struct CloudIceMelt <: MicrophysicsOption end
 
 """Snow melts to rain above freezing."""
 struct SnowMelt <: MicrophysicsOption end
 
-"""No cloud liquid + rain accretion."""
-struct NoCloudLiquidRainAccretion <: MicrophysicsOption end
-
-"""Cloud liquid + rain → rain (Marshall-Palmer kernel).
-Also triggers the coupled rain-sink arm of cloud ice + rain collisions."""
-struct CloudLiquidRainAccretion <: MicrophysicsOption end
-
-"""No cloud liquid + snow accretion."""
-struct NoCloudLiquidSnowAccretion <: MicrophysicsOption end
-
-"""Cloud liquid + snow → snow/rain depending on temperature (includes warm-rain melt contribution)."""
-struct CloudLiquidSnowAccretion <: MicrophysicsOption end
-
-"""No cloud ice + rain accretion."""
-struct NoCloudIceRainAccretion <: MicrophysicsOption end
-
-"""Cloud ice + rain → snow (Marshall-Palmer kernel).
-The coupled rain-sink arm (rain + cloud ice → snow) is toggled automatically."""
-struct CloudIceRainAccretion <: MicrophysicsOption end
-
-"""No cloud ice + snow accretion."""
-struct NoCloudIceSnowAccretion <: MicrophysicsOption end
-
-"""Cloud ice + snow → snow (Marshall-Palmer kernel)."""
-struct CloudIceSnowAccretion <: MicrophysicsOption end
-
-"""No rain-snow collisions."""
-struct NoRainSnowAccretion <: MicrophysicsOption end
-
-"""Snow-rain collisions: both temperature pathways (cold: rai→sno, warm: sno→rai) plus thermal melt."""
-struct RainSnowAccretion <: MicrophysicsOption end
+# ═══════════════════════════════════════════════════════════════════
+# Options struct
+# ═══════════════════════════════════════════════════════════════════
 
 """
     Microphysics1MOptions{CLF, CIF, CIM, RA, SA, RCE, SDS, SM, CLRA, CLSA, CIRA, CISA, RSA}
 
 Process configuration for 1-moment microphysics.
 Each field selects a variant for one microphysical process.
-The `No*` variants disable a process entirely (return zero tendency).
-
-Defaults match the baseline (old main branch) behavior.
+Set a field to `nothing` to disable the process entirely.
 
 # Fields
 $(DocStringExtensions.FIELDS)
@@ -146,61 +371,68 @@ $(DocStringExtensions.FIELDS)
 ```julia
 using CloudMicrophysics.Parameters as CMP
 
-# Default (baseline) options:
-opts = CMP.Microphysics1MOptions()
+# Default options require TOML dict for parametric types
+(i.e. for populating the free parameter values)
+opts = CMP.Microphysics1MOptions(toml_dict)
 
-# Disable all accretion, enable INP-dependent ice and cloud ice melt:
-opts = CMP.Microphysics1MOptions(
-    cloud_ice_formation           = CMP.TemperatureDependentCloudIceFormation(),
-    cloud_ice_melt                = CMP.CloudIceMelt(),
-    cloud_liquid_rain_accretion   = CMP.NoCloudLiquidRainAccretion(),
-    cloud_liquid_snow_accretion   = CMP.NoCloudLiquidSnowAccretion(),
-    cloud_ice_rain_accretion      = CMP.NoCloudIceRainAccretion(),
-    cloud_ice_snow_accretion      = CMP.NoCloudIceSnowAccretion(),
-    rain_snow_accretion           = CMP.NoRainSnowAccretion(),
-    snow_deposition_sublimation   = CMP.SnowDepositionSublimation(),
+# Disable cloud ice melt and snow melt:
+opts = CMP.Microphysics1MOptions(toml_dict;
+    cloud_ice_melt = nothing,
+    snow_melt = nothing,
 )
 ```
 """
-@kwdef struct Microphysics1MOptions{
-    CLF <: MicrophysicsOption,
-    CIF <: MicrophysicsOption,
-    CIM <: MicrophysicsOption,
-    RA <: MicrophysicsOption,
-    SA <: MicrophysicsOption,
-    RCE <: MicrophysicsOption,
-    SDS <: MicrophysicsOption,
-    SM <: MicrophysicsOption,
-    CLRA <: MicrophysicsOption,
-    CLSA <: MicrophysicsOption,
-    CIRA <: MicrophysicsOption,
-    CISA <: MicrophysicsOption,
-    RSA <: MicrophysicsOption,
-} <: ParametersType
-    "cloud liquid formation timescale option"
-    cloud_liquid_formation::CLF = ConstantTimescaleCloudLiquidFormation()
-    "cloud ice formation timescale option"
-    cloud_ice_formation::CIF = ConstantTimescaleCloudIceFormation()
+@kwdef struct Microphysics1MOptions{CLF, CIF, CIM, RA, SA, RCE, SDS, SM, CLRA, CLSA, CIRA, CISA, RSA}
+    "cloud liquid formation option"
+    cloud_liquid_formation::CLF
+    "cloud ice formation option"
+    cloud_ice_formation::CIF
     "cloud ice melting option"
-    cloud_ice_melt::CIM = CloudIceMelt()
+    cloud_ice_melt::CIM
     "rain autoconversion option"
-    rain_autoconversion::RA = RainAutoconversion1M()
+    rain_autoconversion::RA
     "cloud ice to snow autoconversion option"
-    snow_autoconversion::SA = SnowAutoconversionNoSupersaturation()
+    snow_autoconversion::SA
     "rain condensation/evaporation option"
-    rain_condensation_evaporation::RCE = RainEvaporation()
+    rain_condensation_evaporation::RCE
     "snow sublimation/deposition option"
-    snow_deposition_sublimation::SDS = SnowDepositionSublimation()
+    snow_deposition_sublimation::SDS
     "snow melting option"
-    snow_melt::SM = SnowMelt()
+    snow_melt::SM
     "cloud liquid + rain accretion option"
-    cloud_liquid_rain_accretion::CLRA = CloudLiquidRainAccretion()
+    cloud_liquid_rain_accretion::CLRA
     "cloud liquid + snow accretion option"
-    cloud_liquid_snow_accretion::CLSA = CloudLiquidSnowAccretion()
+    cloud_liquid_snow_accretion::CLSA
     "cloud ice + rain accretion option (also toggles rain sink arm)"
-    cloud_ice_rain_accretion::CIRA = CloudIceRainAccretion()
+    cloud_ice_rain_accretion::CIRA
     "cloud ice + snow accretion option"
-    cloud_ice_snow_accretion::CISA = CloudIceSnowAccretion()
+    cloud_ice_snow_accretion::CISA
     "rain-snow collisions option"
-    rain_snow_accretion::RSA = RainSnowAccretion()
+    rain_snow_accretion::RSA
+end
+
+"""
+    Microphysics1MOptions(toml_dict::CP.ParamDict; kwargs...)
+
+Create a `Microphysics1MOptions` with default options and their parameters populated
+from the TOML dictionary. Override individual options via keyword arguments.
+"""
+function Microphysics1MOptions(toml_dict::CP.ParamDict; kwargs...)
+    defaults = (;
+        cloud_liquid_formation = CloudLiquidFormation(toml_dict),
+        cloud_ice_formation = ConstantTimescale(toml_dict),
+        cloud_ice_melt = CloudIceMelt(),
+        rain_autoconversion = Kessler1M(toml_dict),
+        snow_autoconversion = NoSupersaturation(toml_dict),
+        rain_condensation_evaporation = RainEvaporation(),
+        snow_deposition_sublimation = DepositionAndSublimation(),
+        snow_melt = SnowMelt(),
+        cloud_liquid_rain_accretion = CloudLiquidRainAccretion(toml_dict),
+        cloud_liquid_snow_accretion = CloudLiquidSnowAccretion(toml_dict),
+        cloud_ice_rain_accretion = CloudIceRainAccretion(toml_dict),
+        cloud_ice_snow_accretion = CloudIceSnowAccretion(toml_dict),
+        rain_snow_accretion = RainSnowAccretion(toml_dict),
+    )
+    merged = merge(defaults, NamedTuple(kwargs))
+    return Microphysics1MOptions(; merged...)
 end

--- a/src/parameters/Microphysics1MParams.jl
+++ b/src/parameters/Microphysics1MParams.jl
@@ -1,7 +1,7 @@
 export Microphysics1MParams, CloudPhaseParams1M, PrecipPhaseParams1M
 
 """
-    CloudPhaseParams1M{FT, LCL, ICL}
+    CloudPhaseParams1M{LCL, ICL}
 
 Parameters for cloud-phase (non-precipitating) hydrometeors in 1-moment scheme.
 
@@ -18,13 +18,13 @@ Base.show(io::IO, mime::MIME"text/plain", x::CloudPhaseParams1M) =
     ShowMethods.verbose_show_type_and_fields(io, mime, x)
 
 """
-    PrecipPhaseParams1M{FT, RAI, SNO}
+    PrecipPhaseParams1M{RAI, SNO}
 
 Parameters for precipitating hydrometeors in 1-moment scheme.
 
 # Fields
-- `rain::RAI`: Rain — rain parameters (includes autoconversion)
-- `snow::SNO`: Snow — snow parameters (includes autoconversion)
+- `rain::RAI`: Rain — rain parameters
+- `snow::SNO`: Snow — snow parameters
 """
 @kwdef struct PrecipPhaseParams1M{RAI, SNO} <: ParametersType
     rain::RAI
@@ -35,28 +35,29 @@ Base.show(io::IO, mime::MIME"text/plain", x::PrecipPhaseParams1M) =
     ShowMethods.verbose_show_type_and_fields(io, mime, x)
 
 """
-    Microphysics1MParams{OPT, CP, PP, CE, AP, VL, VA, FR}
+    Microphysics1MParams{OPT, CP, PP, AP, VL}
 
 Unified parameter container for 1-moment bulk microphysics.
 
+Process-specific parameters (relaxation timescales, autoconversion thresholds,
+collision efficiencies) live inside the option types in `options`.
+Shared parameters (particle size distributions, air properties, terminal velocities)
+are stored directly.
+
 # Fields
-- `options::OPT`: Microphysics1MOptions — process configuration (selects parameterization variants)
+- `options::OPT`: Microphysics1MOptions — process configuration (carries process-specific parameters)
 - `cloud::CP`: CloudPhaseParams1M — cloud liquid and ice parameters
 - `precip::PP`: PrecipPhaseParams1M — rain and snow parameters
-- `collision::CE`: CollisionEff — collision efficiencies between species
 - `air_properties::AP`: AirProperties — air properties (diffusivities, thermal conductivity)
 - `terminal_velocity::VL`: Blk1MVelType — terminal velocity parameters for rain and snow
-- `autoconv_2M::VA`: VarTimescaleAcnv or Nothing — 2M autoconversion parameters including prescribed Nc (built when `RainAutoconversionPrescribedNd` is selected)
-- `frostenberg2023::FR`: Frostenberg 2023 INP parameters or Nothing (built when `INPDependentIceFormation` is selected)
 
 # Constructors
 
-    Microphysics1MParams(::Type{FT}; options = Microphysics1MOptions())
-    Microphysics1MParams(toml_dict::CP.ParamDict; options = Microphysics1MOptions())
+    Microphysics1MParams(::Type{FT}; options_kwargs...)
+    Microphysics1MParams(toml_dict::CP.ParamDict; options_kwargs...)
 
 Create a `Microphysics1MParams` from a float type or a ClimaParams TOML dictionary.
-The `options` keyword argument selects parameterization variants; sub-parameters
-(`autoconv_2M`, `frostenberg2023`) are conditionally built based on the chosen options.
+Pass keyword arguments to override individual options.
 
 # Example
 ```julia
@@ -65,72 +66,44 @@ using CloudMicrophysics.Parameters as CMP
 # Create 1M parameters with default (baseline) settings
 mp = CMP.Microphysics1MParams(Float64)
 
-# Create with INP-dependent ice formation and cloud ice melt
+# Create with temperature-dependent ice formation and cloud ice melt disabled
 mp = CMP.Microphysics1MParams(Float64;
-    options = CMP.Microphysics1MOptions(
-        cloud_ice_formation  = CMP.TemperatureDependentCloudIceFormation(),
-        cloud_ice_melt = CMP.CloudIceMelt(),
-    ),
-)
-
-# Create with 2M autoconversion
-mp = CMP.Microphysics1MParams(Float64;
-    options = CMP.Microphysics1MOptions(
-        rain_autoconversion = CMP.RainAutoconversionPrescribedNd(),
-    ),
+    cloud_ice_formation = CMP.TemperatureDependent(toml_dict),
+    cloud_ice_melt = nothing,
 )
 ```
 """
-@kwdef struct Microphysics1MParams{OPT, CP, PP, CE, AP, VL, VA, FR} <: ParametersType
+@kwdef struct Microphysics1MParams{OPT, CP, PP, AP, VL} <: ParametersType
     options::OPT
     cloud::CP
     precip::PP
-    collision::CE
     air_properties::AP
     terminal_velocity::VL
-    autoconv_2M::VA
-    frostenberg2023::FR
 end
 Base.show(io::IO, mime::MIME"text/plain", x::Microphysics1MParams) =
     ShowMethods.verbose_show_type_and_fields(io, mime, x)
 
 """
-    Microphysics1MParams(toml_dict::CP.ParamDict; options = Microphysics1MOptions())
+    Microphysics1MParams(toml_dict::CP.ParamDict; options_kwargs...)
 
 Create a `Microphysics1MParams` object from a ClimaParams TOML dictionary.
 
 # Arguments
 - `toml_dict`: ClimaParams parameter dictionary
-- `options`: Process configuration (default: baseline behavior)
+- `options_kwargs...`: Keyword arguments forwarded to `Microphysics1MOptions`
 """
-function Microphysics1MParams(toml_dict::CP.ParamDict; options = Microphysics1MOptions())
-    # Conditional construction driven by options
-    autoconv_2M =
-        options.rain_autoconversion isa RainAutoconversionPrescribedNd ?
-        VarTimescaleAcnv(toml_dict) : nothing
-    frostenberg2023 =
-        options.cloud_ice_formation isa TemperatureDependentCloudIceFormation ?
-        Frostenberg2023(toml_dict) : nothing
-
+function Microphysics1MParams(toml_dict::CP.ParamDict; options_kwargs...)
     return Microphysics1MParams(;
-        # Process options
-        options,
-        # Cloud phase parameters
+        options = Microphysics1MOptions(toml_dict; options_kwargs...),
         cloud = CloudPhaseParams1M(;
             liquid = CloudLiquid(toml_dict),
             ice = CloudIce(toml_dict),
         ),
-        # Precipitation phase parameters
         precip = PrecipPhaseParams1M(;
             rain = Rain(toml_dict),
             snow = Snow(toml_dict),
         ),
-        # Shared physics parameters
-        collision = CollisionEff(toml_dict),
         air_properties = AirProperties(toml_dict),
         terminal_velocity = Blk1MVelType(toml_dict),
-        # Conditionally built parameters
-        autoconv_2M,
-        frostenberg2023,
     )
 end

--- a/test/bulk_tendencies_tests.jl
+++ b/test/bulk_tendencies_tests.jl
@@ -129,7 +129,7 @@ function test_bulk_microphysics_1m_tendencies(FT)
     ice = mp.cloud.ice
     rain = mp.precip.rain
     snow = mp.precip.snow
-    ce = mp.collision
+    E_lcl_sno = mp.options.cloud_liquid_snow_accretion.e
     aps = mp.air_properties
     vel = mp.terminal_velocity
 
@@ -224,7 +224,7 @@ function test_bulk_microphysics_1m_tendencies(FT)
         # Compute autoconversion separately using the same option-dispatched function
         micro_acnv = (; q_tot, q_lcl, q_icl, q_rai, q_sno)
         thermo_acnv = (; ρ, T)
-        S_acnv_lcl = CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversion1M(), mp, tps, micro_acnv, thermo_acnv)
+        S_acnv_lcl = CM1.conv_q_lcl_to_q_rai(mp.options.rain_autoconversion, mp, tps, micro_acnv, thermo_acnv)
 
         # Rain tendency should be positive and include autoconversion
         @test tendencies.dq_rai_dt > FT(0)
@@ -235,11 +235,9 @@ function test_bulk_microphysics_1m_tendencies(FT)
 
     @testset "BulkMicrophysicsTendencies - Autoconversion component (PrescribedNd)" begin
         # Same check as above but using the variable-timescale 2M autoconversion option
-        # (RainAutoconversionPrescribedNd), which uses mp.autoconv_2M.{τ,α,Nc}.
+        # (PrescribedNd), which uses the prescribed {τ,α,Nc}.
         mp_2m = CMP.Microphysics1MParams(FT;
-            options = CMP.Microphysics1MOptions(
-                rain_autoconversion = CMP.RainAutoconversionPrescribedNd(),
-            ),
+            rain_autoconversion = CMP.PrescribedNd(CP.create_toml_dict(FT)),
         )
 
         ρ = FT(1.2)
@@ -259,7 +257,7 @@ function test_bulk_microphysics_1m_tendencies(FT)
         # Compute autoconversion separately using the option-dispatched function
         micro_acnv = (; q_tot, q_lcl, q_icl, q_rai, q_sno)
         thermo_acnv = (; ρ, T)
-        S_acnv_2m = CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversionPrescribedNd(), mp_2m, tps, micro_acnv, thermo_acnv)
+        S_acnv_2m = CM1.conv_q_lcl_to_q_rai(mp_2m.options.rain_autoconversion, mp_2m, tps, micro_acnv, thermo_acnv)
 
         # Rain tendency should be positive and dominated by autoconversion
         @test tendencies_2m.dq_rai_dt > FT(0)
@@ -330,7 +328,7 @@ function test_bulk_microphysics_1m_tendencies(FT)
 
         # Verify accretion is happening by checking snow growth
         # (cloud liquid tendency may be positive overall due to condensation)
-        S_accr = CM1.accretion(liquid, snow, vel.snow, ce, q_lcl, q_sno, ρ)
+        S_accr = CM1.accretion(liquid, snow, vel.snow, E_lcl_sno, q_lcl, q_sno, ρ)
         @test S_accr > FT(0)  # Accretion is occurring
 
         # Snow should increase (riming + deposition)
@@ -356,7 +354,7 @@ function test_bulk_microphysics_1m_tendencies(FT)
         )
 
         # Verify accretion is happening
-        S_accr = CM1.accretion(liquid, snow, vel.snow, ce, q_lcl, q_sno, ρ)
+        S_accr = CM1.accretion(liquid, snow, vel.snow, E_lcl_sno, q_lcl, q_sno, ρ)
         @test S_accr > FT(0)  # Accretion is occurring
 
         # Rain should increase (from accretion + snow melt)
@@ -587,11 +585,11 @@ function test_bulk_microphysics_1m_tendencies(FT)
         )
 
         # Calculate individual components
-        S_accr = CM1.accretion(liquid, snow, vel.snow, ce, q_lcl, q_sno, ρ)
+        S_accr = CM1.accretion(liquid, snow, vel.snow, E_lcl_sno, q_lcl, q_sno, ρ)
         micro_s = (; q_tot, q_lcl, q_icl = FT(0), q_rai = FT(0), q_sno)
         thermo_s = (; ρ, T)
         S_melt = CM1.conv_q_sno_to_q_rai(CMP.SnowMelt(), mp, tps, micro_s, thermo_s)
-        S_subl = CM1.conv_q_sno_to_q_vap(CMP.SnowDepositionSublimation(), mp, tps, micro_s, thermo_s)
+        S_subl = CM1.conv_q_sno_to_q_vap(CMP.DepositionAndSublimation(), mp, tps, micro_s, thermo_s)
 
         # Calculate α
         T_frz = TDI.T_freeze(tps)

--- a/test/common_types_tests.jl
+++ b/test/common_types_tests.jl
@@ -39,7 +39,6 @@ function test_common_types_broadcasts(FT)
         CMP.Ventilation{FT},
         CMP.Acnv1M{FT},
         CMP.CloudLiquid{FT},
-        CMP.CollisionEff{FT},
         CMP.AcnvKK2000{FT},
         CMP.AccrKK2000{FT},
         CMP.AcnvB1994{FT},

--- a/test/gpu_tests.jl
+++ b/test/gpu_tests.jl
@@ -75,7 +75,7 @@ ArrayType = CuArray
 end
 
 @kernel inbounds = true function test_noneq_micro_kernel!(
-    lcl, icl, tps, output, ρ, T, qᵥ_sl, qᵢ, qᵢ_s,
+    lcl, icl, tps, clf, output, ρ, T, qᵥ_sl, qᵢ, qᵢ_s,
 )
     i = @index(Global, Linear)
     FT = eltype(tps)
@@ -84,7 +84,7 @@ end
     micro_mock = (; q_tot = qᵥ_sl[i], q_lcl, q_icl, q_rai, q_sno)
     thermo_mock = (; ρ = ρ[i], T = T[i])
     S_cond = CMN.conv_q_vap_to_q_lcl(
-        CMP.ConstantTimescaleCloudLiquidFormation(), mp_mock, tps, micro_mock, thermo_mock,
+        clf, mp_mock, tps, micro_mock, thermo_mock,
     )
     output[i] = (; S_cond)
 end
@@ -137,30 +137,30 @@ end
     i = @index(Global, Linear)
     micro = (; q_tot = zero(ql[i]), q_lcl = ql[i], q_icl = zero(ql[i]), q_rai = zero(ql[i]), q_sno = zero(ql[i]))
     thermo = (; ρ = zero(ql[i]), T = zero(ql[i]))
-    output[i] = CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversion1M(), mp, tps, micro, thermo)
+    output[i] = CM1.conv_q_lcl_to_q_rai(mp.options.rain_autoconversion, mp, tps, micro, thermo)
 end
 
 @kernel inbounds = true function test_1_moment_micro_acnv2M_kernel!(mp, tps, output, ql)
     i = @index(Global, Linear)
     micro = (; q_tot = zero(ql[i]), q_lcl = ql[i], q_icl = zero(ql[i]), q_rai = zero(ql[i]), q_sno = zero(ql[i]))
     thermo = (; ρ = zero(ql[i]), T = zero(ql[i]))
-    output[i] = CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversionPrescribedNd(), mp, tps, micro, thermo)
+    output[i] = CM1.conv_q_lcl_to_q_rai(mp.options.rain_autoconversion, mp, tps, micro, thermo)
 end
 
 @kernel inbounds = true function test_1_moment_micro_accretion_kernel!(
-    lcl, rain, icl, snow, ce, blk1mvel, output, ρ, qi, qs, ql, qr,
+    lcl, rain, icl, snow, e_lr, e_is, e_ls, e_ir, e_rs, coeff_disp, blk1mvel, output, ρ, qi, qs, ql, qr,
 )
     i = @index(Global, Linear)
-    liq_rai = CM1.accretion(lcl, rain, blk1mvel.rain, ce, ql[i], qr[i], ρ[i])
-    ice_sno = CM1.accretion(icl, snow, blk1mvel.snow, ce, qi[i], qs[i], ρ[i])
-    liq_sno = CM1.accretion(lcl, snow, blk1mvel.snow, ce, ql[i], qs[i], ρ[i])
-    ice_rai = CM1.accretion(icl, rain, blk1mvel.rain, ce, qi[i], qr[i], ρ[i])
-    rai_sink = CM1.accretion_rain_sink(rain, icl, blk1mvel.rain, ce, qi[i], qr[i], ρ[i])
+    liq_rai = CM1.accretion(lcl, rain, blk1mvel.rain, e_lr, ql[i], qr[i], ρ[i])
+    ice_sno = CM1.accretion(icl, snow, blk1mvel.snow, e_is, qi[i], qs[i], ρ[i])
+    liq_sno = CM1.accretion(lcl, snow, blk1mvel.snow, e_ls, ql[i], qs[i], ρ[i])
+    ice_rai = CM1.accretion(icl, rain, blk1mvel.rain, e_ir, qi[i], qr[i], ρ[i])
+    rai_sink = CM1.accretion_rain_sink(rain, icl, blk1mvel.rain, e_ir, qi[i], qr[i], ρ[i])
     sno_rai = CM1.accretion_snow_rain(
-        snow, rain, blk1mvel.snow, blk1mvel.rain, ce, qs[i], qr[i], ρ[i],
+        snow, rain, blk1mvel.snow, blk1mvel.rain, e_rs, coeff_disp, qs[i], qr[i], ρ[i],
     )
     rai_sno = CM1.accretion_snow_rain(
-        rain, snow, blk1mvel.rain, blk1mvel.snow, ce, qr[i], qs[i], ρ[i],
+        rain, snow, blk1mvel.rain, blk1mvel.snow, e_rs, coeff_disp, qr[i], qs[i], ρ[i],
     )
     output[i] = (; liq_rai, ice_sno, liq_sno, ice_rai, rai_sink, sno_rai, rai_sno)
 end
@@ -171,14 +171,12 @@ end
     i = @index(Global, Linear)
     micro = (; q_tot = zero(ρ[i]), q_lcl = ql[i], q_icl = qi[i], q_rai = qr[i], q_sno = qs[i])
     thermo = (; ρ = ρ[i], T = T[i])
-    liq_rai = CM1.accretion(CMP.CloudLiquidRainAccretion(), mp, tps, micro, thermo)
-    liq_sno = CM1.accretion(CMP.CloudLiquidSnowAccretion(), mp, tps, micro, thermo).S_accr
-    ice_rai = CM1.accretion(CMP.CloudIceRainAccretion(), mp, tps, micro, thermo)
-    ice_sno = CM1.accretion(CMP.CloudIceSnowAccretion(), mp, tps, micro, thermo)
-    # rain-sink is now internal (coupled to CloudIceRainAccretion), so use low-level kernel directly
-    rai_sink = CM1.accretion_rain_sink(mp.precip.rain, mp.cloud.ice, mp.terminal_velocity.rain, mp.collision,
-        micro.q_icl, micro.q_rai, ρ[i])
-    r_sr = CM1.accretion_snow_rain(CMP.RainSnowAccretion(), mp, tps, micro, thermo)
+    liq_rai = CM1.accretion(mp.options.cloud_liquid_rain_accretion, mp, tps, micro, thermo)
+    liq_sno = CM1.accretion(mp.options.cloud_liquid_snow_accretion, mp, tps, micro, thermo).S_accr
+    ice_rai = CM1.accretion(mp.options.cloud_ice_rain_accretion, mp, tps, micro, thermo)
+    ice_sno = CM1.accretion(mp.options.cloud_ice_snow_accretion, mp, tps, micro, thermo)
+    rai_sink = CM1.accretion_rain_sink(mp.options.cloud_ice_rain_accretion, mp, tps, micro, thermo)
+    r_sr = CM1.accretion_snow_rain(mp.options.rain_snow_accretion, mp, tps, micro, thermo)
     output[i] = (; liq_rai, ice_sno, liq_sno, ice_rai, rai_sink,
         sno_rai = r_sr.S_rai_sno, rai_sno = r_sr.S_sno_rai)
 end
@@ -188,7 +186,7 @@ end
     i = @index(Global, Linear)
     micro = (; q_tot = zero(ρ[i]), q_lcl = zero(ρ[i]), q_icl = zero(ρ[i]), q_rai = zero(ρ[i]), q_sno = qs[i])
     thermo = (; ρ = ρ[i], T = T[i])
-    output[i] = CM1.conv_q_sno_to_q_rai(CMP.SnowMelt(), mp, tps, micro, thermo)
+    output[i] = CM1.conv_q_sno_to_q_rai(mp.options.snow_melt, mp, tps, micro, thermo)
 end
 
 @kernel inbounds = true function test_2_moment_acnv_kernel!(
@@ -462,7 +460,13 @@ function test_gpu(FT)
     icl = CMP.CloudIce(FT)
     rain = CMP.Rain(FT)
     snow = CMP.Snow(FT)
-    ce = CMP.CollisionEff(FT)
+    mp = CMP.Microphysics1MParams(FT)
+    opts = mp.options
+    e_lr = opts.cloud_liquid_rain_accretion.e
+    e_is = opts.cloud_ice_snow_accretion.e
+    e_ls = opts.cloud_liquid_snow_accretion.e
+    e_ir = opts.cloud_ice_rain_accretion.e
+    e_rs = opts.rain_snow_accretion.e
 
     # Terminal velocity
     blk1mvel = CMP.Blk1MVelType(FT)
@@ -483,9 +487,7 @@ function test_gpu(FT)
     mp_0m = CMP.Microphysics0MParams(FT)
     mp_1m = CMP.Microphysics1MParams(FT)
     mp_1m_2M = CMP.Microphysics1MParams(FT;
-        options = CMP.Microphysics1MOptions(
-            rain_autoconversion = CMP.RainAutoconversionPrescribedNd(),
-        ),
+        rain_autoconversion = CMP.PrescribedNd(CP.create_toml_dict(FT)),
     )
     mp_2m_warm = CMP.Microphysics2MParams(FT; with_ice = false)
     mp_2m_p3 = CMP.Microphysics2MParams(FT; with_ice = true)
@@ -544,8 +546,9 @@ function test_gpu(FT)
         qᵢ = ArrayType([FT(0.003)])
         qᵢ_s = ArrayType([FT(0.002)])
 
+        clf = CMP.CloudLiquidFormation(CP.create_toml_dict(FT))
         kernel! = test_noneq_micro_kernel!(backend, work_groups)
-        kernel!(lcl, icl, tps, output, ρ, T, qᵥ_sl, qᵢ, qᵢ_s; ndrange)
+        kernel!(lcl, icl, tps, clf, output, ρ, T, qᵥ_sl, qᵢ, qᵢ_s; ndrange)
         (; S_cond) = Array(output)[1]
         # test that nonequilibrium cloud formation is callable and returns a reasonable value
         TT.@test S_cond ≈ FT(3.76347635339803e-5)
@@ -624,7 +627,7 @@ function test_gpu(FT)
         # Both inputs are above threshold so both should give positive autoconversion
         TT.@test all(x -> x > 0, out)
 
-        # RainAutoconversionPrescribedNd: variable-timescale autoconversion
+        # PrescribedNd: variable-timescale autoconversion
         bad_value = -99999.99
         (; output, ndrange) = setup_output(2, FT, bad_value)
         ql = ArrayType([FT(2e-3), FT(0)])
@@ -653,8 +656,28 @@ function test_gpu(FT)
         ql = ArrayType([FT(0), FT(5e-4)])
         qr = ArrayType([FT(0), FT(5e-4)])
 
+        coeff_disp = mp.options.rain_snow_accretion.coeff_disp
         kernel! = test_1_moment_micro_accretion_kernel!(backend, work_groups)
-        kernel!(lcl, rain, icl, snow, ce, blk1mvel, output, ρ, qi, qs, ql, qr; ndrange)
+        kernel!(
+            lcl,
+            rain,
+            icl,
+            snow,
+            e_lr,
+            e_is,
+            e_ls,
+            e_ir,
+            e_rs,
+            coeff_disp,
+            blk1mvel,
+            output,
+            ρ,
+            qi,
+            qs,
+            ql,
+            qr;
+            ndrange,
+        )
         out0, out1 = Array(output)
 
         # test 1-moment accretion is callable and returns a reasonable value

--- a/test/microphysics1M_tests.jl
+++ b/test/microphysics1M_tests.jl
@@ -18,7 +18,6 @@ function test_microphysics1M(FT)
     ice = CMP.CloudIce(FT)
     liquid = CMP.CloudLiquid(FT)
 
-    ce = CMP.CollisionEff(FT)
     mp = CMP.Microphysics1MParams(FT)
 
     Ch2022 = CMP.Chen2022VelType(FT)
@@ -193,14 +192,14 @@ function test_microphysics1M(FT)
         # Snow sublimation rate should be negative (losing mass)
         micro = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
         thermo = (; ρ, T)
-        subl_rate = CM1.conv_q_sno_to_q_vap(CMP.SnowSublimation(), mp, tps, micro, thermo)
+        subl_rate = CM1.conv_q_sno_to_q_vap(CMP.SublimationOnly(), mp, tps, micro, thermo)
         TT.@test subl_rate < 0
     end
 
     TT.@testset "RainAutoconversion" begin
 
-        q_lcl_threshold = rain.acnv1M.q_threshold
-        τ_acnv_rai = rain.acnv1M.τ
+        q_lcl_threshold = mp.options.rain_autoconversion.acnv1M.q_threshold
+        τ_acnv_rai = mp.options.rain_autoconversion.acnv1M.τ
 
         micro_s = (; q_tot = FT(0), q_lcl = FT(0.5) * q_lcl_threshold,
             q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
@@ -209,39 +208,37 @@ function test_microphysics1M(FT)
         thermo = (; ρ = FT(1), T = FT(280))
 
         # Below threshold → near zero (smooth logistic)
-        TT.@test CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversion1M(), mp, tps, micro_s, thermo) ≈
+        TT.@test CM1.conv_q_lcl_to_q_rai(mp.options.rain_autoconversion, mp, tps, micro_s, thermo) ≈
                  FT(0.0) atol = 0.15 * q_lcl_threshold / τ_acnv_rai
 
         # Above threshold → ≈ 0.5 * q_threshold / τ (smooth logistic)
-        TT.@test CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversion1M(), mp, tps, micro_b, thermo) ≈
+        TT.@test CM1.conv_q_lcl_to_q_rai(mp.options.rain_autoconversion, mp, tps, micro_b, thermo) ≈
                  FT(0.5) * q_lcl_threshold / τ_acnv_rai atol =
             FT(0.15) * q_lcl_threshold / τ_acnv_rai
 
     end
 
     TT.@testset "RainAutoconversion2M" begin
-        # Variable-timescale autoconversion (RainAutoconversionPrescribedNd)
+        # Variable-timescale autoconversion (PrescribedNd)
         mp_2m = CMP.Microphysics1MParams(FT;
-            options = CMP.Microphysics1MOptions(
-                rain_autoconversion = CMP.RainAutoconversionPrescribedNd(),
-            ),
+            rain_autoconversion = CMP.PrescribedNd(CP.create_toml_dict(FT)),
         )
         thermo = (; ρ = FT(1), T = FT(280))
 
         # Zero cloud liquid → zero rate
         micro_0 = (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
-        TT.@test CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversionPrescribedNd(), mp_2m, tps, micro_0, thermo) == FT(0)
+        TT.@test CM1.conv_q_lcl_to_q_rai(mp_2m.options.rain_autoconversion, mp_2m, tps, micro_0, thermo) == FT(0)
 
         # Negative cloud liquid → zero rate (max(0, q_lcl))
         micro_neg = (; q_tot = FT(0), q_lcl = FT(-1e-4), q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
-        TT.@test CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversionPrescribedNd(), mp_2m, tps, micro_neg, thermo) == FT(0)
+        TT.@test CM1.conv_q_lcl_to_q_rai(mp_2m.options.rain_autoconversion, mp_2m, tps, micro_neg, thermo) == FT(0)
 
         # Positive cloud liquid → positive rate
         q_lcl = FT(2e-3)
-        N_d = mp_2m.autoconv_2M.Nc
-        (; τ, α) = mp_2m.autoconv_2M
+        N_d = mp_2m.options.rain_autoconversion.autoconv.Nc
+        (; τ, α) = mp_2m.options.rain_autoconversion.autoconv
         micro = (; q_tot = FT(0), q_lcl, q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
-        rate = CM1.conv_q_lcl_to_q_rai(CMP.RainAutoconversionPrescribedNd(), mp_2m, tps, micro, thermo)
+        rate = CM1.conv_q_lcl_to_q_rai(mp_2m.options.rain_autoconversion, mp_2m, tps, micro, thermo)
         TT.@test rate > FT(0)
         # Rate should match the formula: q_lcl / (τ * (N_d / 1e8)^α)
         TT.@test rate ≈ q_lcl / (τ * (N_d / 100_000_000)^α)
@@ -256,29 +253,29 @@ function test_microphysics1M(FT)
         TT.@test rate_low_N > rate_high_N
 
         # Regression: keep result constant when code changes
-        # q_lcl = 2e-3, default autoconv_2M.Nc ~1e8
+        # q_lcl = 2e-3, default PrescribedNd Nc ~1e8
         TT.@test rate ≈ FT(2e-6) rtol = 1e-3
 
     end
 
     TT.@testset "SnowAutoconversionNoSupersat" begin
 
-        q_icl_threshold = snow.acnv1M.q_threshold
-        τ_acnv_sno = snow.acnv1M.τ
+        q_icl_threshold = mp.options.snow_autoconversion.acnv1M.q_threshold
+        τ_acnv_sno = mp.options.snow_autoconversion.acnv1M.τ
 
         # Below threshold → rate near zero (uses logistic smoothing)
         q_icl_small = FT(0.5) * q_icl_threshold
         micro_s = (; q_tot = FT(0), q_lcl = FT(0), q_icl = q_icl_small, q_rai = FT(0), q_sno = FT(0))
         thermo_s = (; ρ = FT(1), T = FT(250))
         TT.@test CM1.conv_q_icl_to_q_sno(
-            CMP.SnowAutoconversionNoSupersaturation(), mp, tps, micro_s, thermo_s,
+            mp.options.snow_autoconversion, mp, tps, micro_s, thermo_s,
         ) ≈ FT(0.0) atol = FT(0.15) * q_icl_threshold / τ_acnv_sno
 
         # Above threshold → positive rate
         q_icl_big = FT(1.5) * q_icl_threshold
         micro_b = (; q_tot = FT(0), q_lcl = FT(0), q_icl = q_icl_big, q_rai = FT(0), q_sno = FT(0))
         TT.@test CM1.conv_q_icl_to_q_sno(
-            CMP.SnowAutoconversionNoSupersaturation(), mp, tps, micro_b, thermo_s,
+            mp.options.snow_autoconversion, mp, tps, micro_b, thermo_s,
         ) ≈ FT(0.5) * q_icl_threshold / τ_acnv_sno atol =
             FT(0.15) * q_icl_threshold / τ_acnv_sno
 
@@ -291,9 +288,9 @@ function test_microphysics1M(FT)
         qₛ = FT(1e-4)
         T_freeze = TDI.TD.Parameters.T_freeze(tps)
 
-        # Use mp with SnowAutoconversionWithSupersaturation
+        # Use mp with WithSupersaturation
         mp_ss = CMP.Microphysics1MParams(FT;
-            options = CMP.Microphysics1MOptions(snow_autoconversion = CMP.SnowAutoconversionWithSupersaturation()),
+            snow_autoconversion = CMP.WithSupersaturation(CP.create_toml_dict(FT)),
         )
 
         # above freezing temperatures -> no snow
@@ -304,7 +301,7 @@ function test_microphysics1M(FT)
         T = T_freeze + FT(30)
         micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
         thermo = (; ρ, T)
-        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconversionWithSupersaturation(), mp_ss, tps, micro, thermo) ==
+        TT.@test CM1.conv_q_icl_to_q_sno(mp_ss.options.snow_autoconversion, mp_ss, tps, micro, thermo) ==
                  FT(0)
 
         # no cloud ice -> no snow
@@ -313,7 +310,7 @@ function test_microphysics1M(FT)
         T = T_freeze - FT(30)
         micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
         thermo = (; ρ, T)
-        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconversionWithSupersaturation(), mp_ss, tps, micro, thermo) ==
+        TT.@test CM1.conv_q_icl_to_q_sno(mp_ss.options.snow_autoconversion, mp_ss, tps, micro, thermo) ==
                  FT(0)
 
         # no supersaturation -> no snow
@@ -323,7 +320,7 @@ function test_microphysics1M(FT)
         qₜ = q_sat_ice
         micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
         thermo = (; ρ, T)
-        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconversionWithSupersaturation(), mp_ss, tps, micro, thermo) ≈ FT(0)
+        TT.@test CM1.conv_q_icl_to_q_sno(mp_ss.options.snow_autoconversion, mp_ss, tps, micro, thermo) ≈ FT(0)
 
         # Regression test: keep result constant when code changes
         T = T_freeze - FT(10)
@@ -334,7 +331,7 @@ function test_microphysics1M(FT)
         ref = FT(2.5408135723057333e-9)
         micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
         thermo = (; ρ, T)
-        TT.@test CM1.conv_q_icl_to_q_sno(CMP.SnowAutoconversionWithSupersaturation(), mp_ss, tps, micro, thermo) ≈ ref
+        TT.@test CM1.conv_q_icl_to_q_sno(mp_ss.options.snow_autoconversion, mp_ss, tps, micro, thermo) ≈ ref
     end
 
     TT.@testset "RainLiquidAccretion" begin
@@ -353,13 +350,14 @@ function test_microphysics1M(FT)
         q_rain_range = range(FT(1e-8), stop = FT(5e-3), length = 10)
         ρ_air, q_liq, q_tot = FT(1.2), FT(5e-4), FT(20e-3)
 
+        E_lcl_rai = mp.options.cloud_liquid_rain_accretion.e
         for q_rai in q_rain_range
             if q_rai > eps(FT)
                 TT.@test CM1.accretion(
                     liquid,
                     rain,
                     blk1mvel.rain,
-                    ce,
+                    E_lcl_rai,
                     q_liq,
                     q_rai,
                     ρ_air,
@@ -370,7 +368,7 @@ function test_microphysics1M(FT)
                     liquid,
                     rain,
                     blk1mvel.rain,
-                    ce,
+                    E_lcl_rai,
                     q_liq,
                     q_rai,
                     ρ_air,
@@ -390,34 +388,41 @@ function test_microphysics1M(FT)
         q_liq = FT(5e-4)
         q_rai = FT(5e-4)
 
+        E_lcl_rai = mp.options.cloud_liquid_rain_accretion.e
+        E_lcl_sno = mp.options.cloud_liquid_snow_accretion.e
+        E_icl_rai = mp.options.cloud_ice_rain_accretion.e
+        E_icl_sno = mp.options.cloud_ice_snow_accretion.e
+        E_rai_sno = mp.options.rain_snow_accretion.e
+        coeff_disp = mp.options.rain_snow_accretion.coeff_disp
+
         TT.@test CM1.accretion(
             liquid,
             rain,
             blk1mvel.rain,
-            ce,
+            E_lcl_rai,
             q_liq,
             q_rai,
             ρ,
         ) ≈ FT(1.4150106417043544e-6)
-        TT.@test CM1.accretion(ice, snow, blk1mvel.snow, ce, q_ice, q_sno, ρ) ≈
+        TT.@test CM1.accretion(ice, snow, blk1mvel.snow, E_icl_sno, q_ice, q_sno, ρ) ≈
                  FT(2.453070979562392e-7)
         TT.@test CM1.accretion(
             liquid,
             snow,
             blk1mvel.snow,
-            ce,
+            E_lcl_sno,
             q_liq,
             q_sno,
             ρ,
         ) ≈ FT(2.453070979562392e-7)
-        TT.@test CM1.accretion(ice, rain, blk1mvel.rain, ce, q_ice, q_rai, ρ) ≈
+        TT.@test CM1.accretion(ice, rain, blk1mvel.rain, E_icl_rai, q_ice, q_rai, ρ) ≈
                  FT(1.768763302130443e-6)
 
         TT.@test CM1.accretion_rain_sink(
             rain,
             ice,
             blk1mvel.rain,
-            ce,
+            E_icl_rai,
             q_ice,
             q_rai,
             ρ,
@@ -428,7 +433,8 @@ function test_microphysics1M(FT)
             rain,
             blk1mvel.snow,
             blk1mvel.rain,
-            ce,
+            E_rai_sno,
+            coeff_disp,
             q_sno,
             q_rai,
             ρ,
@@ -438,7 +444,8 @@ function test_microphysics1M(FT)
             snow,
             blk1mvel.rain,
             blk1mvel.snow,
-            ce,
+            E_rai_sno,
+            coeff_disp,
             q_rai,
             q_sno,
             ρ,
@@ -454,34 +461,35 @@ function test_microphysics1M(FT)
         q_ice = FT(5e-4)
         q_sno = FT(5e-4)
         q_rai = FT(5e-4)
-        T_warm = snow.T_freeze + FT(5)   # above freezing
-        T_cold = snow.T_freeze - FT(5)   # below freezing
+        T_freeze = TDI.T_freeze(tps)
+        T_warm = T_freeze + FT(5)   # above freezing
+        T_cold = T_freeze - FT(5)   # below freezing
 
         micro = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
         thermo_warm = (; ρ, T = T_warm)
         thermo_cold = (; ρ, T = T_cold)
 
         # CloudLiquidRainAccretion: scalar, matches internal kernel
-        TT.@test CM1.accretion(CMP.CloudLiquidRainAccretion(), mp, tps, micro, thermo_warm) ≈
+        TT.@test CM1.accretion(mp.options.cloud_liquid_rain_accretion, mp, tps, micro, thermo_warm) ≈
                  FT(1.4150106417043544e-6)
 
         # CloudIceRainAccretion: scalar, matches internal kernel
-        TT.@test CM1.accretion(CMP.CloudIceRainAccretion(), mp, tps, micro, thermo_warm) ≈
+        TT.@test CM1.accretion(mp.options.cloud_ice_rain_accretion, mp, tps, micro, thermo_warm) ≈
                  FT(1.768763302130443e-6)
 
         # CloudIceSnowAccretion: scalar, matches internal kernel
-        TT.@test CM1.accretion(CMP.CloudIceSnowAccretion(), mp, tps, micro, thermo_warm) ≈
+        TT.@test CM1.accretion(mp.options.cloud_ice_snow_accretion, mp, tps, micro, thermo_warm) ≈
                  FT(2.453070979562392e-7)
 
         # CloudLiquidSnowAccretion: NamedTuple (; S_accr, S_melt)
         # S_accr matches the internal lcl×sno kernel; S_melt = α * S_accr (α > 0 warm)
-        (; S_accr, S_melt) = CM1.accretion(CMP.CloudLiquidSnowAccretion(), mp, tps, micro, thermo_warm)
+        (; S_accr, S_melt) = CM1.accretion(mp.options.cloud_liquid_snow_accretion, mp, tps, micro, thermo_warm)
         TT.@test S_accr ≈ FT(2.453070979562392e-7)
         TT.@test S_melt >= FT(0)      # α >= 0
         TT.@test S_melt <= S_accr     # melt ≤ S_accr (α ≤ 1 for reasonable ΔT)
 
         # Cold: melt should be zero (T < T_freeze → α = 0)
-        let r = CM1.accretion(CMP.CloudLiquidSnowAccretion(), mp, tps, micro, thermo_cold)
+        let r = CM1.accretion(mp.options.cloud_liquid_snow_accretion, mp, tps, micro, thermo_cold)
             TT.@test r.S_accr ≈ FT(2.453070979562392e-7)
             TT.@test r.S_melt == FT(0)
         end
@@ -489,31 +497,30 @@ function test_microphysics1M(FT)
         # RainSnowAccretion: NamedTuple (; S_rai_sno, S_sno_rai, S_melt)
         # cold arm S_rai_sno matches internal (sno, rai) call
         # warm arm S_sno_rai matches internal (rai, sno) call
-        let r = CM1.accretion_snow_rain(CMP.RainSnowAccretion(), mp, tps, micro, thermo_warm)
+        let r = CM1.accretion_snow_rain(mp.options.rain_snow_accretion, mp, tps, micro, thermo_warm)
             TT.@test r.S_rai_sno ≈ FT(2.466313958248222e-4)
             TT.@test r.S_sno_rai ≈ FT(6.830957197816771e-5)
             TT.@test r.S_melt >= FT(0)
         end
         # Cold: S_melt = 0 (α = 0 below freezing)
-        let r = CM1.accretion_snow_rain(CMP.RainSnowAccretion(), mp, tps, micro, thermo_cold)
+        let r = CM1.accretion_snow_rain(mp.options.rain_snow_accretion, mp, tps, micro, thermo_cold)
             TT.@test r.S_melt == FT(0)
         end
 
-        # No* variants return zero
+        # nothing variants return zero
         micro_zero = (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
-        TT.@test CM1.accretion(CMP.NoCloudLiquidRainAccretion(), mp, tps, micro_zero, thermo_warm) == FT(0)
-        TT.@test CM1.accretion(CMP.NoCloudIceRainAccretion(), mp, tps, micro_zero, thermo_warm) == FT(0)
-        TT.@test CM1.accretion(CMP.NoCloudIceSnowAccretion(), mp, tps, micro_zero, thermo_warm) == FT(0)
-        TT.@test CM1.accretion(CMP.NoCloudLiquidSnowAccretion(), mp, tps, micro_zero, thermo_warm).S_accr == FT(0)
-        TT.@test CM1.accretion_snow_rain(CMP.NoRainSnowAccretion(), mp, tps, micro_zero, thermo_warm).S_rai_sno == FT(0)
-        TT.@test CM1.accretion_snow_rain(CMP.NoRainSnowAccretion(), mp, tps, micro_zero, thermo_warm).S_sno_rai == FT(0)
+        TT.@test CM1.accretion(nothing, mp, tps, micro_zero, thermo_warm) == FT(0)
+        TT.@test CM1.accretion_snow_rain(nothing, mp, tps, micro_zero, thermo_warm).S_rai_sno == FT(0)
+        TT.@test CM1.accretion_snow_rain(nothing, mp, tps, micro_zero, thermo_warm).S_sno_rai == FT(0)
         # Active variants: zero inputs → zero rates
-        TT.@test CM1.accretion(CMP.CloudLiquidRainAccretion(), mp, tps, micro_zero, thermo_warm) == FT(0)
-        TT.@test CM1.accretion(CMP.CloudIceRainAccretion(), mp, tps, micro_zero, thermo_warm) == FT(0)
-        TT.@test CM1.accretion(CMP.CloudIceSnowAccretion(), mp, tps, micro_zero, thermo_warm) == FT(0)
-        TT.@test CM1.accretion(CMP.CloudLiquidSnowAccretion(), mp, tps, micro_zero, thermo_warm).S_accr == FT(0)
-        TT.@test CM1.accretion_snow_rain(CMP.RainSnowAccretion(), mp, tps, micro_zero, thermo_warm).S_rai_sno == FT(0)
-        TT.@test CM1.accretion_snow_rain(CMP.RainSnowAccretion(), mp, tps, micro_zero, thermo_warm).S_sno_rai == FT(0)
+        TT.@test CM1.accretion(mp.options.cloud_liquid_rain_accretion, mp, tps, micro_zero, thermo_warm) == FT(0)
+        TT.@test CM1.accretion(mp.options.cloud_ice_rain_accretion, mp, tps, micro_zero, thermo_warm) == FT(0)
+        TT.@test CM1.accretion(mp.options.cloud_ice_snow_accretion, mp, tps, micro_zero, thermo_warm) == FT(0)
+        TT.@test CM1.accretion(mp.options.cloud_liquid_snow_accretion, mp, tps, micro_zero, thermo_warm).S_accr == FT(0)
+        TT.@test CM1.accretion_snow_rain(mp.options.rain_snow_accretion, mp, tps, micro_zero, thermo_warm).S_rai_sno ==
+                 FT(0)
+        TT.@test CM1.accretion_snow_rain(mp.options.rain_snow_accretion, mp, tps, micro_zero, thermo_warm).S_sno_rai ==
+                 FT(0)
     end
 
     TT.@testset "RainEvaporation" begin
@@ -621,7 +628,7 @@ function test_microphysics1M(FT)
 
                 micro = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
                 thermo = (; ρ, T)
-                tmp1 = CM1.conv_q_sno_to_q_vap(CMP.SnowSublimation(), mp, tps, micro, thermo)
+                tmp1 = CM1.conv_q_sno_to_q_vap(CMP.SublimationOnly(), mp, tps, micro, thermo)
                 TT.@test tmp1 ≈ ref_val[cnt] rtol = 1e-2
             end
         end
@@ -659,7 +666,7 @@ function test_microphysics1M(FT)
 
                 micro = (; q_tot, q_lcl = q_liq, q_icl = q_ice, q_rai, q_sno)
                 thermo = (; ρ, T)
-                tmp1 = CM1.conv_q_sno_to_q_vap(CMP.SnowDepositionSublimation(), mp, tps, micro, thermo)
+                tmp1 = CM1.conv_q_sno_to_q_vap(CMP.DepositionAndSublimation(), mp, tps, micro, thermo)
                 TT.@test tmp1 ≈ ref_val[cnt] rtol = 1e-2
             end
         end
@@ -705,7 +712,7 @@ function test_microphysics1M(FT)
         ρ = FT(1.2)
         q_icl = FT(1e-4)
         mp_melt = CMP.Microphysics1MParams(FT;
-            options = CMP.Microphysics1MOptions(cloud_ice_melt = CMP.CloudIceMelt()),
+            cloud_ice_melt = CMP.CloudIceMelt(),
         )
         micro = (; q_tot = FT(0), q_lcl = FT(0), q_icl, q_rai = FT(0), q_sno = FT(0))
         thermo = (; ρ, T)
@@ -735,8 +742,8 @@ function test_microphysics1M(FT)
         rate_cool = CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMelt(), mp_melt, tps, micro, thermo_c)
         TT.@test rate_warm > rate_cool
 
-        # NoCloudIceMelt returns zero
-        TT.@test CM1.conv_q_icl_to_q_lcl(CMP.NoCloudIceMelt(), mp, tps, micro, thermo) == FT(0)
+        # nothing returns zero
+        TT.@test CM1.conv_q_icl_to_q_lcl(nothing, mp, tps, micro, thermo) == FT(0)
 
     end
 

--- a/test/microphysics_noneq_tests.jl
+++ b/test/microphysics_noneq_tests.jl
@@ -16,8 +16,12 @@ function test_microphysics_noneq(FT)
     Ch2022 = CMP.Chen2022VelType(FT)
 
     TT.@testset "τ_relax" begin
-        TT.@test CMNe.τ_relax(liquid) ≈ FT(10)
-        TT.@test CMNe.τ_relax(ice) ≈ FT(10)
+        # Default τ_relax values come from the option structs
+        td = ClimaParams.create_toml_dict(FT)
+        clf = CMP.CloudLiquidFormation(td)
+        cif = CMP.ConstantTimescale(td)
+        TT.@test clf.τ_relax ≈ FT(10)
+        TT.@test cif.τ_relax ≈ FT(10)
     end
 
     TT.@testset "τ_relax Frostenberg" begin
@@ -33,8 +37,7 @@ function test_microphysics_noneq(FT)
 
     TT.@testset "CondEvap_DepSub" begin
 
-        τ_liq = CMNe.τ_relax(liquid)
-        τ_ice = CMNe.τ_relax(ice)
+
 
         ρ = FT(0.8)
         T = FT(273 - 10)
@@ -48,7 +51,7 @@ function test_microphysics_noneq(FT)
         #! format: off
         # Test helpers
         _conv_lcl(q_tot, q_lcl, q_icl, ρ, T) = CMNe.conv_q_vap_to_q_lcl(
-            CMP.ConstantTimescaleCloudLiquidFormation(),
+            CMP.CloudLiquidFormation(FT(10)),
             (; cloud = (; liquid = liquid)),
             tps,
             (; q_tot, q_lcl, q_icl, q_rai = FT(0), q_sno = FT(0)),
@@ -56,7 +59,7 @@ function test_microphysics_noneq(FT)
         )
 
         _conv_icl(q_tot, q_lcl, q_icl, ρ, T) = CMNe.conv_q_vap_to_q_icl(
-            CMP.ConstantTimescaleCloudIceFormation(),
+            CMP.ConstantTimescale(FT(10)),
             (; cloud = (; ice = ice)),
             tps,
             (; q_tot, q_lcl, q_icl, q_rai = FT(0), q_sno = FT(0)),
@@ -64,7 +67,7 @@ function test_microphysics_noneq(FT)
         )
 
         _conv_icl_dep(q_tot, q_lcl, q_icl, ρ, T) = CMNe.conv_q_vap_to_q_icl(
-            CMP.TemperatureDependentCloudIceFormation(),
+            CMP.TemperatureDependent(FT(10), frs),
             (; cloud = (; ice = ice), air_properties = aps, frostenberg2023 = frs),
             tps,
             (; q_tot, q_lcl, q_icl, q_rai = FT(0), q_sno = FT(0)),
@@ -106,37 +109,39 @@ function test_microphysics_noneq(FT)
         TT.@test _conv_icl(FT(0.5 * qᵥ_si_w), FT(0), FT(0.001), ρ, T_warm) <= FT(0)
 
         # --- Asymmetric τ_dep ≠ τ_sub ---
-        # Faster sublimation (smaller τ_sub) should give a larger magnitude sublimation rate
-        # We simulate this by changing the mp ice struct
-        ice_base = CMP.CloudIce(FT)
-        ice_slow = CMP.CloudIce(ice_base.pdf, ice_base.mass, ice_base.r0, ice_base.r_ice_snow, FT(100), ice_base.ρᵢ, ice_base.r_eff, ice_base.N_0)
-        ice_fast = CMP.CloudIce(ice_base.pdf, ice_base.mass, ice_base.r0, ice_base.r_ice_snow, FT(1), ice_base.ρᵢ, ice_base.r_eff, ice_base.N_0)
+        # Faster sublimation (smaller τ_relax) should give a larger magnitude sublimation rate
+        # We test by creating ConstantTimescale options with different τ_relax values
+        opt_fast = CMP.ConstantTimescale(FT(1))
+        opt_slow = CMP.ConstantTimescale(FT(100))
         
-        function _conv_icl_custom(ice_mock, q_tot, q_lcl, q_icl, ρ, T)
+        function _conv_icl_custom(opt, q_tot, q_lcl, q_icl, ρ, T)
             CMNe.conv_q_vap_to_q_icl(
-                CMP.ConstantTimescaleCloudIceFormation(),
-                (; cloud = (; ice = ice_mock)),
+                opt,
+                (; cloud = (; ice = ice)),
                 tps,
                 (; q_tot, q_lcl, q_icl, q_rai = FT(0), q_sno = FT(0)),
                 (; ρ, T)
             )
         end
-        sub_fast = _conv_icl_custom(ice_fast, FT(0.5 * qᵥ_si), FT(0), FT(0.001), ρ, T)
-        sub_slow = _conv_icl_custom(ice_slow, FT(0.5 * qᵥ_si), FT(0), FT(0.001), ρ, T)
+        sub_fast = _conv_icl_custom(opt_fast, FT(0.5 * qᵥ_si), FT(0), FT(0.001), ρ, T)
+        sub_slow = _conv_icl_custom(opt_slow, FT(0.5 * qᵥ_si), FT(0), FT(0.001), ρ, T)
         TT.@test sub_fast < sub_slow  # faster sublimation → more negative
 
-        # Deposition rate with TemperatureDependentCloudIceFormation should depend only on τ_dep, not τ_sub
-        function _conv_icl_dep_custom(ice_mock, q_tot, q_lcl, q_icl, ρ, T)
+        # Deposition rate with TemperatureDependent should depend only on τ_dep, not τ_sub
+        # TemperatureDependent uses opt.τ_relax for sublimation but Frostenberg for deposition
+        opt_td_fast = CMP.TemperatureDependent(FT(1), frs)
+        opt_td_slow = CMP.TemperatureDependent(FT(100), frs)
+        function _conv_icl_dep_custom(opt, q_tot, q_lcl, q_icl, ρ, T)
             CMNe.conv_q_vap_to_q_icl(
-                CMP.TemperatureDependentCloudIceFormation(),
-                (; cloud = (; ice = ice_mock), air_properties = aps, frostenberg2023 = frs),
+                opt,
+                (; cloud = (; ice = ice), air_properties = aps, frostenberg2023 = frs),
                 tps,
                 (; q_tot, q_lcl, q_icl, q_rai = FT(0), q_sno = FT(0)),
                 (; ρ, T)
             )
         end
-        dep_a = _conv_icl_dep_custom(ice_fast, FT(1.5 * qᵥ_si), FT(0), FT(0), ρ, T)
-        dep_b = _conv_icl_dep_custom(ice_slow, FT(1.5 * qᵥ_si), FT(0), FT(0), ρ, T)
+        dep_a = _conv_icl_dep_custom(opt_td_fast, FT(1.5 * qᵥ_si), FT(0), FT(0), ρ, T)
+        dep_b = _conv_icl_dep_custom(opt_td_slow, FT(1.5 * qᵥ_si), FT(0), FT(0), ρ, T)
         TT.@test dep_a ≈ dep_b  # τ_sub doesn't affect deposition
 
         #! format: on

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -87,7 +87,6 @@ function benchmark_test(FT)
     ice = CMP.CloudIce(FT)
     rain = CMP.Rain(FT)
     snow = CMP.Snow(FT)
-    ce = CMP.CollisionEff(FT)
 
     # 2-moment parameters
     override_file = joinpath(pkgdir(CM), "src", "parameters", "toml", "SB2006_limiters.toml")
@@ -127,10 +126,9 @@ function benchmark_test(FT)
     # 1-moment microphysics unified params (both liquid autoconversion flavours)
     mp_1m = CMP.Microphysics1MParams(FT)
     mp_1m_2M = CMP.Microphysics1MParams(FT;
-        options = CMP.Microphysics1MOptions(
-            rain_autoconversion = CMP.RainAutoconversionPrescribedNd(),
-        ),
+        rain_autoconversion = CMP.PrescribedNd(CP.create_toml_dict(FT)),
     )
+    E_lcl_rai = mp_1m.options.cloud_liquid_rain_accretion.e
 
     ρ_air = FT(1.2)
     T_air = FT(280)
@@ -183,9 +181,9 @@ function benchmark_test(FT)
     )
     bench_press(FT, P3.get_distribution_logλ, (state,), 30_000)
     bench_press(FT, P3.get_distribution_logλ, (params_P3, L_ice, N_ice, F_rim, ρ_rim), 30_000)
-    bench_press(FT, P3.ice_terminal_velocity_number_weighted, (ch2022, ρ_air, state, logλ), 140_000)
-    bench_press(FT, P3.ice_terminal_velocity_mass_weighted, (ch2022, ρ_air, state, logλ), 160_000)
-    bench_press(FT, P3.integrate, (x -> x^4, FT(0), FT(1)), 6_100)
+    bench_press(FT, P3.ice_terminal_velocity_number_weighted, (ch2022, ρ_air, state, logλ), 170_000)
+    bench_press(FT, P3.ice_terminal_velocity_mass_weighted, (ch2022, ρ_air, state, logλ), 200_000)
+    bench_press(FT, P3.integrate, (x -> x^4, FT(0), FT(1)), 7_000)
     bench_press(FT, P3.D_m, (state, logλ), 3_000)
 
     @info "P3 Ice Nucleation"
@@ -199,7 +197,7 @@ function benchmark_test(FT)
         @NamedTuple{dNdt::FT, dLdt::FT},
         P3.ice_melt,
         (ch2022, aps, tps, T_air, ρ_air, Δt, state, logλ),
-        180_000,
+        210_000,
     )
     bench_press(FT, CMI_het.P3_deposition_N_i, (ip.p3, T_air_cold), 230)
     bench_press(FT, CMI_het.P3_het_N_i, (ip.p3, T_air_cold, N_liq, V_liq, Δt), 230)
@@ -231,13 +229,13 @@ function benchmark_test(FT)
     bench_press(FT, CMI_hom.homogeneous_J_linear, (ip.homogeneous, Delta_a_w), 230)
 
     @info "Non-equilibrium Microphysics"
-    bench_press(FT, CMN.τ_relax, (liquid,), 15)
+    bench_press(FT, CMN.τ_relax, (ice, aps, ip_frostenberg, FT(1e-4), FT(250)), 200)
 
     mp_mock = (; cloud = (; liquid = liquid))
     micro_mock = (; q_tot = FT(0.00145), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
     thermo_mock = (; ρ = FT(0.8), T = FT(263))
     bench_press(FT, CMN.conv_q_vap_to_q_lcl,
-        (CMP.ConstantTimescaleCloudLiquidFormation(), mp_mock, tps, micro_mock, thermo_mock), 140)
+        (CMP.CloudLiquidFormation(CP.create_toml_dict(FT)), mp_mock, tps, micro_mock, thermo_mock), 140)
 
     @info "0-Moment Scheme"
     bench_press(FT, CM0.remove_precipitation, (p0m, q_liq, q_ice), 12)
@@ -248,29 +246,29 @@ function benchmark_test(FT)
     thermo_1m = (; ρ = ρ_air, T = T_air)
     bench_press(
         FT, CM1.conv_q_lcl_to_q_rai,
-        (CMP.RainAutoconversion1M(), mp_1m, tps, micro_1m, thermo_1m),
+        (mp_1m.options.rain_autoconversion, mp_1m, tps, micro_1m, thermo_1m),
         500,
     )
     bench_press(
         FT, CM1.conv_q_lcl_to_q_rai,
-        (CMP.RainAutoconversionPrescribedNd(), mp_1m_2M, tps, micro_1m, thermo_1m),
+        (mp_1m_2M.options.rain_autoconversion, mp_1m_2M, tps, micro_1m, thermo_1m),
         500,
     )
-    bench_press(FT, CM1.accretion, (liquid, rain, blk1mvel.rain, ce, q_liq, q_rai, ρ_air), 360)
-    bench_press(FT, CM1.accretion, (CMP.CloudLiquidRainAccretion(), mp_1m, tps, micro_1m, thermo_1m), 360)
+    bench_press(FT, CM1.accretion, (liquid, rain, blk1mvel.rain, E_lcl_rai, q_liq, q_rai, ρ_air), 360)
+    bench_press(FT, CM1.accretion, (mp_1m.options.cloud_liquid_rain_accretion, mp_1m, tps, micro_1m, thermo_1m), 360)
     bench_press(
         @NamedTuple{S_accr::FT, S_melt::FT},
         CM1.accretion,
-        (CMP.CloudLiquidSnowAccretion(), mp_1m, tps, micro_1m, thermo_1m),
+        (mp_1m.options.cloud_liquid_snow_accretion, mp_1m, tps, micro_1m, thermo_1m),
         360,
     )
-    bench_press(FT, CM1.accretion, (CMP.CloudIceRainAccretion(), mp_1m, tps, micro_1m, thermo_1m), 360)
-    bench_press(FT, CM1.accretion, (CMP.CloudIceSnowAccretion(), mp_1m, tps, micro_1m, thermo_1m), 360)
+    bench_press(FT, CM1.accretion, (mp_1m.options.cloud_ice_rain_accretion, mp_1m, tps, micro_1m, thermo_1m), 360)
+    bench_press(FT, CM1.accretion, (mp_1m.options.cloud_ice_snow_accretion, mp_1m, tps, micro_1m, thermo_1m), 360)
     bench_press(
         @NamedTuple{S_rai_sno::FT, S_sno_rai::FT, S_melt::FT},
         CM1.accretion_snow_rain,
-        (CMP.RainSnowAccretion(), mp_1m, tps, micro_1m, thermo_1m),
-        1200,
+        (mp_1m.options.rain_snow_accretion, mp_1m, tps, micro_1m, thermo_1m),
+        1400,
     )
     bench_press(FT, CMD.radar_reflectivity_1M, (rain, q_rai, ρ_air), 300)
 
@@ -281,13 +279,13 @@ function benchmark_test(FT)
         @NamedTuple{dq_lcl_dt::FT, dq_icl_dt::FT, dq_rai_dt::FT, dq_sno_dt::FT},
         BMT.bulk_microphysics_tendencies,
         (BMT.Instantaneous(), CM1M, mp_1m, tps, ρ_air, T_air, q_tot, q_liq, q_ice, q_rai, q_sno),
-        5000,
+        5500,
     )
     bench_press(
         @NamedTuple{dq_lcl_dt::FT, dq_icl_dt::FT, dq_rai_dt::FT, dq_sno_dt::FT},
         BMT.bulk_microphysics_tendencies,
         (BMT.LinearizedAverage(), CM1M, mp_1m, tps, ρ_air, T_air, q_tot, q_liq, q_ice, q_rai, q_sno, Δt),
-        5000,
+        5500,
     )
     bench_press(
         @NamedTuple{dq_lcl_dt::FT, dq_icl_dt::FT, dq_rai_dt::FT, dq_sno_dt::FT},


### PR DESCRIPTION
Addressing some comments from https://github.com/CliMA/CloudMicrophysics.jl/pull/714. We will do more refactoring later. 

This PR consolidates the 1-moment microphysics API around having two names:
-  one name for each physical process (i.e. what is happening?). Done via abstract type + function
-  one name for each parameterization of that process (i.e. how it is represented in the model. Done via concrete parameterization type. 

Every microphysical process is now represented by a concrete option type that:
- **carries its own parameters** (e.g. collision efficiency `e`, relaxation timescale `τ_relax`)
- **is used directly for dispatch** (no separate singleton)
- **lives inside `Microphysics1MOptions`**, a field of `Microphysics1MParams`

Disabling a process is done by setting its option to `nothing`; a `::Nothing` method returns `zero(FT)`.

### Process → method naming

| Process (abstract type) | Methods (concrete types) |
|---|---|
| `CloudLiquidFormation` | `CloudLiquidFormation` (constant timescale) |
| `CloudIceFormation` | `ConstantTimescale`, `TemperatureDependent` |
| `RainAutoconversion` | `Kessler1M`, `PrescribedNd` |
| `SnowAutoconversion` | `NoSupersaturation`, `WithSupersaturation` |
| `Accretion` (various) | `CloudLiquidRainAccretion`, `CloudLiquidSnowAccretion`, `CloudIceRainAccretion`, `CloudIceSnowAccretion`, `RainSnowAccretion` |

Removed redundant fields from particle structs:

- τ_relax from CloudLiquid and CloudIce → moved to option types
- acnv1M, r0 from Rain and Snow → moved to option types / deleted (unused)
- T_freeze from Snow → use TDI.T_freeze(tps) from Thermodynamics
- CollisionEff struct → collision efficiencies moved into each accretion option's e field
- autoconv_2M, frostenberg2023, collision from Microphysics1MParams → moved to options