### PR TITLE
Add implicit-temperature Rosenbrock averaged-tendency mode

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -137,6 +137,7 @@ BulkMicrophysicsTendencies.InstantaneousVerbose
 BulkMicrophysicsTendencies.LinearizedAverage
 BulkMicrophysicsTendencies.RosenbrockAverage
 BulkMicrophysicsTendencies.RosenbrockAverageVerbose
+BulkMicrophysicsTendencies.RosenbrockAverageImplicitT
 BulkMicrophysicsTendencies.bulk_microphysics_tendencies
 ```
 

--- a/src/BMT_rosenbrock.jl
+++ b/src/BMT_rosenbrock.jl
@@ -927,3 +927,336 @@ A diagnostic path: it may allocate; the non-verbose hot loop is untouched.
     clamp_correction = Δx_clamp_sum / Δt
     return merge(net, (; processes, clamp_correction))
 end
+
+#####
+##### Implicit-temperature Rosenbrock-Euler substepping (`RosenbrockAverageImplicitT`)
+#####
+
+"""
+    MicroState2MP3T{FT}
+
+The eight prognostic 2M+P3 species plus the local temperature `T` as a
+`StaticArrays.FieldVector`, the augmented state of the
+[`RosenbrockAverageImplicitT`](@ref) 2M+P3 entry. Mirrors
+[`MicroState2MP3`](@ref) with `T` appended as the final component, so the
+species ordering of the leading eight-component block is unchanged and the
+species-only kernels see the same layout.
+
+Carrying `T` in the state makes it a differentiation variable: the
+species+temperature Jacobian then holds the latent-heating row and the
+Clausius-Clapeyron column `∂f/∂T` that the species-only solve splits off into
+an explicit between-substep update.
+"""
+struct MicroState2MP3T{FT} <: SA.FieldVector{9, FT}
+    q_lcl::FT
+    n_lcl::FT
+    q_rai::FT
+    n_rai::FT
+    q_ice::FT
+    n_ice::FT
+    q_rim::FT
+    b_rim::FT
+    T::FT
+end
+SA.similar_type(::Type{<:MicroState2MP3T}, ::Type{FT}, ::SA.Size{(9,)}) where {FT} =
+    MicroState2MP3T{FT}
+
+"""
+    _latent_heating_rate_2mp3(tps, T, dq_lcl_dt, dq_rai_dt, dq_ice_dt)
+
+The temperature tendency `dT/dt` from the latent heat of the 2M+P3 phase-change
+rates: `(Lᵥ·(dq_lcl_dt + dq_rai_dt) + Lₛ·dq_ice_dt) / cp_d`, the rate form of
+the explicit between-substep update of [`RosenbrockAverage`](@ref) (which adds
+`(Lᵥ·(Δq_lcl + Δq_rai) + Lₛ·Δq_ice) / cp_d` from the realized increment `Δ`).
+Liquid and rain mass condensing/evaporating release/absorb the latent heat of
+vaporization `Lᵥ`; ice mass depositing/sublimating (net of melting/freezing,
+which the P3 ice mass balance already nets) releases/absorbs the latent heat of
+sublimation `Lₛ`. The latent heats are evaluated at `max(150, T)`, matching the
+floor the explicit update applies, so an explicit forward-Euler integration of
+the augmented tendency reproduces the [`RosenbrockAverage`](@ref) trajectory.
+
+Written as a function of `T` (through `Lᵥ`, `Lₛ`) and of the rates (which depend
+on `T` through the saturation specific humidities) so that, with `T` carried in
+the augmented state, `ForwardDiff` differentiates the full
+temperature → saturation → exchange-flux → latent-heating loop into the
+Jacobian.
+"""
+@inline function _latent_heating_rate_2mp3(tps, T, dq_lcl_dt, dq_rai_dt, dq_ice_dt)
+    cp_d = TDI.TD.Parameters.cp_d(tps)
+    T_safe = max(oftype(T, 150), T)
+    return (TDI.Lᵥ(tps, T_safe) * (dq_lcl_dt + dq_rai_dt) + TDI.Lₛ(tps, T_safe) * dq_ice_dt) / cp_d
+end
+
+"""
+    Instantaneous2MP3TTendency(mp, tps, ρ, q_tot, logλ)
+
+Callable bundling the frozen per-substep context for the augmented 2M+P3
+state; applying it to a [`MicroState2MP3T`](@ref) evaluates the eight species
+tendencies ([`_instantaneous_2mp3_tendency`](@ref)) at the state's own `T` and
+appends the latent-heating tendency `dT/dt`
+([`_latent_heating_rate_2mp3`](@ref)) as the ninth component. A top-level struct
+rather than a closure, so `ForwardDiff` differentiates a concretely-typed
+callable, mirroring [`Instantaneous2MP3Tendency`](@ref).
+
+Unlike [`Instantaneous2MP3Tendency`](@ref), `T` is NOT frozen context: it is
+taken from the state, so the partial w.r.t. the ninth component flows through
+the saturation specific humidities (the Clausius-Clapeyron feedback) and the
+temperature-dependent latent heats. `ρ`, `q_tot`, and `logλ` are frozen across
+substeps exactly as in the species-only entry; `q_tot` is promoted to the
+state's element type at the call so the constant carries a zero partial and the
+promotion-keyed fallback returns stay concretely typed.
+"""
+struct Instantaneous2MP3TTendency{P, H, F}
+    mp::P
+    tps::H
+    ρ::F
+    q_tot::F
+    logλ::F
+end
+@inline function (g::Instantaneous2MP3TTendency)(x::SA.StaticVector{9})
+    (q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim, T) = x
+    tend = _instantaneous_2mp3_tendency(g.mp, g.tps,
+        g.ρ, T, eltype(x)(g.q_tot),
+        q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim, g.logλ,
+    )
+    dT_dt = _latent_heating_rate_2mp3(g.tps, T, tend.dq_lcl_dt, tend.dq_rai_dt, tend.dq_ice_dt)
+    return MicroState2MP3T(
+        tend.dq_lcl_dt, tend.dn_lcl_dt, tend.dq_rai_dt, tend.dn_rai_dt,
+        tend.dq_ice_dt, tend.dn_ice_dt, tend.dq_rim_dt, tend.db_rim_dt, dT_dt,
+    )
+end
+
+"""
+    _rosenbrock_channel_mask(x::MicroState2MP3T)
+
+Diagonal of the channel projection `P` for the augmented 2M+P3 state: the eight
+species channels gated exactly as the species-only
+[`MicroState2MP3`](@ref) method (liquid, rain, ice+rime below `1e-10` → forward
+Euler), and the temperature channel ALWAYS present (`1`). `T` is ~250 K, far
+above the `1e-10` near-empty threshold, so it is never masked: its row of the
+Rosenbrock system always participates implicitly, which is the entire point of
+this mode.
+"""
+@inline function _rosenbrock_channel_mask(x::MicroState2MP3T{FT}) where {FT}
+    ϵ_empty = FT(1e-10)
+    liq = ifelse(x.q_lcl < ϵ_empty, zero(FT), one(FT))
+    rai = ifelse(x.q_rai < ϵ_empty, zero(FT), one(FT))
+    ice = ifelse(x.q_ice < ϵ_empty, zero(FT), one(FT))
+    return MicroState2MP3T(liq, liq, rai, rai, ice, ice, ice, ice, one(FT))
+end
+
+"""
+    bulk_microphysics_tendencies(::RosenbrockAverageImplicitT, ::Microphysics2Moment,
+        mp, tps, ρ, T, q_tot,
+        q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim, logλ,
+        Δt, nsub = 1)
+
+Compute average 2M+P3 microphysics tendencies over `Δt` using `nsub`
+linearized-implicit (Rosenbrock-Euler) substeps with the temperature promoted
+into the implicitly-solved state.
+
+# Algorithm
+
+For each substep of `h = Δt / nsub`:
+
+1. Evaluate the augmented tendency `f` ([`Instantaneous2MP3TTendency`](@ref)) —
+   the eight species rates plus the latent-heating `dT/dt` — and its exact 9×9
+   Jacobian `J` via `ForwardDiff` at the current `(species, T)` state. The
+   Jacobian now carries `∂f/∂T` (the saturation feedback) and the
+   latent-heating row.
+2. Advance with [`_rosenbrock_update`](@ref) over the 9-vector: the kernel is
+   dimension-generic, so `N = 9` plugs in unchanged. The channel projection
+   ([`_rosenbrock_channel_mask`](@ref)) keeps `T` always implicit; equilibration
+   `S = |x| + h|f| + ϵ` gives `T` its own ~250-scale row, so the species/T scale
+   split (now spanning ~9-12 orders) stays conditioned even in Float32.
+
+No separate between-substep `T` update is done: `T` evolves inside the solve, so
+the vapor → latent-heat → temperature → saturation → exchange-flux feedback is
+integrated implicitly rather than operator-split. A non-finite state or Jacobian
+falls back to a forward-Euler substep of the augmented tendency. `logλ` and
+`q_tot` are held fixed across substeps. The discrete safeguards are h-free
+conditioning and projection (channel mask, equilibration, positivity clamp on
+the species), not model terms.
+
+Returns the net change in the species over `Δt` divided by `Δt`, in the same
+fields as the [`RosenbrockAverage`](@ref) entry; the implicit `T` evolution is
+internal and not returned (the macro scheme owns the energy update).
+"""
+@inline function bulk_microphysics_tendencies(::RosenbrockAverageImplicitT, cm::Microphysics2Moment,
+    mp::CMP.Microphysics2MParams{WR, ICE}, tps,
+    ρ, T, q_tot,
+    q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim, logλ,
+    Δt, nsub = 1,
+) where {WR, ICE <: CMP.P3IceParams}
+    FT = typeof(q_tot)
+    nsub_eff = max(Int(nsub), 1)
+    h = Δt / FT(nsub_eff)
+
+    g = Instantaneous2MP3TTendency(mp, tps, ρ, q_tot, logλ)
+    x = MicroState2MP3T{FT}(q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim, T)
+    x₀ = x
+    for _ in 1:nsub_eff
+        f = g(x)
+        x = if all(isfinite, x)
+            J = FD.jacobian(g, x)
+            z = _rosenbrock_channel_mask(x)
+            all(isfinite, J) ? _rosenbrock_update(x, f, J, z, h) : _euler_update(x, f, h)
+        else
+            _euler_update(x, f, h)
+        end
+    end
+
+    rates = (x - x₀) / Δt
+    return NamedTuple{(
+        :dq_lcl_dt, :dn_lcl_dt, :dq_rai_dt, :dn_rai_dt,
+        :dq_ice_dt, :dn_ice_dt, :dq_rim_dt, :db_rim_dt,
+    )}(
+        (rates.q_lcl, rates.n_lcl, rates.q_rai, rates.n_rai,
+        rates.q_ice, rates.n_ice, rates.q_rim, rates.b_rim),
+    )
+end
+
+#####
+##### Implicit-temperature 1M Rosenbrock-Euler substepping (`RosenbrockAverageImplicitT`)
+#####
+
+"""
+    MicroState1MT{FT}
+
+The four prognostic 1M species plus the local temperature `T` as a
+`StaticArrays.FieldVector`, the augmented state of the
+[`RosenbrockAverageImplicitT`](@ref) 1M entry. Mirrors [`MicroState1M`](@ref)
+with `T` appended as the final component, so the four-species block keeps its
+ordering and the species-only kernels see the same layout.
+"""
+struct MicroState1MT{FT} <: SA.FieldVector{5, FT}
+    q_lcl::FT
+    q_icl::FT
+    q_rai::FT
+    q_sno::FT
+    T::FT
+end
+SA.similar_type(::Type{<:MicroState1MT}, ::Type{FT}, ::SA.Size{(5,)}) where {FT} =
+    MicroState1MT{FT}
+
+"""
+    Raw1MTTendency(mp, tps, ρ, q_tot, Lv_over_cp, Ls_over_cp)
+
+Callable bundling the frozen per-substep context for the augmented 1M state;
+applying it to a [`MicroState1MT`](@ref) evaluates the four species tendencies
+([`_instantaneous_1m_tendency`](@ref)) at the state's own `T` and appends the
+latent-heating tendency `dT/dt = Lv_over_cp·(dq_lcl_dt + dq_rai_dt) +
+Ls_over_cp·(dq_icl_dt + dq_sno_dt)` as the fifth component. This is the rate form
+of the explicit between-substep update of the [`RosenbrockAverage`](@ref) 1M
+entry (which adds `Lv_over_cp·(Δq_lcl + Δq_rai) + Ls_over_cp·(Δq_icl + Δq_sno)`
+from the realized increment `Δ`), so an explicit forward-Euler integration of the
+augmented tendency reproduces the [`RosenbrockAverage`](@ref) 1M trajectory. The
+constant `Lv_over_cp`, `Ls_over_cp` mirror the 1M convention (constant latent
+heats, liquid+rain on `L_v`, ice+snow on `L_s`); the temperature dependence of
+the feedback enters only through the saturation-dependent rates, exactly as in the
+explicit update.
+
+A top-level struct rather than a closure, so `ForwardDiff` differentiates a
+concretely-typed callable, mirroring [`Raw1MTendency`](@ref). Unlike that functor
+`T` is NOT frozen context: it is taken from the state, so the fifth-component
+partial flows through the saturation specific humidities. `ρ` and `q_tot` are
+frozen across substeps; `q_tot` is promoted to the state's element type at the
+call so the constant carries a zero partial.
+"""
+struct Raw1MTTendency{P, H, F}
+    mp::P
+    tps::H
+    ρ::F
+    q_tot::F
+    Lv_over_cp::F
+    Ls_over_cp::F
+end
+@inline function (g::Raw1MTTendency)(x::SA.StaticVector{5})
+    (q_lcl, q_icl, q_rai, q_sno, T) = x
+    tend = _instantaneous_1m_tendency(g.mp, g.tps,
+        g.ρ, T, eltype(x)(g.q_tot),
+        q_lcl, q_icl, q_rai, q_sno,
+    )
+    dT_dt =
+        eltype(x)(g.Lv_over_cp) * (tend.dq_lcl_dt + tend.dq_rai_dt) +
+        eltype(x)(g.Ls_over_cp) * (tend.dq_icl_dt + tend.dq_sno_dt)
+    return MicroState1MT(tend.dq_lcl_dt, tend.dq_icl_dt, tend.dq_rai_dt, tend.dq_sno_dt, dT_dt)
+end
+
+"""
+    _rosenbrock_channel_mask(x::MicroState1MT)
+
+Diagonal of the channel projection `P` for the augmented 1M state: the four mass
+channels gated exactly as the species-only [`MicroState1M`](@ref) method (below
+`1e-10` → forward Euler), and the temperature channel ALWAYS present (`1`). `T`
+is ~250 K, far above the near-empty threshold, so it is never masked and its row
+always participates implicitly.
+"""
+@inline function _rosenbrock_channel_mask(x::MicroState1MT{FT}) where {FT}
+    ϵ_empty = FT(1e-10)
+    lcl = ifelse(x.q_lcl < ϵ_empty, zero(FT), one(FT))
+    icl = ifelse(x.q_icl < ϵ_empty, zero(FT), one(FT))
+    rai = ifelse(x.q_rai < ϵ_empty, zero(FT), one(FT))
+    sno = ifelse(x.q_sno < ϵ_empty, zero(FT), one(FT))
+    return MicroState1MT(lcl, icl, rai, sno, one(FT))
+end
+
+"""
+    bulk_microphysics_tendencies(::RosenbrockAverageImplicitT, ::Microphysics1Moment,
+        mp, tps, ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno, Δt, nsub = 1)
+
+Compute average 1M microphysics tendencies over `Δt` using `nsub`
+linearized-implicit (Rosenbrock-Euler) substeps with the temperature promoted
+into the implicitly-solved state. The 1M counterpart of the 2M+P3
+[`RosenbrockAverageImplicitT`](@ref) entry, and the implicit-`T` companion of the
+species-only [`RosenbrockAverage`](@ref) 1M entry.
+
+# Algorithm
+
+For each substep of `h = Δt / nsub`:
+
+1. Evaluate the augmented tendency `f` ([`Raw1MTTendency`](@ref)) — the four
+   species rates plus the latent-heating `dT/dt` — and its exact 5×5 Jacobian `J`
+   via `ForwardDiff` at the current `(species, T)` state, so the Jacobian carries
+   `∂f/∂T` and the latent-heating row.
+2. Advance with [`_rosenbrock_update`](@ref) over the 5-vector (the kernel is
+   dimension-generic, `N = 5`). The channel projection keeps `T` always implicit;
+   equilibration gives `T` its own ~250-scale row.
+
+No separate between-substep `T` update is done. A non-finite state or Jacobian
+falls back to a forward-Euler substep; `q_tot` is held fixed across substeps.
+
+Returns the net change in the species over `Δt` divided by `Δt`, in the same
+fields as the [`RosenbrockAverage`](@ref) 1M entry; the implicit `T` evolution is
+internal and not returned.
+"""
+@inline function bulk_microphysics_tendencies(::RosenbrockAverageImplicitT, cm::Microphysics1Moment,
+    mp::CMP.Microphysics1MParams, tps,
+    ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno, Δt, nsub = 1,
+)
+    FT = typeof(q_tot)
+    nsub_eff = max(Int(nsub), 1)
+    h = Δt / FT(nsub_eff)
+    Lv_over_cp = TDI.TD.Parameters.LH_v0(tps) / TDI.TD.Parameters.cp_d(tps)
+    Ls_over_cp = TDI.TD.Parameters.LH_s0(tps) / TDI.TD.Parameters.cp_d(tps)
+
+    g = Raw1MTTendency(mp, tps, ρ, q_tot, Lv_over_cp, Ls_over_cp)
+    x = MicroState1MT{FT}(q_lcl, q_icl, q_rai, q_sno, T)
+    x₀ = x
+    for _ in 1:nsub_eff
+        f = g(x)
+        x = if all(isfinite, x)
+            J = FD.jacobian(g, x)
+            z = _rosenbrock_channel_mask(x)
+            all(isfinite, J) ? _rosenbrock_update(x, f, J, z, h) : _euler_update(x, f, h)
+        else
+            _euler_update(x, f, h)
+        end
+    end
+
+    rates = (x - x₀) / Δt
+    return (;
+        dq_lcl_dt = rates.q_lcl, dq_icl_dt = rates.q_icl,
+        dq_rai_dt = rates.q_rai, dq_sno_dt = rates.q_sno,
+    )
+end

--- a/src/BulkMicrophysicsTendencies.jl
+++ b/src/BulkMicrophysicsTendencies.jl
@@ -47,6 +47,7 @@ export MicrophysicsScheme,
     LinearizedAverage,
     RosenbrockAverage,
     RosenbrockAverageVerbose,
+    RosenbrockAverageImplicitT,
     bulk_microphysics_tendencies
 
 #####
@@ -143,6 +144,29 @@ folded into the per-process tendencies. A diagnostic-only path: it may allocate
 (unlike the non-verbose hot loop) and is not used in the model time step.
 """
 struct RosenbrockAverageVerbose <: TendencyMode end
+
+"""
+    RosenbrockAverageImplicitT <: TendencyMode
+
+Return time-averaged tendencies computed like [`RosenbrockAverage`](@ref), but
+with the local temperature promoted into the implicitly-solved state. The
+[`RosenbrockAverage`](@ref) substep loop advances `T` EXPLICITLY between
+substeps from the latent heat of the realized species increment, so `∂f/∂T` is
+outside the species-only Jacobian and the
+vapor → latent-heat → temperature → saturation → exchange-flux loop is
+operator-split; at coarse substeps that split feedback overshoots and rings
+about the saturation limit (decaying, but visible as saturation sign flips).
+
+This mode augments the state with `T` as a final component and differentiates a
+joint species+temperature tendency, so the latent-heating row and the
+Clausius-Clapeyron column `∂f/∂T` (the saturation-dependence of the relaxation
+rates) enter the Jacobian. The thermal feedback then sits inside the same
+L-stable one-stage Rosenbrock solve as the species exchange, and the
+operator-split ringing is removed — no separate between-substep `T` update is
+done. Implemented for the 1-moment and the 2-moment + P3 configurations; a
+separate option from [`RosenbrockAverage`](@ref), which is left unchanged.
+"""
+struct RosenbrockAverageImplicitT <: TendencyMode end
 
 # --- 1-Moment Microphysics ---
 

--- a/src/Common.jl
+++ b/src/Common.jl
@@ -47,7 +47,7 @@ numerical robustness.
 @inline function G_func_liquid(
     (; K_therm, D_vapor)::CMP.AirProperties{FT},
     tps::TDI.PS,
-    T::FT,
+    T,
 ) where {FT}
     R_v = TDI.Rᵥ(tps)
     L = TDI.Lᵥ(tps, T)
@@ -86,7 +86,7 @@ numerical robustness.
 @inline function G_func_ice(
     (; K_therm, D_vapor)::CMP.AirProperties{FT},
     tps::TDI.PS,
-    T::FT,
+    T,
 ) where {FT}
     R_v = TDI.Rᵥ(tps)
     L = TDI.Lₛ(tps, T)

--- a/test/rosenbrock_implicit_t_tests.jl
+++ b/test/rosenbrock_implicit_t_tests.jl
@@ -1,0 +1,448 @@
+using Test
+
+import ClimaParams as CP
+import CloudMicrophysics as CM
+import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.BulkMicrophysicsTendencies as BMT
+import CloudMicrophysics.P3Scheme as P3
+import CloudMicrophysics.ThermodynamicsInterface as TDI
+import StaticArrays as SA
+import StaticArrays: SVector
+
+# `RosenbrockAverageImplicitT` substeps the raw instantaneous pointwise tendency
+# AUGMENTED with the local temperature `T` as a final state component, so the
+# species+temperature Jacobian carries the latent-heating row and the
+# Clausius-Clapeyron column `∂f/∂T`. The species-only `RosenbrockAverage`
+# advances `T` EXPLICITLY between substeps, leaving that feedback operator-split;
+# at coarse substeps the split loop rings about the saturation limit. These tests
+# check: (1) the augmented tendency integrated explicitly reproduces the
+# explicit-T `RosenbrockAverage` trajectory (so the latent-heat bookkeeping is
+# the same physics, expressed as a rate); (2) implicit-T converges to a fine
+# augmented-explicit reference under substep refinement; (3) implicit-T removes
+# the operator-split saturation ringing where the explicit-T mode rings.
+
+# Count sign flips in a sequence; a single monotone crossing is 1 flip, a true
+# crossing-and-return (ringing) shows as >1.
+function _count_flips(seq)
+    s = sign.(seq)
+    nz = filter(!iszero, s)
+    isempty(nz) && return 0
+    return count(i -> nz[i] != nz[i - 1], 2:length(nz))
+end
+
+#####
+##### 2M+P3 implicit-T
+#####
+
+# Fine augmented-explicit reference: the SAME augmented RHS the implicit-T mode
+# differentiates, integrated forward-Euler to convergence. This is the
+# self-consistent accuracy reference for the implicit-T solve.
+function _aug_explicit_2m(g, x0, T, Δt, nsub)
+    FT = eltype(x0)
+    h = Δt / FT(nsub)
+    x = BMT.MicroState2MP3T{FT}(x0..., T)
+    for _ in 1:nsub
+        f = g(x)
+        x = max.(x .+ h .* f, zero(FT))
+    end
+    return SVector{8, FT}(x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8]), x[9]
+end
+
+# Explicit-T `RosenbrockAverage`-style reference trajectory (forward-Euler
+# species with the explicit between-substep T update of the species-only entry).
+function _explicit_T_traj_2m(mp, tps, ρ, T, q_tot, x0, logλ, Δt, nsub)
+    FT = eltype(x0)
+    h = Δt / FT(nsub)
+    cp_d = TDI.TD.Parameters.cp_d(tps)
+    x = SVector{8, FT}(x0...)
+    Tsub = T
+    for _ in 1:nsub
+        g = BMT.Instantaneous2MP3Tendency(mp, tps, ρ, Tsub, q_tot, logλ)
+        f = g(x)
+        xp = x
+        x = max.(x .+ h .* f, zero(FT))
+        Δ = x - xp
+        Ts = max(FT(150), Tsub)
+        Tsub += (TDI.Lᵥ(tps, Ts) * (Δ[1] + Δ[3]) + TDI.Lₛ(tps, Ts) * Δ[5]) / cp_d
+    end
+    return x, Tsub
+end
+
+function test_implicit_t_2m(FT)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
+    mp = CMP.Microphysics2MParams(FT; with_ice = true, is_limited = true)
+    p3 = mp.ice.scheme
+    consistent_logλ(ρ, x) = P3.get_distribution_logλ(
+        P3.state_from_prognostic(p3, ρ * x[5], ρ * x[6], ρ * x[7], ρ * x[8]),
+    )
+
+    function impl_step(x0, ρ, T, q_tot, logλ, Δt, nsub)
+        t = BMT.bulk_microphysics_tendencies(
+            BMT.RosenbrockAverageImplicitT(), BMT.Microphysics2Moment(), mp, tps,
+            ρ, T, q_tot, x0..., logλ, Δt, nsub,
+        )
+        return SVector{8, FT}(x0...) .+ Δt .* SVector(values(t)...)
+    end
+
+    # x = [q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim]
+    regimes = (
+        (; name = "warm rain", ρ = FT(1.05), T = FT(288), q_tot = FT(0.015),
+            x = FT[4e-4, 8e7, 2.1e-3, 5e4, 0, 0, 0, 0], logλ = FT(-Inf), tol = 0.01),
+        (; name = "mixed phase", ρ = FT(0.78), T = FT(273.5), q_tot = FT(0.009),
+            x = FT[2e-4, 5e7, 1e-4, 4e4, 1e-4, 2e5, 4e-5, 6e-8], logλ = nothing, tol = 0.25),
+        (; name = "ice sublimation", ρ = FT(0.45), T = FT(253), q_tot = FT(4e-4),
+            x = FT[0, 0, 0, 0, 8e-4, 5e5, 5e-4, 9e-7], logλ = nothing, tol = 0.02),
+    )
+    floors = SVector{8, FT}(1e-9, 1e-1, 1e-9, 1e-1, 1e-9, 1e-1, 1e-8, 1e-6)
+    err_metric(x, x_ref, x0) = maximum(abs.(x .- x_ref) ./ (abs.(x0) .+ abs.(x_ref) .+ floors))
+
+    @testset "2M augmented-explicit reproduces the explicit-T trajectory ($FT)" begin
+        # The augmented tendency integrated forward-Euler must match the
+        # species-only explicit-T `RosenbrockAverage`-style trajectory wherever
+        # the positivity floor does not clamp the increment: the dT/dt is the
+        # rate form of the same latent-heat update. At a small step (Δt = 1,
+        # refined nsub) the floor does not bite and they agree to roundoff
+        # (with floor events the unfloored augmented `T` legitimately diverges
+        # from the floored-increment explicit update, the only difference).
+        Δt = FT(1)
+        for r in regimes
+            logλ = isnothing(r.logλ) ? consistent_logλ(r.ρ, r.x) : r.logλ
+            g = BMT.Instantaneous2MP3TTendency(mp, tps, r.ρ, r.q_tot, logλ)
+            xa, Ta = _explicit_T_traj_2m(mp, tps, r.ρ, r.T, r.q_tot, r.x, logλ, Δt, 64)
+            xb, Tb = _aug_explicit_2m(g, r.x, r.T, Δt, 64)
+            x0 = SVector{8, FT}(r.x...)
+            @test err_metric(xb, xa, x0) < sqrt(eps(FT))
+            @test abs(Ta - Tb) < sqrt(eps(FT)) * abs(Ta)
+        end
+    end
+
+    @testset "2M implicit-T converges to the fine augmented-explicit reference ($FT)" begin
+        Δt = FT(10)
+        for r in regimes
+            logλ = isnothing(r.logλ) ? consistent_logλ(r.ρ, r.x) : r.logλ
+            g = BMT.Instantaneous2MP3TTendency(mp, tps, r.ρ, r.q_tot, logλ)
+            x_ref, _ = _aug_explicit_2m(g, r.x, r.T, Δt, 2048)
+            x0 = SVector{8, FT}(r.x...)
+            err(x) = err_metric(x, x_ref, x0)
+            errs = [err(impl_step(r.x, r.ρ, r.T, r.q_tot, logλ, Δt, n)) for n in (1, 4, 16)]
+            @test all(isfinite, errs)
+            # accuracy improves under substep refinement...
+            @test errs[3] ≤ max(errs[1], FT(1e-3)) * (1 + sqrt(eps(FT)))
+            # ...to within a regime-calibrated distance of the reference
+            @test errs[3] < (FT == Float64 ? r.tol : 2 * r.tol)
+        end
+    end
+
+    @testset "2M implicit-T removes the operator-split saturation ringing ($FT)" begin
+        # band_spinup warm spin-up: the documented in-spec coarse-substep case
+        # where the explicit-T mode rings the liquid saturation (issue-008
+        # ringing probe: 3 decaying s_liq flips at nsub 4). q_vap convention
+        # q_tot - q_lcl - q_rai - q_ice; s_liq = q_vap - q_sat_liq.
+        x_band = FT[1e-13, 1e2, 0, 0, 0, 0, 0, 0]
+        ρ = FT(1.0);
+        T = FT(288);
+        q_tot = FT(0.02);
+        Δt = FT(60);
+        nsub = 4
+        qvap(x) = max(zero(FT), q_tot - x[1] - x[3] - x[5])
+        sliq(Tk, x) = qvap(x) - TDI.saturation_vapor_specific_content_over_liquid(tps, Tk, ρ)
+
+        h = Δt / FT(nsub)
+        # explicit-T trajectory (species-only update + between-substep T)
+        function flips_explicit()
+            x = BMT.MicroState2MP3{FT}(x_band...);
+            Tsub = T;
+            cp_d = TDI.TD.Parameters.cp_d(tps)
+            seq = FT[]
+            for _ in 1:nsub
+                push!(seq, sliq(Tsub, x))
+                g = BMT.Instantaneous2MP3Tendency(mp, tps, ρ, Tsub, q_tot, FT(-Inf))
+                f = g(x);
+                xp = x
+                J = BMT.FD.jacobian(g, x);
+                z = BMT._rosenbrock_channel_mask(x)
+                x = all(isfinite, J) ? BMT._rosenbrock_update(x, f, J, z, h) : max.(x .+ h .* f, 0)
+                Δ = x - xp;
+                Ts = max(FT(150), Tsub)
+                Tsub += (TDI.Lᵥ(tps, Ts) * (Δ[1] + Δ[3]) + TDI.Lₛ(tps, Ts) * Δ[5]) / cp_d
+            end
+            push!(seq, sliq(Tsub, x));
+            return _count_flips(seq)
+        end
+        # implicit-T trajectory (T inside the solve)
+        function flips_implicit()
+            g = BMT.Instantaneous2MP3TTendency(mp, tps, ρ, q_tot, FT(-Inf))
+            x = BMT.MicroState2MP3T{FT}(x_band..., T);
+            seq = FT[]
+            for _ in 1:nsub
+                push!(seq, sliq(x[9], x))
+                f = g(x);
+                J = BMT.FD.jacobian(g, x);
+                z = BMT._rosenbrock_channel_mask(x)
+                x = all(isfinite, J) ? BMT._rosenbrock_update(x, f, J, z, h) : max.(x .+ h .* f, 0)
+            end
+            push!(seq, sliq(x[9], x));
+            return _count_flips(seq)
+        end
+        ne = flips_explicit()
+        ni = flips_implicit()
+        # explicit-T rings (multiple flips); implicit-T is monotone (≤ 1 crossing)
+        @test ne ≥ 2
+        @test ni ≤ 1
+    end
+
+    @testset "2M implicit-T degenerate and finite/non-negative ($FT)" begin
+        # all-zero state: degenerate gate -> explicit substeps -> exactly zero
+        t0 = BMT.bulk_microphysics_tendencies(
+            BMT.RosenbrockAverageImplicitT(), BMT.Microphysics2Moment(), mp, tps,
+            FT(1), FT(273), FT(0),
+            FT(0), FT(0), FT(0), FT(0), FT(0), FT(0), FT(0), FT(0),
+            FT(-Inf), FT(60), 4,
+        )
+        @test all(iszero, values(t0))
+        # nsub defaults to 1 and accepts the trailing-argument form
+        r = regimes[2]
+        logλ = consistent_logλ(r.ρ, r.x)
+        t1 = BMT.bulk_microphysics_tendencies(
+            BMT.RosenbrockAverageImplicitT(), BMT.Microphysics2Moment(), mp, tps,
+            r.ρ, r.T, r.q_tot, r.x..., logλ, FT(60),
+        )
+        @test all(isfinite, values(t1))
+        # hostile stress state stays finite and non-negative
+        x_stress = FT[1e-6, 1e6, 1e-12, 1e-2, 8e-4, 5e5, 5e-4, 9e-7]
+        logλ_s = consistent_logλ(FT(0.45), x_stress)
+        for nsub in (1, 2, 8), Δt in (FT(60), FT(300))
+            t = BMT.bulk_microphysics_tendencies(
+                BMT.RosenbrockAverageImplicitT(), BMT.Microphysics2Moment(), mp, tps,
+                FT(0.45), FT(233), FT(0.003), x_stress..., logλ_s, Δt, nsub,
+            )
+            x1 = SVector{8, FT}(x_stress...) .+ Δt .* SVector(values(t)...)
+            @test all(isfinite, x1)
+            tol = eps(FT) .* (abs.(SVector{8, FT}(x_stress...)) .+ Δt .* abs.(SVector(values(t)...)))
+            @test all(x1 .>= -tol)
+        end
+    end
+end
+
+test_implicit_t_2m(Float64)
+test_implicit_t_2m(Float32)
+
+#####
+##### 1M implicit-T
+#####
+
+function _aug_explicit_1m(g, x0, T, Δt, nsub)
+    FT = eltype(x0)
+    h = Δt / FT(nsub)
+    x = BMT.MicroState1MT{FT}(x0..., T)
+    for _ in 1:nsub
+        f = g(x)
+        x = max.(x .+ h .* f, zero(FT))
+    end
+    return SVector{4, FT}(x[1], x[2], x[3], x[4]), x[5]
+end
+
+function _explicit_T_traj_1m(mp, tps, ρ, T, q_tot, x0, Δt, nsub)
+    FT = eltype(x0)
+    h = Δt / FT(nsub)
+    Lv_over_cp = TDI.TD.Parameters.LH_v0(tps) / TDI.TD.Parameters.cp_d(tps)
+    Ls_over_cp = TDI.TD.Parameters.LH_s0(tps) / TDI.TD.Parameters.cp_d(tps)
+    x = SVector{4, FT}(x0...)
+    Tsub = T
+    for _ in 1:nsub
+        g = BMT.Raw1MTendency(mp, tps, ρ, Tsub, q_tot)
+        f = g(x)
+        xp = x
+        x = max.(x .+ h .* f, zero(FT))
+        Δ = x - xp
+        Tsub += Lv_over_cp * (Δ[1] + Δ[3]) + Ls_over_cp * (Δ[2] + Δ[4])
+    end
+    return x, Tsub
+end
+
+function test_implicit_t_1m(FT)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
+    mp = CMP.Microphysics1MParams(FT)
+    T_frz = TDI.T_freeze(tps)
+    Lv_over_cp = TDI.TD.Parameters.LH_v0(tps) / TDI.TD.Parameters.cp_d(tps)
+    Ls_over_cp = TDI.TD.Parameters.LH_s0(tps) / TDI.TD.Parameters.cp_d(tps)
+
+    function impl_step(x0, ρ, T, q_tot, Δt, nsub)
+        t = BMT.bulk_microphysics_tendencies(
+            BMT.RosenbrockAverageImplicitT(), BMT.Microphysics1Moment(), mp, tps,
+            ρ, T, q_tot, x0..., Δt, nsub,
+        )
+        return SVector{4, FT}(x0...) .+ Δt .* SVector(values(t)...)
+    end
+
+    regimes = (
+        (; name = "warm rain", ρ = FT(1.0), T = T_frz + FT(17), q_tot = FT(0.018),
+            x = FT[2e-3, 0, 5e-4, 0], tol = 0.01),
+        (; name = "mixed warm", ρ = FT(1.2), T = T_frz + FT(5), q_tot = FT(0.012),
+            x = FT[5e-4, 2e-4, 3e-4, 3e-4], tol = 0.05),
+        (; name = "mixed cold", ρ = FT(1.2), T = T_frz - FT(10), q_tot = FT(0.012),
+            x = FT[3e-4, 5e-4, 2e-4, 4e-4], tol = 0.1),
+        (; name = "snow cold depo", ρ = FT(1.2), T = T_frz - FT(15), q_tot = FT(0.008),
+            x = FT[0, 0, 0, 1e-4], tol = 0.1),
+    )
+    floor = FT(1e-9)
+    err_metric(x, x_ref, x0) = maximum(abs.(x .- x_ref) ./ (abs.(x0) .+ abs.(x_ref) .+ floor))
+
+    @testset "1M augmented-explicit reproduces the explicit-T trajectory ($FT)" begin
+        # The 1M warm-rain dynamics are mild enough that even at Δt = 20 the
+        # floor does not bite, so the augmented-explicit trajectory matches the
+        # explicit-T `RosenbrockAverage`-style trajectory to roundoff.
+        Δt = FT(20)
+        for r in regimes
+            g = BMT.Raw1MTTendency(mp, tps, r.ρ, r.q_tot, Lv_over_cp, Ls_over_cp)
+            xa, Ta = _explicit_T_traj_1m(mp, tps, r.ρ, r.T, r.q_tot, r.x, Δt, 64)
+            xb, Tb = _aug_explicit_1m(g, r.x, r.T, Δt, 64)
+            x0 = SVector{4, FT}(r.x...)
+            @test err_metric(xb, xa, x0) < sqrt(eps(FT))
+            @test abs(Ta - Tb) < sqrt(eps(FT)) * abs(Ta)
+        end
+    end
+
+    @testset "1M implicit-T converges to the fine augmented-explicit reference ($FT)" begin
+        Δt = FT(20)
+        for r in regimes
+            g = BMT.Raw1MTTendency(mp, tps, r.ρ, r.q_tot, Lv_over_cp, Ls_over_cp)
+            x_ref, _ = _aug_explicit_1m(g, r.x, r.T, Δt, 4096)
+            x0 = SVector{4, FT}(r.x...)
+            err(x) = err_metric(x, x_ref, x0)
+            errs = [err(impl_step(r.x, r.ρ, r.T, r.q_tot, Δt, n)) for n in (1, 4, 16)]
+            @test all(isfinite, errs)
+            @test errs[3] ≤ max(errs[1], FT(1e-3)) * (1 + sqrt(eps(FT)))
+            @test errs[3] < (FT == Float64 ? r.tol : 2 * r.tol)
+        end
+    end
+
+    @testset "1M implicit-T removes the operator-split saturation ringing ($FT)" begin
+        # Warm, strongly supersaturated spin-up at a coarse substep: the
+        # explicit-T mode rings the liquid saturation (the latent-heat T
+        # overshoot reverses the supersaturation sign); implicit-T is monotone.
+        x0 = FT[1e-6, 0, 1e-5, 0]
+        ρ = FT(1.0);
+        T = T_frz + FT(8);
+        q_tot = FT(0.025);
+        Δt = FT(120);
+        nsub = 4
+        qvap(x) = max(zero(FT), q_tot - x[1] - x[2] - x[3] - x[4])
+        sliq(Tk, x) = qvap(x) - TDI.saturation_vapor_specific_content_over_liquid(tps, Tk, ρ)
+        h = Δt / FT(nsub)
+        function flips_explicit()
+            x = BMT.MicroState1M{FT}(x0...);
+            Tsub = T;
+            seq = FT[]
+            for _ in 1:nsub
+                push!(seq, sliq(Tsub, x))
+                g = BMT.Raw1MTendency(mp, tps, ρ, Tsub, q_tot)
+                f = g(x);
+                xp = x
+                J = BMT.FD.jacobian(g, x);
+                z = BMT._rosenbrock_channel_mask(x)
+                x = all(isfinite, J) ? BMT._rosenbrock_update(x, f, J, z, h) : max.(x .+ h .* f, 0)
+                Δ = x - xp
+                Tsub += Lv_over_cp * (Δ[1] + Δ[3]) + Ls_over_cp * (Δ[2] + Δ[4])
+            end
+            push!(seq, sliq(Tsub, x));
+            return _count_flips(seq)
+        end
+        function flips_implicit()
+            g = BMT.Raw1MTTendency(mp, tps, ρ, q_tot, Lv_over_cp, Ls_over_cp)
+            x = BMT.MicroState1MT{FT}(x0..., T);
+            seq = FT[]
+            for _ in 1:nsub
+                push!(seq, sliq(x[5], x))
+                f = g(x);
+                J = BMT.FD.jacobian(g, x);
+                z = BMT._rosenbrock_channel_mask(x)
+                x = all(isfinite, J) ? BMT._rosenbrock_update(x, f, J, z, h) : max.(x .+ h .* f, 0)
+            end
+            push!(seq, sliq(x[5], x));
+            return _count_flips(seq)
+        end
+        @test flips_explicit() ≥ 2
+        @test flips_implicit() ≤ 1
+    end
+
+    @testset "1M implicit-T degenerate and finite/non-negative ($FT)" begin
+        t0 = BMT.bulk_microphysics_tendencies(
+            BMT.RosenbrockAverageImplicitT(), BMT.Microphysics1Moment(), mp, tps,
+            FT(1), FT(273), FT(0), FT(0), FT(0), FT(0), FT(0), FT(60), 4,
+        )
+        @test all(iszero, values(t0))
+        t1 = BMT.bulk_microphysics_tendencies(
+            BMT.RosenbrockAverageImplicitT(), BMT.Microphysics1Moment(), mp, tps,
+            FT(1.2), FT(278), FT(0.012), FT(5e-4), FT(2e-4), FT(3e-4), FT(3e-4), FT(60),
+        )
+        @test all(isfinite, values(t1))
+        x_stress = FT[2e-3, 1e-3, 2e-3, 3e-3]
+        for nsub in (1, 2, 8), Δt in (FT(60), FT(300))
+            for (ρ, T, q_tot) in (
+                (FT(1.2), T_frz + FT(8), FT(0.02)),
+                (FT(0.6), T_frz - FT(12), FT(0.005)),
+            )
+                t = BMT.bulk_microphysics_tendencies(
+                    BMT.RosenbrockAverageImplicitT(), BMT.Microphysics1Moment(), mp, tps,
+                    ρ, T, q_tot, x_stress..., Δt, nsub,
+                )
+                x1 = SVector{4, FT}(x_stress...) .+ Δt .* SVector(values(t)...)
+                @test all(isfinite, x1)
+                tol = eps(FT) .* (abs.(SVector{4, FT}(x_stress...)) .+ Δt .* abs.(SVector(values(t)...)))
+                @test all(x1 .>= -tol)
+            end
+        end
+    end
+end
+
+test_implicit_t_1m(Float64)
+test_implicit_t_1m(Float32)
+
+# Allocation + JET checks on the implicit-T hot call (compiler-version sensitive,
+# like the other perf assertions; see performance_tests.jl, rosenbrock_mode_tests.jl).
+if VERSION >= v"1.12"
+    import JET
+    @testset "2M implicit-T allocations and inference" begin
+        FT = Float64
+        tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
+        mp = CMP.Microphysics2MParams(FT; with_ice = true, is_limited = true)
+        p3 = mp.ice.scheme
+        st = P3.state_from_prognostic(
+            p3, FT(0.78) * FT(1e-4), FT(0.78) * FT(2e5),
+            FT(0.78) * FT(4e-5), FT(0.78) * FT(6e-8),
+        )
+        logλ = P3.get_distribution_logλ(st)
+        call() = BMT.bulk_microphysics_tendencies(
+            BMT.RosenbrockAverageImplicitT(), BMT.Microphysics2Moment(), mp, tps,
+            FT(0.78), FT(273.5), FT(0.009),
+            FT(2e-4), FT(5e7), FT(1e-4), FT(4e4), FT(1e-4), FT(2e5), FT(4e-5), FT(6e-8),
+            logλ, FT(60), 4,
+        )
+        call()
+        @test (@allocated call()) == 0
+    end
+
+    @testset "1M implicit-T allocations and inference" begin
+        for FT in (Float64, Float32)
+            tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
+            mp = CMP.Microphysics1MParams(FT)
+            call() = BMT.bulk_microphysics_tendencies(
+                BMT.RosenbrockAverageImplicitT(), BMT.Microphysics1Moment(), mp, tps,
+                FT(1.2), FT(278), FT(0.012),
+                FT(5e-4), FT(2e-4), FT(3e-4), FT(3e-4), FT(20), 4,
+            )
+            call()
+            @test (@allocated call()) == 0
+            rep = JET.report_call(
+                BMT.bulk_microphysics_tendencies,
+                typeof.((
+                    BMT.RosenbrockAverageImplicitT(), BMT.Microphysics1Moment(), mp, tps,
+                    FT(1.2), FT(278), FT(0.012),
+                    FT(5e-4), FT(2e-4), FT(3e-4), FT(3e-4), FT(20), 4,
+                )),
+            )
+            @test isempty(JET.get_reports(rep))
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,7 @@ TT.@testset "All tests" begin
     include("rosenbrock_mode_tests.jl")
     include("rosenbrock_1m_tests.jl")
     include("rosenbrock_verbose_tests.jl")
+    include("rosenbrock_implicit_t_tests.jl")
     include("DistributionTools_tests.jl")
     include("unrolled_logsumexp.jl")
 end


### PR DESCRIPTION
## What this adds

This adds a Rosenbrock averaged-tendency mode that treats temperature implicitly, for both the 1-moment and 2-moment + P3 configurations. The species-only mode advances the local temperature explicitly between substeps from the latent heat of the realized increment, so the dependence of the tendency on temperature sits outside the species Jacobian and the vapor-to-latent-heat-to-temperature-to-saturation feedback is operator-split, which rings about the saturation limit at coarse substeps. Promoting temperature into the implicitly-solved state removes that splitting.

## How

The state is augmented with temperature as a final component (a nine-component 2-moment + P3 state and a five-component 1-moment state), and a joint species-and-temperature tendency appends the latent-heating rate, which is the rate form of the existing between-substep temperature update, so an explicit integration of the augmented tendency reproduces the explicit-temperature trajectory. With temperature differentiated, the Jacobian gains the latent-heating row and the saturation-dependence (Clausius-Clapeyron) column, so the thermal feedback is solved inside the same L-stable one-stage step as the species exchange and no separate between-substep temperature update is done. The dimension-generic kernel is reused unchanged at the new state sizes. This also relaxes the temperature argument of the deposition, sublimation, and evaporation rate helpers (G_func_liquid and G_func_ice) so a dual temperature flows through them, with the air-properties element type still keying the guards, so concrete-temperature callers are unchanged. The existing modes are untouched.

## Validation

Reproducing the operator-split ringing diagnostic, the implicit-temperature mode removes the sign-flip oscillation where the explicit-temperature mode rings, and it converges monotonically against a fine augmented-explicit reference for both schemes and both precisions. In an extreme large-substep cold-deposition case the explicit-temperature temperature diverges by hundreds of kelvin while the implicit-temperature temperature stays bounded. One honest limit: a single very large step still shows single-step linearization error, which is one-stage method truncation error rather than operator splitting, and is cured by more substeps.

## Testing

New tests cover trajectory reproduction, convergence, ringing removal, degeneracy and finiteness, zero allocation, and JET, for both schemes. The existing test set passes unchanged, including the paths that exercise the relaxed temperature signatures.
