### PR TITLE
feat(P3): Gauss-Legendre quadrature, integrand breakpoints -> GL(6) default

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -221,6 +221,7 @@ These methods integrate over the particle size distribution.
 P3Scheme.D_m
 P3Scheme.ice_particle_terminal_velocity
 P3Scheme.ice_terminal_velocity_number_weighted
+P3Scheme.ice_terminal_velocity_number_weighted_from_prognostic
 P3Scheme.ice_terminal_velocity_mass_weighted
 ```
 
@@ -247,10 +248,19 @@ P3Scheme.bulk_liquid_ice_collision_sources
 Supporting methods:
 
 ```@docs
+P3Scheme.VolumetricCollisionRate
 P3Scheme.volumetric_collision_rate_integrand
 P3Scheme.compute_max_freeze_rate
 P3Scheme.compute_local_rime_density
 P3Scheme.get_liquid_integrals
+P3Scheme.crossing_integral_bounds
+P3Scheme.crossover_diameter
+P3Scheme.closed_rain_inner_NM
+P3Scheme.collision_cross_section_ice_liquid
+P3Scheme.collision_cross_section_ice_liquid_coeffs
+P3Scheme.collision_cross_section_ice_ice
+P3Scheme.ice_self_collection
+P3Scheme.wet_growth_onset_diameter
 P3Scheme.∫liquid_ice_collisions
 ```
 
@@ -262,8 +272,9 @@ P3Scheme.integrate
 P3Scheme.subintervals
 P3Scheme.ChebyshevGauss
 Quadrature.GaussLegendre
-Quadrature.build_quadrature
 P3Scheme.integral_bounds
+P3Scheme.velocity_integral_bounds
+P3Scheme.velocity_breakpoints
 ```
 
 # Aerosol model
@@ -406,6 +417,8 @@ Utilities.fac
 
 ```@docs
 Common
+Common.Chen2022VelocityCurve
+Common.particle_terminal_velocity
 Common.G_func_liquid
 Common.G_func_ice
 Common.logistic_function

--- a/docs/src/DevelopersGuide.md
+++ b/docs/src/DevelopersGuide.md
@@ -206,3 +206,25 @@ Add a comment of what you are testing and use `@test` to create your test.
 The GPU tests are ran twice: for `Float64` and `Float32`.
 Similar as with performance tests, some trial and error is needed
   to find good tolerances for both options.
+
+### P3 quadrature error study
+
+The P3 scheme evaluates its size-distribution integrals with a Gauss-Legendre
+rule whose default order is recorded in `src/parameters/Microphysics2MParams.jl`.
+The study that supports the default lives in `test/p3_quadrature_error_study.jl`:
+it measures the relative error of every quadrature-consuming P3 quantity against
+a high-order reference, across a set of physically plausible column states, and
+attributes it to the transport components (sedimentation velocities, melt), the
+components proportional to the collision efficiency, and the full bulk tendency
+vector.
+
+Run it from the repository root with
+
+```
+julia --project=test -e 'include("test/p3_quadrature_error_study.jl");
+                         run_quadrature_error_study()'
+```
+
+Rerun the study when changing the quadrature rule, the integral bounds or
+breakpoints, or the P3 process integrands, and revisit the default order and the
+tolerances in `test/bulk_tendencies_quadrature_tests.jl` accordingly.

--- a/docs/src/plots/P3Melting.jl
+++ b/docs/src/plots/P3Melting.jl
@@ -9,6 +9,7 @@ FT = Float64
 # parameters
 params = CMP.ParametersP3(FT; slope_law = :constant)
 vel = CMP.Chen2022VelType(FT)
+quad = CMP.Microphysics2MParams(FT; with_ice = true).ice.quad  # the package default rule
 aps = CMP.AirProperties(FT)
 tps = TDI.PS(FT)
 
@@ -34,7 +35,7 @@ Fᵣ = FT(0.8)
 label1 = "ρₐ=$ρₐ kg/m³, Fᵣ=$Fᵣ, ρᵣ=$(Int(ρᵣ)) kg/m³"
 state = P3.P3State(params, Lᵢ, Nᵢ, Fᵣ, ρᵣ)
 logλ = P3.get_distribution_logλ(state)
-melt1 = P3.ice_melt.(vel, aps, tps, params.T_freeze .+ ΔT_range, ρₐ, state, logλ)
+melt1 = P3.ice_melt.(vel, aps, tps, params.T_freeze .+ ΔT_range, ρₐ, state, logλ; quad)
 dLdt1 = getfield.(melt1, :dLdt)
 dNdt1 = getfield.(melt1, :dNdt)
 
@@ -42,7 +43,7 @@ Fᵣ = FT(0.2)
 label2 = "ρₐ=$ρₐ kg/m³, Fᵣ=$Fᵣ, ρᵣ=$(Int(ρᵣ)) kg/m³"
 state = P3.P3State(params, Lᵢ, Nᵢ, Fᵣ, ρᵣ)
 logλ = P3.get_distribution_logλ(state)
-melt2 = P3.ice_melt.(vel, aps, tps, params.T_freeze .+ ΔT_range, ρₐ, state, logλ)
+melt2 = P3.ice_melt.(vel, aps, tps, params.T_freeze .+ ΔT_range, ρₐ, state, logλ; quad)
 dLdt2 = getfield.(melt2, :dLdt)
 dNdt2 = getfield.(melt2, :dNdt)
 
@@ -50,7 +51,7 @@ dNdt2 = getfield.(melt2, :dNdt)
 label3 = "ρₐ=$ρₐ kg/m³, Fᵣ=$Fᵣ, ρᵣ=$(Int(ρᵣ)) kg/m³"
 state = P3.P3State(params, Lᵢ, Nᵢ, Fᵣ, ρᵣ)
 logλ = P3.get_distribution_logλ(state)
-melt3 = P3.ice_melt.(vel, aps, tps, params.T_freeze .+ ΔT_range, ρₐ, state, logλ)
+melt3 = P3.ice_melt.(vel, aps, tps, params.T_freeze .+ ΔT_range, ρₐ, state, logλ; quad)
 dLdt3 = getfield.(melt3, :dLdt)
 dNdt3 = getfield.(melt3, :dNdt)
 
@@ -58,7 +59,7 @@ dNdt3 = getfield.(melt3, :dNdt)
 label4 = "ρₐ=$ρₐ kg/m³, Fᵣ=$Fᵣ, ρᵣ=$(Int(ρᵣ)) kg/m³"
 state = P3.P3State(params, Lᵢ, Nᵢ, Fᵣ, ρᵣ)
 logλ = P3.get_distribution_logλ(state)
-melt4 = P3.ice_melt.(vel, aps, tps, params.T_freeze .+ ΔT_range, ρₐ, state, logλ)
+melt4 = P3.ice_melt.(vel, aps, tps, params.T_freeze .+ ΔT_range, ρₐ, state, logλ; quad)
 dLdt4 = getfield.(melt4, :dLdt)
 dNdt4 = getfield.(melt4, :dNdt)
 

--- a/docs/src/plots/P3TerminalVelocityPlots.jl
+++ b/docs/src/plots/P3TerminalVelocityPlots.jl
@@ -27,6 +27,7 @@ function get_values(
     D_m = zeros(x_resolution, y_resolution)
     D_m_regimes = zeros(x_resolution, y_resolution)
     ϕᵢ = zeros(x_resolution, y_resolution)
+    quad = CMP.Microphysics2MParams(FT; with_ice = true).ice.quad  # the package default rule
 
     for i in 1:x_resolution
         for j in 1:y_resolution
@@ -35,8 +36,8 @@ function get_values(
             state = P3.P3State(params, L, N, F_rim, ρ_rim)
             state_noar = P3.P3State(params_noar, L, N, F_rim, ρ_rim)
             logλ = P3.get_distribution_logλ(state)
-            V_m[i, j] = P3.ice_terminal_velocity_mass_weighted(Chen2022, ρ_a, state_noar, logλ)
-            V_m_ϕ[i, j] = P3.ice_terminal_velocity_mass_weighted(Chen2022, ρ_a, state, logλ)
+            V_m[i, j] = P3.ice_terminal_velocity_mass_weighted(Chen2022, ρ_a, state_noar, logλ; quad)
+            V_m_ϕ[i, j] = P3.ice_terminal_velocity_mass_weighted(Chen2022, ρ_a, state, logλ; quad)
             D_m[i, j] = P3.D_m(state, logλ)
             D_m_regimes[i, j] = D_m[i, j]
             ϕᵢ[i, j] = P3.ϕᵢ(state, D_m[i, j])

--- a/src/P3_integral_properties.jl
+++ b/src/P3_integral_properties.jl
@@ -41,7 +41,26 @@ Compute the integration bounds for the P3 size distribution,
 
     # Only integrate up to the maximum diameter, `D_max`, including intermediate thresholds
     # If `F_rim` is very close to 1, `D_cr` may be greater than `D_max`, in which case it is disregarded.
-    return segment_boundaries(state, D_min, D_max)
+    bnds = segment_boundaries(state, D_min, D_max)
+    # `D_max` sits `log(1/p)` decay lengths into the size-distribution tail; a
+    # breakpoint at the decay scale keeps each subinterval resolvable at low order
+    D_e = clamp(3 / λ, D_min, D_max)
+    return Tuple(SA.sort(SA.SVector(bnds..., D_e)))
+end
+
+"""
+    velocity_integral_bounds(state::P3State, logλ, v_term; p, moment_order = 0)
+
+Compute the integration bounds for a velocity-weighted P3 integral: the
+mass-regime [`integral_bounds`](@ref) with the [`velocity_breakpoints`](@ref)
+of the terminal-velocity closure `v_term` clamped into `[D_min, D_max]` and
+re-sorted, so each breakpoint coincides with a subinterval boundary. Returns a
+fixed-length tuple.
+"""
+function velocity_integral_bounds(state::P3State{FT}, logλ, v_term::V; p, moment_order = 0) where {FT, V}
+    bnds = integral_bounds(state, logλ; p, moment_order)
+    breaks = map(D -> clamp(FT(D), first(bnds), last(bnds)), velocity_breakpoints(v_term))
+    return Tuple(SA.sort(SA.SVector(bnds..., breaks...)))
 end
 
 """

--- a/src/P3_processes.jl
+++ b/src/P3_processes.jl
@@ -57,14 +57,14 @@ end
  - `logλ`: the log of the slope parameter [log(1/m)]
 
 # Keyword arguments
- - `quad`: quadrature rule, default is `ChebyshevGauss(100)`
+ - `quad`: quadrature rule (a `Quadrature.QuadratureRule`)
 
 Returns the melting rate of ice (QIMLT in Morrison and Mildbrandt (2015)).
 """
 @inline function ice_melt(
     velocity_params, aps::CMP.AirProperties, tps::TDI.PS,
     Tₐ, ρₐ, state::P3State, logλ;
-    quad = ChebyshevGauss(100),
+    quad,
 )
     # Note: process not dependent on `F_liq`
     # (we want ice core shape params)
@@ -79,9 +79,10 @@ Returns the melting rate of ice (QIMLT in Morrison and Mildbrandt (2015)).
     F_v = CO.ventilation_factor(vent, aps, v_term)
     N′ = size_distribution(state, logλ)
 
-    # Integrate
+    # Integrate; the ventilation factor carries the terminal-velocity regime
+    # break, so the velocity cutoff is a subinterval boundary
     fac = 4 * K_therm / L_f * (Tₐ - T_freeze)
-    bnds = integral_bounds(state, logλ; p = 1e-6)
+    bnds = velocity_integral_bounds(state, logλ, v_term; p = 1e-6)
     melt_integrand = D -> ∂ice_mass_∂D(state, D) * F_v(D) * N′(D) / D
     dLdt_unclamped = fac * integrate(melt_integrand, bnds, quad)
 
@@ -124,18 +125,10 @@ collision_cross_section_ice_liquid(state, Dᵢ, Dₗ) =
     evalpoly(Dₗ, collision_cross_section_ice_liquid_coeffs(state, Dᵢ))
 
 """
-    volumetric_collision_rate_integrand(state, velocity_params, ρₐ)
+    VolumetricCollisionRate(state, v_i, v_l)
 
-Returns a function that computes the volumetric collision rate integrand for ice-liquid collisions [m³/s].
-The returned function takes ice and liquid particle diameters as arguments.
-
-# Arguments
-- `state`: [`P3State`](@ref)
-- `velocity_params`: velocity parameterization, e.g. [`CMP.Chen2022VelType`](@ref)
-- `ρₐ`: air density
-
-# Returns
-A function `(D_ice, D_liq) -> E * K * |vᵢ - vₗ|` where:
+Volumetric collision rate for ice-liquid collisions [m³/s], evaluated as
+`(D_ice, D_liq) -> E * K * |vᵢ - vₗ|` where:
 - `D_ice` and `D_liq` are the (maximum) diameters of the ice and liquid particles
 - `E` is the collision efficiency
 - `K` is the collision cross section
@@ -143,23 +136,43 @@ A function `(D_ice, D_liq) -> E * K * |vᵢ - vₗ|` where:
 
 Note that `E`, `K`, `vᵢ` and `vₗ` are all, in general, functions of `D_ice` and `D_liq`.
 
-This function is a component of integrals like
+This is a component of integrals like
 
 ```math
 ∫ ∫ E * K * |vᵢ - vₗ| * N'_i * N'_l dD_i dD_l
 ```
-"""
-function volumetric_collision_rate_integrand(velocity_params, ρₐ, state)
-    v_ice = ice_particle_terminal_velocity(velocity_params, ρₐ, state)
-    v_liq = CO.particle_terminal_velocity(velocity_params.rain, ρₐ)
-    function integrand(D_ice::FT, D_liq::FT) where {FT}
-        E = FT(1)  # TODO - Make collision efficiency a function of Dᵢ and Dₗ
-        K = collision_cross_section_ice_liquid(state, D_ice, D_liq)
-        return E * K * abs(v_ice(D_ice) - v_liq(D_liq))
-    end
 
-    return integrand
+The terminal-velocity closures `v_i` and `v_l` are fields, so consumers of the
+collision rate can query the velocities and their structure directly: the
+fall-speed crossing (see [`crossing_integral_bounds`](@ref)), the
+[`velocity_breakpoints`](@ref), and the coefficients of a
+[`CO.Chen2022VelocityCurve`](@ref) used by the closed-form rain integrals.
+"""
+struct VolumetricCollisionRate{S, VI, VL} <: Function
+    state::S
+    v_i::VI
+    v_l::VL
 end
+@inline function (∂ₜV::VolumetricCollisionRate)(D_ice::FT, D_liq::FT) where {FT}
+    E = FT(1)  # TODO - Make collision efficiency a function of Dᵢ and Dₗ
+    K = collision_cross_section_ice_liquid(∂ₜV.state, D_ice, D_liq)
+    return E * K * abs(∂ₜV.v_i(D_ice) - ∂ₜV.v_l(D_liq))
+end
+
+"""
+    volumetric_collision_rate_integrand(velocity_params, ρₐ, state)
+
+Construct the [`VolumetricCollisionRate`](@ref) for the Chen 2022 ice and
+rain terminal velocities at air density `ρₐ`.
+
+!!! note
+    We use the same terminal velocity parametrization for cloud and rain water.
+"""
+volumetric_collision_rate_integrand(velocity_params, ρₐ, state) = VolumetricCollisionRate(
+    state,
+    ice_particle_terminal_velocity(velocity_params, ρₐ, state),
+    CO.particle_terminal_velocity(velocity_params.rain, ρₐ),
+)
 
 """
     compute_max_freeze_rate(aps, tps, velocity_params, ρₐ, Tₐ, state)
@@ -211,9 +224,10 @@ function compute_max_freeze_rate(aps, tps, velocity_params, ρₐ, Tₐ, state)
         # fallback values typed by the promotion of the node and the captured state
         # (mixed plain/Dual under differentiation)
         FT = UT.promote_typeof(Dᵢ, ΔT, Δρᵥ_sat, denom)
-        Tₐ ≥ T_frz && return zero(FT)  # No collisional freezing above the freezing temperature
-        denom > 0 || return floatmax(FT)
-        return 2 * (π * Dᵢ) * F_v(Dᵢ) * (K_therm * ΔT + Lᵥ * D_vapor * Δρᵥ_sat) / denom
+        # `rate` is non-finite when `denom ≤ 0`; the selection below discards it
+        rate = 2 * (π * Dᵢ) * F_v(Dᵢ) * (K_therm * ΔT + Lᵥ * D_vapor * Δρᵥ_sat) / denom
+        # zero above the freezing temperature; floatmax when denom ≤ 0 (see above)
+        return ifelse(Tₐ ≥ T_frz, zero(FT), ifelse(denom > 0, FT(rate), floatmax(FT)))
     end
     return max_freeze_rate
 end
@@ -279,20 +293,22 @@ function compute_local_rime_density(velocity_params, ρₐ, T, state)
 end
 
 """
-    get_liquid_integrals(n, ∂ₜV, m_liq, ρ′_rim, liq_bounds; [quad])
+    get_liquid_integrals(n, ∂ₜV, m_liq, ρ′_rim, liq_bounds; quad)
 
-Returns a function `liquid_integrals(Dᵢ)` that computes the liquid particle integrals
+Return a function `liquid_integrals(Dᵢ)` that computes the liquid particle integrals
     for a given ice particle diameter `Dᵢ`.
 
 # Arguments
 - `n`: liquid particle size distribution function `n(D)`
-- `∂ₜV`: volumetric collision rate integrand function `∂ₜV(Dᵢ, D)`
+- `∂ₜV`: the [`VolumetricCollisionRate`](@ref) `∂ₜV(Dᵢ, D)`
 - `m_liq`: liquid particle mass function `m_liq(D)`
 - `ρ′_rim`: local rime density function `ρ′_rim(Dᵢ, D)`
-- `liq_bounds`: integration bounds for liquid particles
+- `liq_bounds`: integration bounds for liquid particles; the fall-speed
+    crossing `∂ₜV.v_l(D) = ∂ₜV.v_i(Dᵢ)` is inserted as a subinterval boundary,
+    see [`crossing_integral_bounds`](@ref)
 
 # Keyword arguments
-- `quad`: quadrature rule, default is `ChebyshevGauss(100)`
+- `quad`: quadrature rule (a `Quadrature.QuadratureRule`)
 
 # Notes
 The function `liquid_integrals(Dᵢ)` returns a tuple `(∂ₜN_col, ∂ₜM_col, ∂ₜB_col)`
@@ -301,22 +317,40 @@ The function `liquid_integrals(Dᵢ)` returns a tuple `(∂ₜN_col, ∂ₜM_col
 - `∂ₜM_col`: mass collision rate [kg/s]
 - `∂ₜB_col`: rime volume collision rate [m³/s]
 """
-@inline function get_liquid_integrals(n, ∂ₜV, m_liq, ρ′_rim, liq_bounds; quad = ChebyshevGauss(100))
+@inline function get_liquid_integrals(n, ∂ₜV, m_liq, ρ′_rim, liq_bounds; quad)
     function liquid_integrals(Dᵢ)
         integrand = D -> begin
-            V_val = ∂ₜV(Dᵢ, D)
-            n_val = n(D)
-            m_val = m_liq(D)
-            term1 = V_val * n_val
-            term2 = term1 * m_val
-            term3 = term2 / ρ′_rim(Dᵢ, D)
-            return SA.SVector(term1, term2, term3)
+            ∂ₜV_D = ∂ₜV(Dᵢ, D)
+            ∂ₜN = ∂ₜV_D * n(D)          # number collision rate
+            ∂ₜM = ∂ₜN * m_liq(D)        # mass collision rate
+            ∂ₜB = ∂ₜM / ρ′_rim(Dᵢ, D)   # rime volume collision rate
+            return SA.SVector(∂ₜN, ∂ₜM, ∂ₜB)
         end
-        (∂ₜN_col, ∂ₜM_col, ∂ₜB_col) = integrate(integrand, liq_bounds, quad)
+        bnds = crossing_integral_bounds(liq_bounds, ∂ₜV, Dᵢ)
+        (∂ₜN_col, ∂ₜM_col, ∂ₜB_col) = integrate(integrand, bnds, quad)
         return ∂ₜN_col, ∂ₜM_col, ∂ₜB_col
     end
     return liquid_integrals
 end
+
+"""
+    crossing_integral_bounds(liq_bounds, ∂ₜV, Dᵢ)
+
+Insert the fall-speed crossing `∂ₜV.v_l(D) = ∂ₜV.v_i(Dᵢ)` into `liq_bounds`, so
+that the derivative discontinuity of `|v_i(Dᵢ) - v_l(D)|` lies on a subinterval
+boundary.
+
+For a collision-rate integrand that does not carry the terminal-velocity
+closures, the bounds are returned unchanged.
+
+Called from [`get_liquid_integrals`](@ref).
+"""
+@inline function crossing_integral_bounds(liq_bounds::NTuple{2, Any}, ∂ₜV::VolumetricCollisionRate, Dᵢ)
+    (D_min, D_max) = liq_bounds
+    Dstar = crossover_diameter(∂ₜV.v_i(Dᵢ), ∂ₜV.v_l, D_min, D_max)
+    return (D_min, clamp(Dstar, D_min, D_max), D_max)
+end
+@inline crossing_integral_bounds(liq_bounds, ∂ₜV, Dᵢ) = liq_bounds
 
 """
     crossover_diameter(v_target, v_l, D_min, D_max)
@@ -336,15 +370,16 @@ end
 
 """
     closed_rain_inner_NM(
-        Dᵢ, v_i_at_Dᵢ, v_l, rᵢ, ρw, ai, bi, ci, D_min, D_max, N₀r, Dr_mean,
+        v_i_at_Dᵢ, Dstar, rᵢ, ρw, ai, bi, ci, D_min, D_max, N₀r, Dr_mean,
     )
 
-Closed-form `(∂ₜN_col, ∂ₜM_col)` for the rain inner integral at one outer `Dᵢ`.
+Closed-form `(∂ₜN_col, ∂ₜM_col)` for the rain inner integral at one outer ice
+diameter, where `v_i_at_Dᵢ` is the ice particle terminal velocity there and
+`Dstar` the fall-speed crossing from [`crossover_diameter`](@ref).
 """
-function closed_rain_inner_NM(Dᵢ, v_i_at_Dᵢ, v_l::F, rᵢ, ρw, ai, bi, ci, D_min, D_max, N₀r, Dr_mean) where {F}
+function closed_rain_inner_NM(v_i_at_Dᵢ, Dstar, rᵢ, ρw, ai, bi, ci, D_min, D_max, N₀r, Dr_mean)
     FT = float(eltype(ai))
     λ = inv(Dr_mean)  # rain PSD slope: n_r(D) ∝ e^{-λ D}
-    Dstar = crossover_diameter(v_i_at_Dᵢ, v_l, D_min, D_max)
 
     # Compute rain PSD incomplete moments weighted by ice-liquid collision
     # cross-section `K`, and sedimentation velocity difference `|vᵢ - vₗ|`
@@ -370,25 +405,25 @@ end
 
 """
     get_liquid_integrals_rain_closed(
-        psd_r::RainParticlePDF_SB2006, vel::Chen2022VelType,
+        psd_r::RainParticlePDF_SB2006,
         n_r, ρₐ, L_r, N_r, state, ∂ₜV, m_liq, ρ′_rim, bounds_r; quad
     )
 
-Returns a function `liquid_integrals(Dᵢ) -> (∂ₜN_col, ∂ₜM_col, ∂ₜB_col)` 
-where N and M are the exact incomplete-gamma closed form and 
-B_rim is computed by quadrature
+Return a function `liquid_integrals(Dᵢ) -> (∂ₜN_col, ∂ₜM_col, ∂ₜB_col)`
+where N and M are the exact incomplete-gamma closed form and
+B_rim is computed by quadrature, split at the fall-speed crossing.
+The velocities and the rain velocity-curve coefficients come from the
+[`VolumetricCollisionRate`](@ref) `∂ₜV`.
 """
 @inline function get_liquid_integrals_rain_closed(
-    psd_r::CMP.RainParticlePDF_SB2006, vel::CMP.Chen2022VelType,
+    psd_r::CMP.RainParticlePDF_SB2006,
     n_r, ρₐ, L_r, N_r, state, ∂ₜV, m_liq, ρ′_rim, bounds_r; quad,
 )
     FT = promote_type(eltype(state), UT.promote_typeof(ρₐ, L_r, N_r))
     ρw = psd_r.ρw
     (; N₀r, Dr_mean) = CM2.pdf_rain_parameters(psd_r, L_r / ρₐ, ρₐ, N_r)
-    ai_t, bi_t, ci_t = CO.Chen2022_vel_coeffs(vel.rain, ρₐ)
-    ai, bi, ci = SA.SVector(ai_t), SA.SVector(bi_t), SA.SVector(ci_t)
-    v_l = CO.particle_terminal_velocity(vel.rain, ρₐ)
-    v_i = ice_particle_terminal_velocity(vel, ρₐ, state)
+    (; v_i, v_l) = ∂ₜV
+    ai, bi, ci = SA.SVector(v_l.ai), SA.SVector(v_l.bi), SA.SVector(v_l.ci)
     D_min, D_max = bounds_r
     zero_rates = (zero(FT), zero(FT), zero(FT))
     function liquid_integrals(Dᵢ)
@@ -397,8 +432,9 @@ B_rim is computed by quadrature
         end
         v_i_at_Dᵢ = v_i(Dᵢ)
         rᵢ = sqrt(ice_area(state, Dᵢ) / π)
+        Dstar = crossover_diameter(v_i_at_Dᵢ, v_l, D_min, D_max)
         ∂ₜN_col, ∂ₜM_col = closed_rain_inner_NM(
-            Dᵢ, v_i_at_Dᵢ, v_l, rᵢ, ρw, ai, bi, ci,
+            v_i_at_Dᵢ, Dstar, rᵢ, ρw, ai, bi, ci,
             D_min, D_max, N₀r, Dr_mean,
         )
         if !(isfinite(∂ₜN_col) && isfinite(∂ₜM_col))
@@ -406,7 +442,7 @@ B_rim is computed by quadrature
         end
         ∂ₜB_col = integrate(
             D -> ∂ₜV(Dᵢ, D) * n_r(D) * m_liq(D) / ρ′_rim(Dᵢ, D),
-            bounds_r,
+            (D_min, clamp(Dstar, D_min, D_max), D_max),
             quad,
         )
         return (∂ₜN_col, ∂ₜM_col, ∂ₜB_col)
@@ -415,15 +451,15 @@ B_rim is computed by quadrature
 end
 
 @inline _rain_inner_integrals(
-    psd_r::CMP.RainParticlePDF_SB2006, vel::CMP.Chen2022VelType,
-    n_r, ∂ₜV, m_liq, ρ′_rim, bounds_r, ρₐ, L_r, N_r, state; quad,
+    psd_r::CMP.RainParticlePDF_SB2006,
+    n_r, ∂ₜV::VolumetricCollisionRate{<:Any, <:Any, <:CO.Chen2022VelocityCurve},
+    m_liq, ρ′_rim, bounds_r, ρₐ, L_r, N_r, state; quad,
 ) = get_liquid_integrals_rain_closed(
-    psd_r, vel, n_r, ρₐ, L_r, N_r, state, ∂ₜV, m_liq, ρ′_rim, bounds_r;
+    psd_r, n_r, ρₐ, L_r, N_r, state, ∂ₜV, m_liq, ρ′_rim, bounds_r;
     quad,
 )
 @inline _rain_inner_integrals(
-    ::Any, ::Any,
-    n_r, ∂ₜV, m_liq, ρ′_rim, bounds_r, ρₐ, L_r, N_r, state; quad,
+    psd_r, n_r, ∂ₜV, m_liq, ρ′_rim, bounds_r, ρₐ, L_r, N_r, state; quad,
 ) = get_liquid_integrals(n_r, ∂ₜV, m_liq, ρ′_rim, bounds_r; quad)
 
 """
@@ -438,27 +474,15 @@ Computes the bulk collision rate integrands between ice and liquid particles.
 - `∂ₜM_max`: maximum freezing rate function ∂ₜM_max(Dᵢ)
 - `cloud_integrals`: an instance of [`get_liquid_integrals`](@ref) for cloud particles
 - `rain_integrals`: an instance of [`get_liquid_integrals`](@ref) for rain particles
-- `ice_bounds`: integration bounds for ice particles, from [`integral_bounds`](@ref)
+- `ice_bounds`: integration bounds for ice particles, from [`velocity_integral_bounds`](@ref)
 
 # Keyword arguments
-- `quad`: quadrature rule, default is `ChebyshevGauss(100)`
+- `quad`: quadrature rule (a `Quadrature.QuadratureRule`)
 
 # Returns
 A tuple of 8 integrands, see [`∫liquid_ice_collisions`](@ref) for details.
 """
-@inline function ∫liquid_ice_collisions(
-    n_i,
-    ∂ₜM_max,
-    cloud_integrals,
-    rain_integrals,
-    ice_bounds;
-    # Chebyshev–Gauss (not the Gauss–Legendre default used elsewhere):
-    # this integrand has √-type endpoint/weight behavior that Gauss–Legendre resolves
-    # poorly, so a higher node count is used here. TODO: run the same convergence check
-    # used for the Gauss-Legendre default and lower this to the smallest node count within
-    # tolerance.
-    quad = ChebyshevGauss(100),
-)
+@inline function ∫liquid_ice_collisions(n_i, ∂ₜM_max, cloud_integrals, rain_integrals, ice_bounds; quad)
     function liquid_ice_collisions_integrands(Dᵢ)
         # Inner integrals over liquid particle diameters
         ∂ₜN_c_col, ∂ₜM_c_col, ∂ₜB_c_col = cloud_integrals(Dᵢ)
@@ -542,29 +566,148 @@ A tuple `(QCFRZ, QCSHD, NCCOL, QRFRZ, QRSHD, NRCOL, ∫M_col, BCCOL, BRCOL, ∫�
     n_r = DT.size_distribution(psd_r, L_r / ρₐ, ρₐ, N_r)  # n_r(Dₗ)
     n_i = DT.size_distribution(state, logλ)               # n_i(Dᵢ)
 
-    # Initialize integration buffers by evaluating a representative integral
-    p = FT(0.00001)
-    ice_bounds = integral_bounds(state, logλ; p)
-    bounds_c = CM2.get_size_distribution_bounds(psd_c, L_c / ρₐ, ρₐ, N_c, p)
-    bounds_r = CM2.get_size_distribution_bounds(psd_r, L_r / ρₐ, ρₐ, N_r, p)
-
-    # Integrand components
+    # Integrand components; the collision rate carries the ice and liquid
+    # terminal-velocity closures used below
     # NOTE: We assume collision efficiency, shape (spherical), and terminal velocity is the
     #   same for cloud and precipitating liquid particles ⟹ same volumetric collision rate, ∂ₜV
     ∂ₜV = volumetric_collision_rate_integrand(vel, ρₐ, state)  # ∂ₜV(Dᵢ, Dₗ)
     ρ′_rim = compute_local_rime_density(vel, ρₐ, T, state)  # ρ′_rim(Dᵢ, Dₗ)
     ∂ₜM_max = compute_max_freeze_rate(aps, tps, vel, ρₐ, T, state)  # ∂ₜM_max(Dᵢ)
 
+    p = FT(0.00001)
+    ice_bounds = velocity_integral_bounds(state, logλ, ∂ₜV.v_i; p)
+    bounds_c = CM2.get_size_distribution_bounds(psd_c, L_c / ρₐ, ρₐ, N_c, p)
+    bounds_r = CM2.get_size_distribution_bounds(psd_r, L_r / ρₐ, ρₐ, N_r, p)
+
+    # The freeze/shed partition and the wet-growth indicator change branch at the
+    # wet-growth onset diameter, so the onset is a subinterval boundary of the
+    # outer integral
+    (D_wet₁, D_wet₂) = wet_growth_onset_diameter(
+        psd_c, psd_r, ∂ₜV, ∂ₜM_max, state,
+        L_c, N_c, L_r, N_r, ρₐ, bounds_r,
+        first(ice_bounds), last(ice_bounds),
+    )
+    ice_bounds = Tuple(
+        SA.sort(
+            SA.SVector(
+                ice_bounds...,
+                clamp(D_wet₁, first(ice_bounds), last(ice_bounds)),
+                clamp(D_wet₂, first(ice_bounds), last(ice_bounds)),
+            ),
+        ),
+    )
+
     cloud_integrals = get_liquid_integrals(n_c, ∂ₜV, m_liq, ρ′_rim, bounds_c; quad)  # (∂ₜN_c_col, ∂ₜM_c_col, ∂ₜB_c_col)
     # Rain inner: exact closed form for the (SB2006-exp PSD, Chen-2022) pair
     # Numerical fallback for any other PSD/velocity type.
     rain_integrals = _rain_inner_integrals(
-        psd_r, vel, n_r, ∂ₜV, m_liq, ρ′_rim, bounds_r,
+        psd_r, n_r, ∂ₜV, m_liq, ρ′_rim, bounds_r,
         ρₐ, L_r, N_r, state; quad,
     )  # (∂ₜN_r_col, ∂ₜM_r_col, ∂ₜB_r_col)
 
     return ∫liquid_ice_collisions(n_i, ∂ₜM_max, cloud_integrals, rain_integrals, ice_bounds; quad)
 end
+
+"""
+    wet_growth_onset_diameter(
+        psd_c, psd_r, ∂ₜV, ∂ₜM_max, state,
+        L_c, N_c, L_r, N_r, ρₐ, bounds_r, D_lo, D_hi,
+    )
+
+Return up to two ice diameters in `[D_lo, D_hi]` where the collected liquid
+mass rate balances the freeze limit `∂ₜM_max` (the boundaries of the wet-growth
+window; `D_lo` stands in for absent crossings). The balance is
+evaluated in closed form: the cloud collection term neglects the droplet fall
+speed relative to the ice fall speed, making it a polynomial moment of the
+cloud size distribution, and the rain term is the closed-form mass component
+from [`closed_rain_inner_NM`](@ref). Crossings are located on a log-spaced
+scan of the interval and refined by fixed-iteration bisection.
+
+The closed form applies to the (`CMP.CloudParticlePDF_SB2006`,
+`CMP.RainParticlePDF_SB2006`) distributions with a
+[`CO.Chen2022VelocityCurve`](@ref) liquid velocity; for any other combination
+`(D_lo, D_lo)` is returned.
+"""
+function wet_growth_onset_diameter(
+    psd_c::CMP.CloudParticlePDF_SB2006, psd_r::CMP.RainParticlePDF_SB2006,
+    ∂ₜV::VolumetricCollisionRate{<:Any, <:Any, <:CO.Chen2022VelocityCurve},
+    ∂ₜM_max, state,
+    L_c, N_c, L_r, N_r, ρₐ, bounds_r, D_lo, D_hi,
+)
+    (; v_i, v_l) = ∂ₜV
+    FT = promote_type(eltype(state), UT.promote_typeof(L_c, N_c, L_r, N_r, ρₐ))
+    πFT = FT(π)
+    # Cloud collection with the droplet fall speed neglected:
+    #   ∫ K(D, Dₗ) n_c(Dₗ) m_liq(Dₗ) dDₗ = ∑ⱼ Kⱼ(rᵢ) (ρw π/6) M⁽ʲ⁺³⁾,
+    # with K quadratic in Dₗ and M⁽ᵏ⁾ the cloud size-distribution moments
+    (; λc, νcD, μcD) = CM2.pdf_cloud_parameters(psd_c, L_c / ρₐ, ρₐ, N_c)
+    ρw = psd_c.ρw
+    mfac = ρw * CO.volume_sphere_D(one(FT))
+    M₃ = mfac * DT.generalized_gamma_Mⁿ(νcD, μcD, λc, N_c, 3)
+    M₄ = mfac * DT.generalized_gamma_Mⁿ(νcD, μcD, λc, N_c, 4)
+    M₅ = mfac * DT.generalized_gamma_Mⁿ(νcD, μcD, λc, N_c, 5)
+
+    (; N₀r, Dr_mean) = CM2.pdf_rain_parameters(psd_r, L_r / ρₐ, ρₐ, N_r)
+    ai, bi, ci = SA.SVector(v_l.ai), SA.SVector(v_l.bi), SA.SVector(v_l.ci)
+    D_min_r, D_max_r = bounds_r
+    rain_active = !iszero(N₀r) && (D_max_r > D_min_r)
+
+    function excess_mass_rate(D)
+        v = v_i(D)
+        rᵢ = sqrt(ice_area(state, D) / πFT)
+        (k₀, k₁, k₂) = collision_cross_section_ice_liquid_coeffs(rᵢ)
+        cloud_rate = v * (k₀ * M₃ + k₁ * M₄ + k₂ * M₅)
+        rain_rate = if rain_active
+            Dstar = crossover_diameter(v, v_l, D_min_r, D_max_r)
+            (_, ∂ₜM_col_r) = closed_rain_inner_NM(
+                v, Dstar, rᵢ, ρw, ai, bi, ci, D_min_r, D_max_r, N₀r, Dr_mean,
+            )
+            ifelse(isfinite(∂ₜM_col_r), ∂ₜM_col_r, zero(∂ₜM_col_r))
+        else
+            zero(v)
+        end
+        return cloud_rate + rain_rate - ∂ₜM_max(D)
+    end
+    # The balance can cross twice (a wet-growth window: collection outgrows the
+    # freeze limit at intermediate sizes and falls behind again at large sizes),
+    # so locate sign changes on a log-spaced grid, then refine each crossing in
+    # log diameter within its grid bracket.
+    llo, lhi = log(FT(D_lo)), log(FT(D_hi))
+    n_scan = 16
+    Δl = (lhi - llo) / n_scan
+    maxiters = FT === Float32 ? 8 : 10
+    tol = FixedIterations{FT}()
+    function refine_crossing(l₁, l₂)
+        sol = RS.find_zero(l -> excess_mass_rate(exp(l)),
+            RS.BrentsMethod(l₁, l₂), RS.CompactSolution(),
+            tol, maxiters,
+        )
+        return exp(sol.root)
+    end
+    onset₁ = FT(D_lo)
+    onset₂ = FT(D_lo)
+    l_prev = llo
+    g_prev = excess_mass_rate(FT(D_lo))
+    for i in 1:n_scan
+        l = llo + i * Δl
+        g = excess_mass_rate(exp(l))
+        if g * g_prev < 0
+            root = refine_crossing(l_prev, l)
+            if onset₁ == FT(D_lo)
+                onset₁ = root
+            elseif onset₂ == FT(D_lo)
+                onset₂ = root
+            end
+        end
+        l_prev = l
+        g_prev = g
+    end
+    return onset₁, onset₂
+end
+wet_growth_onset_diameter(
+    psd_c, psd_r, ∂ₜV, ∂ₜM_max, state,
+    L_c, N_c, L_r, N_r, ρₐ, bounds_r, D_lo, D_hi,
+) = (D_lo, D_lo)
 
 """
     bulk_liquid_ice_collision_sources(
@@ -606,7 +749,7 @@ A `NamedTuple` of `(; ∂ₜq_c, ∂ₜq_r, ∂ₜN_c, ∂ₜN_r, ∂ₜL_rim, �
 @inline function bulk_liquid_ice_collision_sources(
     state, logλ,
     psd_c, psd_r, L_c, N_c, L_r, N_r,
-    aps, tps, vel, ρₐ, T; quad = ChebyshevGauss(100),
+    aps, tps, vel, ρₐ, T; quad,
 )
     FT = promote_type(eltype(state), UT.promote_typeof(L_c, N_c, L_r, N_r, ρₐ, T))
     (; τ_wet, ρ_i) = state.params
@@ -654,6 +797,19 @@ A `NamedTuple` of `(; ∂ₜq_c, ∂ₜq_r, ∂ₜN_c, ∂ₜN_r, ∂ₜL_rim, �
     )
 end
 
+
+"""
+    collision_cross_section_ice_ice(state, D_1, D_2)
+
+Ice-ice collision cross-section [m²], `π (r(D_1) + r(D_2))²`, where the ice
+effective radius is `r(D) = √(ice_area(state, D) / π)`; see [`ice_area`](@ref).
+Used in [`ice_self_collection`](@ref).
+"""
+function collision_cross_section_ice_ice(state, D_1, D_2)
+    r_eff(D) = √(ice_area(state, D) / π)
+    return π * (r_eff(D_1) + r_eff(D_2))^2  # collision cross section
+end
+
 """
     ice_self_collection(state, logλ, vel, ρₐ; [quad])
 
@@ -667,46 +823,37 @@ while leaving mass, rime mass, and rime volume unchanged.
 - `ρₐ`: air density [kg/m³]
 
 # Keyword arguments
-- `quad`: quadrature rule, default is `ChebyshevGauss(100)`
+- `quad`: quadrature rule (a `Quadrature.QuadratureRule`)
 
 # Returns
 A `NamedTuple` of `(; dNdt)`, where:
 1. `dNdt`: ice number concentration tendency due to self-collection [1/m³/s] (always positive or zero, represents a loss rate)
 """
-@inline function ice_self_collection(state, logλ, vel, ρₐ; quad = ChebyshevGauss(100))
+@inline function ice_self_collection(state, logλ, vel, ρₐ; quad)
     n_i = DT.size_distribution(state, logλ)
     v_ice = ice_particle_terminal_velocity(vel, ρₐ, state)
 
     p = eps(one(ρₐ))
-    ice_bounds = integral_bounds(state, logλ; p)
+    ice_bounds = velocity_integral_bounds(state, logλ, v_ice; p)
+    D_min, D_max = ice_bounds[1], ice_bounds[end]
 
     function inner_integral(D_1)
-        v1 = v_ice(D_1)
-        r1 = sqrt(ice_area(state, D_1) / π)
-        # Volumetric collision rate integrand: E · K · |v₁ − v₂| · n(D₂)
-        # where E = 1 (collision efficiency),
-        #       K = π (r₁ + r₂)² is the geometric collision cross-section,
-        #       |v₁ − v₂| is the differential sedimentation speed,
-        #       r = √(A/π) is the effective radius from projected ice area A.
-        integrand = D_2 -> begin
-            v2 = v_ice(D_2)
-            r2 = sqrt(ice_area(state, D_2) / π)
-            K = π * (r1 + r2)^2                    # collision cross section
-            return K * abs(v1 - v2) * n_i(D_2)     # E = 1 implied
-        end
-        # Split the inner integral at the |v1 - v2| cusp (D_2 = D_1, where the relative
-        # fall speed vanishes and the integrand has a kink). Each half is then smooth, so
-        # the quadrature converges like the other (cusp-free) P3 integrals rather than
-        # being cusp-limited, letting a much lower node count reach target accuracy.
-        D_lo, D_hi = first(ice_bounds), last(ice_bounds)
-        rate_at_D1 = integrate(integrand, (D_lo, D_1), quad) + integrate(integrand, (D_1, D_hi), quad)
-        return rate_at_D1 * n_i(D_1)
+        # Inner integral over D_2 ∈ [D_1, D_max] (the upper triangle). Its
+        # subinterval boundaries are the P3 regime breakpoints restricted to that
+        # window: clamping each breakpoint up to D_1 drops those below it to
+        # zero-width (no-op) subintervals. v_ice(D_1) and n_i(D_1) do not vary
+        # over the inner integral, so evaluate them once here.
+        v_1 = v_ice(D_1)
+        n_1 = n_i(D_1)
+        collision_rate =
+            D_2 -> collision_cross_section_ice_ice(state, D_1, D_2) * abs(v_1 - v_ice(D_2)) * n_i(D_2)
+        D_lo = clamp(D_1, D_min, D_max)
+        inner_bounds = map(D -> max(D, D_lo), ice_bounds)
+        return n_1 * integrate(collision_rate, inner_bounds, quad)
     end
 
-    total_rate = integrate(inner_integral, ice_bounds, quad)
-
-    # The 0.5 factor accounts for double-counting in self-collection
-    FT = eltype(state)
-    dNdt = FT(0.5) * total_rate
+    # Integrate the upper triangle D_1 ≤ D_2, counting each unordered particle
+    # pair once — the self-collection rate.
+    dNdt = integrate(inner_integral, ice_bounds, quad)
     return (; dNdt)
 end

--- a/src/P3_terminal_velocity.jl
+++ b/src/P3_terminal_velocity.jl
@@ -21,6 +21,16 @@ end
 end
 
 """
+    velocity_breakpoints(v_term)
+
+Diameters where the terminal-velocity closure `v_term` changes functional form.
+Integrals with `v_term` in the integrand place these on subinterval boundaries,
+see [`velocity_integral_bounds`](@ref).
+"""
+velocity_breakpoints(f::P3IceParticleVelocityFunctor) = (f.D_cutoff,)
+velocity_breakpoints(::CO.Chen2022VelocityCurve) = ()
+
+"""
     ice_particle_terminal_velocity(velocity_params, ρₐ, state::P3State)
 
 Return a single-argument function `v_term(D)` that gives the Chen 2022
@@ -66,28 +76,28 @@ Return the terminal velocity of the number-weighted mean ice particle size.
 
 # Keyword arguments
  - `p`: Tolerance parameter for the integral bounds. Default is 1e-6.
- - `quad`: Quadrature rule, default is `ChebyshevGauss(100)`
+ - `quad`: quadrature rule (a `Quadrature.QuadratureRule`)
 
 See also [`ice_terminal_velocity_mass_weighted`](@ref)
 """
 function ice_terminal_velocity_number_weighted(
     velocity_params::CMP.Chen2022VelType, ρₐ, state::P3State, logλ;
-    p = 1e-6, quad = ChebyshevGauss(100),
+    p = 1e-6, quad,
 )
     (; ρn_ice, ρq_ice) = state
-    # TODO - do we want to swicth to ϵ_numerics(FT)
-    if ρn_ice < eps(one(ρn_ice)) || ρq_ice < eps(one(ρq_ice))
-        return zero(promote_type(eltype(state), UT.promote_typeof(ρₐ, logλ)))
-    end
-
     v_term = ice_particle_terminal_velocity(velocity_params, ρₐ, state)
     n = DT.size_distribution(state, logλ)
 
-    # ∫n(D) v(D) dD
+    # ∫n(D) v(D) dD, normalized by the number concentration
     number_weighted_integrand = P3NumberWeightedIntegrand(n, v_term)
+    bnds = velocity_integral_bounds(state, logλ, v_term; p)
+    integ = integrate(number_weighted_integrand, bnds, quad)
 
-    bnds = integral_bounds(state, logλ; p)
-    return integrate(number_weighted_integrand, bnds, quad) / ρn_ice
+    # A degenerate ice state (ρn_ice or ρq_ice below ϵ) integrates to zero over
+    # zero-width bounds; select zero in place of the degenerate ratio.
+    below_ϵ = (ρn_ice < eps(one(ρn_ice))) | (ρq_ice < eps(one(ρq_ice)))
+    result = integ / ρn_ice  # non-finite for a degenerate state; discarded below
+    return ifelse(below_ϵ, zero(result), result)
 end
 
 struct P3MassWeightedIntegrand{N, V, S} <: Function
@@ -110,28 +120,28 @@ Return the terminal velocity of the mass-weighted mean ice particle size.
 
 # Keyword arguments
  - `p`: Tolerance parameter for the integral bounds. Default is 1e-6.
- - `quad`: Quadrature rule, default is `ChebyshevGauss(100)`
+ - `quad`: quadrature rule (a `Quadrature.QuadratureRule`)
 
 See also [`ice_terminal_velocity_number_weighted`](@ref)
 """
 function ice_terminal_velocity_mass_weighted(
     velocity_params::CMP.Chen2022VelType, ρₐ, state::P3State, logλ;
-    p = 1e-6, quad = ChebyshevGauss(100),
+    p = 1e-6, quad,
 )
     (; ρn_ice, ρq_ice) = state
-    # TODO - do we want to swicth to ϵ_numerics(FT)
-    if ρn_ice < eps(one(ρn_ice)) || ρq_ice < eps(one(ρq_ice))
-        return zero(promote_type(eltype(state), UT.promote_typeof(ρₐ, logλ)))
-    end
-
     v_term = ice_particle_terminal_velocity(velocity_params, ρₐ, state)
-    n = DT.size_distribution(state, logλ)  # Number concentration at diameter D
+    n = DT.size_distribution(state, logλ)
 
-    # ∫n(D) m(D) v(D) dD
+    # ∫n(D) m(D) v(D) dD, normalized by the mass concentration
     mass_weighted_integrand = P3MassWeightedIntegrand(n, v_term, state)
+    bnds = velocity_integral_bounds(state, logλ, v_term; p)
+    integ = integrate(mass_weighted_integrand, bnds, quad)
 
-    bnds = integral_bounds(state, logλ; p)
-    return integrate(mass_weighted_integrand, bnds, quad) / ρq_ice
+    # A degenerate ice state (ρn_ice or ρq_ice below ϵ) integrates to zero over
+    # zero-width bounds; select zero in place of the degenerate ratio.
+    below_ϵ = (ρn_ice < eps(one(ρn_ice))) | (ρq_ice < eps(one(ρq_ice)))
+    result = integ / ρq_ice  # non-finite for a degenerate state; discarded below
+    return ifelse(below_ϵ, zero(result), result)
 end
 
 """

--- a/src/Quadrature.jl
+++ b/src/Quadrature.jl
@@ -30,7 +30,7 @@ export QuadratureRule, ChebyshevGauss, GaussLegendre, integrate
 abstract type QuadratureRule end
 
 """
-    integrate(f, a, b, quad = ChebyshevGauss(100))
+    integrate(f, a, b, quad)
 
  Approximate the definite integral ∫ₐᵇ f(x) dx using the quadrature rule `quad`.
 
@@ -52,14 +52,12 @@ abstract type QuadratureRule end
 # Arguments
  - `f`: Function to integrate
  - `a`, `b`: Integration bounds. Note: if `a ≥ b`, or `a` or `b` is `NaN`, `zero(f(a))` is returned.
-
-# Keyword arguments
- - `quad`: Quadrature scheme, default: `ChebyshevGauss(100)`
+ - `quad`: Quadrature scheme (a `QuadratureRule`).
 
 # Returns
  Approximation to the definite integral ∫ₐᵇ f(x) dx
 """
-@inline function integrate(f::F, a::T, b::T, quad::QuadratureRule = ChebyshevGauss(100)) where {F, T}
+@inline function integrate(f::F, a::T, b::T, quad::QuadratureRule) where {F, T}
     FT = eltype(float(a))
     # Pre-compute transformation parameters
     scale_factor = (b - a) / 2
@@ -102,21 +100,19 @@ dispatch.
     UU.unrolled_map(tuple, Base.front(bnds), Base.tail(bnds))
 
 """
-    integrate(f, bnds, quad = ChebyshevGauss(100))
+    integrate(f, bnds, quad)
 
 Integrate the function `f` over each subinterval of the integration bounds, `bnds`.
 
 # Arguments
  - `f`: Function to integrate
  - `bnds`: A tuple of bounds, `(a, b, c, d, ...)`
- - `quad`: Quadrature scheme, default: `ChebyshevGauss(100)`
+ - `quad`: Quadrature scheme (a `QuadratureRule`).
 
  The integral is computed as the sum of the integrals over each subinterval,
  `(a, b), (b, c), (c, d), ...` — see [`subintervals`](@ref).
 """
-@inline function integrate(
-    f::F, bnds::NTuple{N, T}, quad::QuadratureRule = ChebyshevGauss(100),
-) where {F, N, T}
+@inline function integrate(f::F, bnds::NTuple{N, T}, quad::QuadratureRule) where {F, N, T}
     @inbounds result = integrate(f, bnds[1], bnds[2], quad)
     @inbounds for i in 2:(N - 1)
         result += integrate(f, bnds[i], bnds[i + 1], quad)
@@ -193,7 +189,7 @@ nodes/weights as `SVector{N, FT}`, so per-`integrate` access is a static lookup
 a GPU kernel.
 
 Arbitrary orders `n ≥ 1` are supported (the order is the type parameter `N`).
-`40` is the ClimaAtmos production `quadrature_order`.
+`40` is the ClimaAtmos production order.
 
 # GPU / type-stability
 
@@ -204,14 +200,14 @@ construction; the object is built host-side once and shipped to the device, so
 
 # Accuracy vs `ChebyshevGauss`
 
-At matched `n`, Gauss-Legendre is substantially more accurate on the smooth P3
+At matched `n`, Gauss-Legendre is more accurate on the smooth P3
 size-distribution integrals (e.g. ~20× lower error than `ChebyshevGauss(40)` on
 the dominant ice-rain collision integral, verified against an adaptive QuadGK
-reference) at equal cost. It is **not** uniformly better on the cusp-limited
-`ice_self_collection` diagonal — there both schemes are quadrature-limited at low
-`n` and the structural remedy is a diagonal split, not the scheme. The
-production default therefore remains `ChebyshevGauss`; switch a call site to
-`GaussLegendre` deliberately where the integrand is smooth.
+reference) at equal cost, and it is the default rule on the P3 parameters. The
+`ice_self_collection` diagonal `D_1 = D_2` was the one integrand where a fixed
+rule stalled; with that diagonal restricted to a subinterval boundary (see
+`ice_self_collection`) the integrand is smooth on each subinterval and
+Gauss-Legendre converges geometrically there too.
 
 # Available methods
 
@@ -253,28 +249,5 @@ function GaussLegendre(::Type{FT}, n::Int) where {FT}
     return GaussLegendre{FT, n}(n, nodes, weights)
 end
 GaussLegendre(n::Int) = GaussLegendre(Float64, n)
-
-"""
-    build_quadrature(FT, quadrature_order)
-
-Select and **construct** the quadrature rule for the P3 size-distribution
-integrals from a single `quadrature_order` knob, in element type `FT`. This is
-the host-side, one-shot builder; the returned object is `isbits` and stored on a
-parameter struct for reuse in the (GPU) hot loop.
-
-Gauss-Legendre is preferred for the orders where it is meaningfully more
-accurate than Chebyshev-Gauss on the smooth P3 integrands (≈20× lower error on
-the dominant ice-rain collision integral at matched `n`; see [`GaussLegendre`](@ref)),
-namely `quadrature_order ∈ {16, 32, 40, 64}` (incl. the ClimaAtmos production
-order 40). Any other order falls back to [`ChebyshevGauss`](@ref), preserving the
-default behaviour for non-preferred orders.
-"""
-function build_quadrature(::Type{FT}, quadrature_order::Int) where {FT}
-    return if quadrature_order in (16, 32, 40, 64)
-        GaussLegendre(FT, quadrature_order)
-    else
-        ChebyshevGauss(quadrature_order)
-    end
-end
 
 end # module Quadrature

--- a/src/parameters/Microphysics2MParams.jl
+++ b/src/parameters/Microphysics2MParams.jl
@@ -39,11 +39,9 @@ $(DocStringExtensions.FIELDS)
 
 # Constructor
 
-The main constructor is
-```
-P3IceParams(toml_dict::CP.ParamDict; is_limited = true)
-```
-which constructs the parameterization with components:
+    P3IceParams(toml_dict::CP.ParamDict; is_limited = true, quadrature_order, quad, inp_depletion_model)
+
+builds the components:
 - `scheme` = [`ParametersP3`](@ref)
 - `terminal_velocity` = [`Chen2022VelType`](@ref)
 - `cloud_pdf` = [`CloudParticlePDF_SB2006`](@ref)
@@ -51,6 +49,14 @@ which constructs the parameterization with components:
 - `ice_nucleation` = [`Frostenberg2023`](@ref)
 - `rain_freezing` = [`RainFreezing`](@ref)
 
+# Keyword arguments
+- `is_limited`: use limited rain size-distribution parameters. By default, `true`.
+- `quadrature_order`: order of the default `Quadrature.GaussLegendre` rule. By default, `6`.
+- `quad`: the size-distribution `Quadrature.QuadratureRule`. By default,
+  `Quadrature.GaussLegendre(FT, quadrature_order)`. Pass this to use a rule other
+  than Gauss-Legendre.
+- `inp_depletion_model`: the F23 INP-activation depletion model. By default,
+  [`NIceProxyDepletion`](@ref).
 """
 @kwdef struct P3IceParams{P3, VL, PDc, PDr, HET, RF, INPDM, Q} <: ParametersType
     "The core P3 scheme parameters"
@@ -71,27 +77,18 @@ which constructs the parameterization with components:
     immersion-cap rates. (A prognostic activation-memory model is deferred
     to a follow-up PR.)"
     inp_depletion_model::INPDM = NIceProxyDepletion()
-    "Number of quadrature nodes used for size-distribution integrals
+    "Quadrature rule for the size-distribution integrals
     (deposition / sublimation, melting, riming, ice-rain collection,
-    sedimentation). Lower → faster, slightly less accurate. Default 16
-    auto-selects Gauss-Legendre (see [`Quadrature.build_quadrature`](@ref)),
-    giving < 0.5% worst-case error vs a 200-node reference on the full P3
-    tendency vector. The `ice_self_collection` cusp (the historical accuracy
-    limiter) is now split at the |Δv|=0 diagonal, so this low node count
-    suffices; bump to 32 for < 0.2% if extra margin is wanted."
-    quadrature_order::Int = 16
-    "Pre-constructed quadrature rule for the size-distribution integrals,
-    built once (host-side) from `quadrature_order` via
-    [`Quadrature.build_quadrature`](@ref) and reused in the (GPU) hot loop.
-    It is `isbits` (`GaussLegendre`/`ChebyshevGauss`), so it ships to device
-    kernels with no per-call construction. See [`Quadrature.GaussLegendre`](@ref)."
-    quad::Q = QUAD.build_quadrature(Float64, quadrature_order)
+    sedimentation). See also [`Quadrature.GaussLegendre`](@ref)."
+    quad::Q = QUAD.GaussLegendre(Float64, 6)
 end
 Base.show(io::IO, mime::MIME"text/plain", x::P3IceParams) =
     ShowMethods.verbose_show_type_and_fields(io, mime, x)
 
 P3IceParams(toml_dict::CP.ParamDict;
-    is_limited = true, quadrature_order::Int = 16,
+    is_limited = true,
+    quadrature_order = 6,
+    quad = QUAD.GaussLegendre(CP.float_type(toml_dict), quadrature_order),
     inp_depletion_model = NIceProxyDepletion(τ_act = 300),
 ) = P3IceParams(;
     scheme = ParametersP3(toml_dict),
@@ -101,11 +98,7 @@ P3IceParams(toml_dict::CP.ParamDict;
     ice_nucleation = Frostenberg2023(toml_dict),
     rain_freezing = RainFreezing(toml_dict),
     inp_depletion_model,
-    quadrature_order,
-    # Build the quadrature in the working float type, so its nodes/weights
-    # adopt the integrand's eltype (a Float64 rule would leak Float64 into the
-    # Float32 collision integrals). Construction is host-side and one-shot.
-    quad = QUAD.build_quadrature(CP.float_type(toml_dict), quadrature_order),
+    quad,
 )
 
 """
@@ -139,24 +132,34 @@ Base.show(io::IO, mime::MIME"text/plain", x::Microphysics2MParams) =
     ShowMethods.verbose_show_type_and_fields(io, mime, x)
 
 """
-    Microphysics2MParams(toml_dict::CP.ParamDict; with_ice = false, is_limited = true)
+    Microphysics2MParams(toml_dict::CP.ParamDict; with_ice = false, is_limited = true, quadrature_order, quad, inp_depletion_model)
 
 Create a `Microphysics2MParams` object from a ClimaParams TOML dictionary.
 
 # Arguments
-- `toml_dict`: ClimaParams parameter dictionary
-- `with_ice`: Include P3 ice-phase parameters (default: false)
-- `is_limited`: Use limited rain size distribution parameters (default: true)
+- `toml_dict`: ClimaParams parameter dictionary.
+
+# Keyword arguments
+- `with_ice`: include P3 ice-phase parameters. By default, `false`.
+- `is_limited`: use limited rain size-distribution parameters. By default, `true`.
+- `quadrature_order`: order of the default `Quadrature.GaussLegendre` rule passed to
+  [`P3IceParams`](@ref) when `with_ice`. By default, `6`.
+- `quad`: the size-distribution `Quadrature.QuadratureRule` passed to
+  [`P3IceParams`](@ref) when `with_ice`. By default,
+  `Quadrature.GaussLegendre(FT, quadrature_order)`.
+- `inp_depletion_model`: the F23 INP-activation depletion model passed to
+  [`P3IceParams`](@ref) when `with_ice`. By default, [`NIceProxyDepletion`](@ref).
 """
 Microphysics2MParams(toml_dict::CP.ParamDict;
     with_ice = false, is_limited = true,
-    quadrature_order::Int = 16,
+    quadrature_order = 6,
+    quad = QUAD.GaussLegendre(CP.float_type(toml_dict), quadrature_order),
     inp_depletion_model = NIceProxyDepletion(τ_act = 300),
 ) = Microphysics2MParams(;
     # Warm rain parameters (always present)
     warm_rain = WarmRainParams2M(toml_dict; is_limited),
     # Optional ice phase parameters
     ice = with_ice ?
-          P3IceParams(toml_dict; is_limited, quadrature_order, inp_depletion_model) :
+          P3IceParams(toml_dict; is_limited, quad, inp_depletion_model) :
           nothing,
 )

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -28,6 +28,7 @@ Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/test/bulk_tendencies_quadrature_tests.jl
+++ b/test/bulk_tendencies_quadrature_tests.jl
@@ -7,208 +7,35 @@ import CloudMicrophysics.BulkMicrophysicsTendencies as BMT
 import CloudMicrophysics.ThermodynamicsInterface as TDI
 
 """
-Sweep test for the P3-ice quadrature order. `quadrature_order` now lives
-on `P3IceParams`, so the sweep is over `Microphysics2MParams(FT;
-with_ice = true, quadrature_order = n)`.
+Sweep test for the P3-ice quadrature order. The quadrature rule lives on
+`P3IceParams`, so the sweep constructs `Microphysics2MParams(FT; with_ice = true,
+quad = CM.Quadrature.GaussLegendre(FT, n))` at several orders `n` and compares the
+full BMT tendency vector against a high-order reference across a set of physically
+plausible column states.
 
-Issue 011 measured the worst-case relative error of one single integral
-(`bulk_liquid_ice_collision_sources`) across 5 states and 7 orders, and
-found all values < 1 % even at `n = 15`. This suite extends that to the
-**full BMT tendency vector**, sweeping a broader set of physically
-plausible column states and asserting lenient per-`n` tolerances.
+Per-order relative tolerances, applied on `max(abs(a), abs(b), ε)` with
+`ε = 1e-16 · mass_scale` so tendencies that are near-zero by physics are skipped:
 
-# Tolerance rationale
+- `n = 100`: < 2e-3
+- `n = 50`:  < 6e-3
+- `n = 25`:  < 5e-2
+- `n = 15`:  < 2e-1
+- `n = 12`:  < 5e-3
+- `n = 8`:   < 5e-3
+- `n = 7`:   < 1e-2
+- `n = 6`:   < 2e-2
 
-The goal is a sanity check for a student picking a lower `n` for fast
-iteration, not a tight correctness check. The tolerances are set to the
-level where the approximation is "good enough" for debugging but still
-meaningfully faster:
+The `n ≤ 12` rows hold because the integrand breakpoints (velocity crossing,
+decay scale) keep low orders accurate; the state set includes graupel/hail
+cores for this reason. Non-finite (`NaN` / `Inf`) outputs fail regardless of
+tolerance.
 
-- `n = 100`: < 2e-3 relative on all fields. Issue 011 showed the
-  single-integral error is ~1e-5, but the full BMT pipeline composes
-  multiple integrals (bulk liquid-ice collisions, ice aggregation,
-  melting), which can compound. 2e-3 is loose enough to absorb
-  integration-scheme drift while still catching genuine regressions.
-- `n = 50`:  < 5e-3 relative — "safe for most KiD runs".
-- `n = 25`:  < 5e-2 relative — acceptable for short diagnostics.
-- `n = 15`:  < 2e-1 — order-of-magnitude agreement only.
-
-The tolerance is applied on `max(abs(a), abs(b), ε)` where
-`ε = 1e-16 · mass_scale` to avoid false failures on tendencies that are
-near-zero by physics (e.g. ice processes in a rain-only column). All
-finite-valued outputs are checked; `NaN` / `Inf` trigger a failure
-regardless of tolerance.
-
-This does NOT include the timing assertions from the issue text — those
-are flaky under CI load. A separate `@info` block reports the
-wall-clock ratios for the student's information when the test file is
-run directly.
+The tolerances lock in the error study in `p3_quadrature_error_study.jl`
+(included below for the shared state set); rerun that study when changing the
+quadrature rule, integral bounds, or P3 process integrands.
 """
 
-function generate_column_states(::Type{FT}) where {FT}
-    # A hand-curated collection of physically plausible (ρ, T, q_*) states
-    # spanning the regimes the Jouan kinematic column experiences. Each row
-    # is a NamedTuple fed directly into `bulk_microphysics_tendencies`.
-
-    # Saturation-vapor helper (local)
-    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
-    q_vs_l(T, ρ) = TDI.saturation_vapor_specific_content_over_liquid(tps, T, ρ)
-    q_vs_i(T, ρ) = TDI.saturation_vapor_specific_content_over_ice(tps, T, ρ)
-
-    states = NamedTuple[]
-
-    # 1. Warm, cloudy, no ice, no rain — pure activation/condensation
-    let ρ = FT(1.2), T = FT(290)
-        push!(
-            states,
-            (;
-                ρ, T,
-                q_tot = q_vs_l(T, ρ) + FT(1e-3),
-                q_lcl = FT(1e-3), n_lcl = FT(1e8),
-                q_rai = FT(0), n_rai = FT(0),
-                q_ice = FT(0), n_ice = FT(0),
-                q_rim = FT(0), b_rim = FT(0),
-            ),
-        )
-    end
-
-    # 2. Warm, heavy rain, no cloud
-    let ρ = FT(1.1), T = FT(285)
-        push!(
-            states,
-            (;
-                ρ, T,
-                q_tot = q_vs_l(T, ρ) + FT(5e-4),
-                q_lcl = FT(0), n_lcl = FT(0),
-                q_rai = FT(5e-4), n_rai = FT(1e4),
-                q_ice = FT(0), n_ice = FT(0),
-                q_rim = FT(0), b_rim = FT(0),
-            ),
-        )
-    end
-
-    # 3. Freezing-level mixed phase, light ice, no rime
-    let ρ = FT(0.9), T = FT(270)
-        push!(
-            states,
-            (;
-                ρ, T,
-                q_tot = q_vs_l(T, ρ) + FT(1e-4) + FT(1e-5),
-                q_lcl = FT(1e-4), n_lcl = FT(1e8),
-                q_rai = FT(0), n_rai = FT(0),
-                q_ice = FT(1e-5), n_ice = FT(1e5),
-                q_rim = FT(0), b_rim = FT(0),
-            ),
-        )
-    end
-
-    # 4. Cold cirrus, trace ice, no rain, no cloud
-    let ρ = FT(0.5), T = FT(240)
-        push!(
-            states,
-            (;
-                ρ, T,
-                q_tot = q_vs_i(T, ρ) + FT(1e-6),
-                q_lcl = FT(0), n_lcl = FT(0),
-                q_rai = FT(0), n_rai = FT(0),
-                q_ice = FT(1e-6), n_ice = FT(1e5),
-                q_rim = FT(0), b_rim = FT(0),
-            ),
-        )
-    end
-
-    # 5. Heavy riming regime
-    let ρ = FT(0.85), T = FT(265)
-        push!(
-            states,
-            (;
-                ρ, T,
-                q_tot = q_vs_l(T, ρ) + FT(5e-4) + FT(5e-4),
-                q_lcl = FT(5e-4), n_lcl = FT(1e8),
-                q_rai = FT(2e-4), n_rai = FT(1e4),
-                q_ice = FT(5e-4), n_ice = FT(1e5),
-                q_rim = FT(1e-4), b_rim = FT(1e-4 / 300),
-            ),
-        )
-    end
-
-    # 6. Dry subsaturated, no condensate — evaporation regime
-    let ρ = FT(1.0), T = FT(290)
-        push!(
-            states,
-            (;
-                ρ, T,
-                q_tot = FT(0.5) * q_vs_l(T, ρ),
-                q_lcl = FT(0), n_lcl = FT(0),
-                q_rai = FT(1e-4), n_rai = FT(1e4),
-                q_ice = FT(0), n_ice = FT(0),
-                q_rim = FT(0), b_rim = FT(0),
-            ),
-        )
-    end
-
-    # 7. Just below 273 K — melting threshold with heavy ice
-    let ρ = FT(1.0), T = FT(272.5)
-        push!(
-            states,
-            (;
-                ρ, T,
-                q_tot = q_vs_l(T, ρ) + FT(1e-3),
-                q_lcl = FT(0), n_lcl = FT(0),
-                q_rai = FT(0), n_rai = FT(0),
-                q_ice = FT(1e-3), n_ice = FT(5e4),
-                q_rim = FT(0), b_rim = FT(0),
-            ),
-        )
-    end
-
-    # 8. Just above 273 K — melting active
-    let ρ = FT(1.0), T = FT(274.0)
-        push!(
-            states,
-            (;
-                ρ, T,
-                q_tot = q_vs_l(T, ρ) + FT(1e-3),
-                q_lcl = FT(0), n_lcl = FT(0),
-                q_rai = FT(0), n_rai = FT(0),
-                q_ice = FT(1e-3), n_ice = FT(5e4),
-                q_rim = FT(0), b_rim = FT(0),
-            ),
-        )
-    end
-
-    # 9. Strong supersaturation over ice, no liquid
-    let ρ = FT(0.7), T = FT(250)
-        push!(
-            states,
-            (;
-                ρ, T,
-                q_tot = FT(1.5) * q_vs_i(T, ρ),
-                q_lcl = FT(0), n_lcl = FT(0),
-                q_rai = FT(0), n_rai = FT(0),
-                q_ice = FT(1e-5), n_ice = FT(1e5),
-                q_rim = FT(0), b_rim = FT(0),
-            ),
-        )
-    end
-
-    # 10. Mixed-phase mid-troposphere with rain + ice
-    let ρ = FT(0.8), T = FT(268)
-        push!(
-            states,
-            (;
-                ρ, T,
-                q_tot = q_vs_l(T, ρ) + FT(3e-4) + FT(3e-4),
-                q_lcl = FT(3e-4), n_lcl = FT(1e8),
-                q_rai = FT(1e-4), n_rai = FT(5e3),
-                q_ice = FT(3e-4), n_ice = FT(1e5),
-                q_rim = FT(1e-5), b_rim = FT(1e-5 / 400),
-            ),
-        )
-    end
-
-    return states
-end
+include("p3_quadrature_error_study.jl")
 
 function compare_with_reference(tendencies_ref, tendencies_n, tol;
     mass_scale = 1e-12, report = false)
@@ -240,21 +67,32 @@ end
 
 function test_quadrature_order_sweep(FT)
     tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
-    # `quadrature_order` now lives on `P3IceParams`, so building one
-    # `Microphysics2MParams` per order keeps the sweep clean.
-    make_mp(n) = CMP.Microphysics2MParams(FT; with_ice = true, quadrature_order = n)
+    # The quadrature rule lives on `P3IceParams`; build one `Microphysics2MParams`
+    # per order to sweep it.
+    make_mp(n) = CMP.Microphysics2MParams(FT; with_ice = true, quad = CM.Quadrature.GaussLegendre(FT, n))
 
     orders_and_tol = [
         (100, FT(2e-3)),
-        (50, FT(5e-3)),
+        (50, FT(6e-3)),
         (25, FT(5e-2)),
         (15, FT(2e-1)),
+        # With the velocity-crossing and decay-scale breakpoints, low orders
+        # stay accurate down to the default order (8), including in the
+        # large-mean-size states below. See #741.
+        (12, FT(5e-3)),
+        (8, FT(5e-3)),
+        (7, FT(1e-2)),
+        (6, FT(2e-2)),
     ]
     reference_n = 200
 
     mp_ref = make_mp(reference_n)
     states = generate_column_states(FT)
     @test length(states) >= 10
+    append!(
+        states,
+        hail_core_states(FT, ((0.8, 600.0, 100.0), (0.8, 600.0, 20.0), (0.95, 800.0, 50.0))),
+    )
 
     @testset "Quadrature order sweep" begin
         for (idx, s) in enumerate(states)

--- a/test/gpu_performance.jl
+++ b/test/gpu_performance.jl
@@ -57,12 +57,12 @@ end
 end
 
 @kernel inbounds = true function benchmark_p3_kernel!(
-    p3_params, vel_params, output, L_ice, N_ice, F_rim, ρ_rim, ρₐ,
+    p3_params, vel_params, output, L_ice, N_ice, F_rim, ρ_rim, ρₐ, quad,
 )
     i = @index(Global, Linear)
     state = P3.P3State(p3_params, L_ice[i], N_ice[i], F_rim[i], ρ_rim[i])
     logλ = P3.get_distribution_logλ(state)
-    sc = P3.ice_self_collection(state, logλ, vel_params, ρₐ[i])
+    sc = P3.ice_self_collection(state, logλ, vel_params, ρₐ[i]; quad)
     output[i] = (; logλ, sc)
 end
 
@@ -247,13 +247,25 @@ function run_gpu_performance_benchmarks(FT)
         F_rim = constant_data(FT(0.95); ndrange)
         ρ_rim = constant_data(FT(400.0); ndrange)
 
+        _glq = P3.GaussLegendre(FT, 12)
         kernel_p3! = benchmark_p3_kernel!(backend, work_groups)
-        t_compile_p3 = @elapsed kernel_p3!(p3_params, Ch2022, output, L_ice, N_ice, F_rim, ρ_rim, ρ_arr; ndrange)
+        t_compile_p3 = @elapsed kernel_p3!(p3_params, Ch2022, output, L_ice, N_ice, F_rim, ρ_rim, ρ_arr, _glq; ndrange)
         KernelAbstractions.synchronize(backend)
         @info "P3 Kernel first call (compile + run time): $(round(t_compile_p3, digits=4)) seconds"
 
         b_p3 = BT.@benchmark (
-            $kernel_p3!($p3_params, $Ch2022, $output, $L_ice, $N_ice, $F_rim, $ρ_rim, $ρ_arr; ndrange = $ndrange);
+            $kernel_p3!(
+                $p3_params,
+                $Ch2022,
+                $output,
+                $L_ice,
+                $N_ice,
+                $F_rim,
+                $ρ_rim,
+                $ρ_arr,
+                $_glq;
+                ndrange = $ndrange,
+            );
             KernelAbstractions.synchronize($backend)
         )
         @info "P3 Kernel runtime benchmark:" BT.minimum(b_p3)

--- a/test/gpu_tests.jl
+++ b/test/gpu_tests.jl
@@ -439,12 +439,12 @@ end
 end
 
 @kernel inbounds = true function test_P3_ice_self_collection_kernel!(
-    p3_params, vel_params, output, L_ice, N_ice, F_rim, ρ_rim, ρₐ,
+    p3_params, vel_params, output, L_ice, N_ice, F_rim, ρ_rim, ρₐ, quad,
 )
     i = @index(Global, Linear)
     state = P3.P3State(p3_params, L_ice[i], N_ice[i], F_rim[i], ρ_rim[i])
     logλ = P3.get_distribution_logλ(state)
-    output[i] = P3.ice_self_collection(state, logλ, vel_params, ρₐ[i])
+    output[i] = P3.ice_self_collection(state, logλ, vel_params, ρₐ[i]; quad)
 end
 
 # Evaluates the fast incomplete-gamma approximations on the device. This is the
@@ -1239,22 +1239,15 @@ function test_gpu(FT)
 
         kernel! = test_bulk_tendencies_2m_p3_kernel!(backend, work_groups)
         TT.@testset "2M+P3" begin
-            if VERSION < v"1.12"
-                # The collision path exceeds Julia <= 1.11's inference depth, so this
-                # kernel does not compile there (InvalidIRError: dynamic dispatch).
-                # 1.12 inference resolves it. TODO: fix once GPU CI is >= 1.12.
-                TT.@test_broken VERSION >= v"1.12"
-            else
-                kernel!(
-                    mp_2m_p3, tps, output, ρ, T, q_tot,
-                    q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim;
-                    ndrange,
-                )
-                TT.@test allequal(Array(output))
-                tendencies = Array(output)[1]
-                TT.@test all(isfinite, tendencies)
-                TT.@test !iszero(tendencies.dq_ice_dt)
-            end
+            kernel!(
+                mp_2m_p3, tps, output, ρ, T, q_tot,
+                q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim;
+                ndrange,
+            )
+            TT.@test allequal(Array(output))
+            tendencies = Array(output)[1]
+            TT.@test all(isfinite, tendencies)
+            TT.@test !iszero(tendencies.dq_ice_dt)
         end
     end  # TT.@testset "Bulk microphysics tendencies kernels"
 
@@ -1289,7 +1282,7 @@ function test_gpu(FT)
         ρₐ = constant_data(FT(1.2); ndrange)
 
         kernel! = test_P3_ice_self_collection_kernel!(backend, work_groups)
-        kernel!(p3_params, Ch2022, output, L_ice, N_ice, F_rim, ρ_rim, ρₐ; ndrange)
+        kernel!(p3_params, Ch2022, output, L_ice, N_ice, F_rim, ρ_rim, ρₐ, P3.GaussLegendre(FT, 12); ndrange)
         out = Array(output)
 
         TT.@test allequal(out)

--- a/test/microphysics2M_tests.jl
+++ b/test/microphysics2M_tests.jl
@@ -609,10 +609,12 @@ function test_microphysics2M(FT)
             TT.@test DT.exponential_cdf(Dr_mean, D_max) ≈ 1 - p
 
             # Sanity checks for number concentrations for rain
-            ND = P3.integrate(f_D, D_min, D_max, P3.ChebyshevGauss(1000))
-            Nx = P3.integrate(f_x, x_min, x_max, P3.ChebyshevGauss(100_000))
-            ND_psd = P3.integrate(psd, D_min, D_max, P3.ChebyshevGauss(1000))
-            TT.@test ND ≈ Nᵣ rtol = 1e-6
+            ND = P3.integrate(f_D, D_min, D_max, P3.GaussLegendre(FT, 16))
+            Nx = P3.integrate(f_x, x_min, x_max, P3.GaussLegendre(FT, 45_000))
+            ND_psd = P3.integrate(psd, D_min, D_max, P3.GaussLegendre(FT, 16))
+            # D_min/D_max truncate 2p of the distribution, so the exact
+            # truncated integral is Nᵣ(1 - 2p); ND recovers Nᵣ only to O(2p) = 2e-6.
+            TT.@test ND ≈ Nᵣ rtol = 3e-6
             if FT == Float64
                 TT.@test Nx ≈ Nᵣ rtol = 7e-3
             else
@@ -621,9 +623,9 @@ function test_microphysics2M(FT)
             TT.@test ND_psd == ND
 
             # Sanity checks for specific contents for rain
-            qD = P3.integrate(Mⁿ(3, f_D), D_min, D_max, P3.ChebyshevGauss(100)) * k_m / ρₐ
-            qx = P3.integrate(Mⁿ(1, f_x), x_min, x_max, P3.ChebyshevGauss(100)) / ρₐ
-            qD_psd = P3.integrate(Mⁿ(3, psd), D_min, D_max, P3.ChebyshevGauss(100)) * k_m / ρₐ
+            qD = P3.integrate(Mⁿ(3, f_D), D_min, D_max, P3.GaussLegendre(FT, 96)) * k_m / ρₐ
+            qx = P3.integrate(Mⁿ(1, f_x), x_min, x_max, P3.GaussLegendre(FT, 96)) / ρₐ
+            qD_psd = P3.integrate(Mⁿ(3, psd), D_min, D_max, P3.GaussLegendre(FT, 96)) * k_m / ρₐ
             TT.@test qD ≈ qᵣ rtol = 6e-4
             TT.@test qx ≈ qᵣ rtol = 5e-4
             TT.@test qD_psd == qD
@@ -701,16 +703,16 @@ function test_microphysics2M(FT)
 
 
         # Sanity checks of specific content and number concentration with mass distribution
-        Nx = P3.integrate(Mⁿ(0, f_x), x_min, x_max, P3.ChebyshevGauss(100))
-        qx = P3.integrate(Mⁿ(1, f_x), x_min, x_max, P3.ChebyshevGauss(100)) / ρₐ
+        Nx = P3.integrate(Mⁿ(0, f_x), x_min, x_max, P3.GaussLegendre(FT, 32))
+        qx = P3.integrate(Mⁿ(1, f_x), x_min, x_max, P3.GaussLegendre(FT, 32)) / ρₐ
         TT.@test qx ≈ qₗ rtol = 2e-5
         TT.@test Nx ≈ Nₗ rtol = 1e-5
 
         # Sanity checks of specific content and number concentration with diameter distribution
-        ND = P3.integrate(Mⁿ(0, f_D), D_min, D_max, P3.ChebyshevGauss(100))
-        ND_psd = P3.integrate(Mⁿ(0, psd), D_min, D_max, P3.ChebyshevGauss(100))
-        qD = P3.integrate(Mⁿ(3, f_D), D_min, D_max, P3.ChebyshevGauss(100)) * k_m / ρₐ
-        qD_psd = P3.integrate(Mⁿ(3, psd), D_min, D_max, P3.ChebyshevGauss(100)) * k_m / ρₐ
+        ND = P3.integrate(Mⁿ(0, f_D), D_min, D_max, P3.GaussLegendre(FT, 32))
+        ND_psd = P3.integrate(Mⁿ(0, psd), D_min, D_max, P3.GaussLegendre(FT, 32))
+        qD = P3.integrate(Mⁿ(3, f_D), D_min, D_max, P3.GaussLegendre(FT, 32)) * k_m / ρₐ
+        qD_psd = P3.integrate(Mⁿ(3, psd), D_min, D_max, P3.GaussLegendre(FT, 32)) * k_m / ρₐ
         TT.@test ND ≈ Nₗ rtol = 1e-5
         TT.@test ND_psd ≈ Nₗ rtol = 1e-5
         TT.@test qD ≈ qₗ rtol = 2e-5
@@ -744,6 +746,8 @@ function test_microphysics2M(FT)
         TT.@test CM2.number_tendency_from_mass_limits(numadj_nt, q, n_high) ≈ (q / x_min - n_high) / τ
         # q ≈ 0: target is zero number
         TT.@test CM2.number_tendency_from_mass_limits(numadj_nt, FT(0), n_inrange) ≈ -n_inrange / τ
+        # x_min = 0: q / x_min is Inf, so the lower-bound relaxation never fires
+        TT.@test CM2.number_tendency_from_mass_limits((; x_min = FT(0), x_max, τ), q, n_high) ≈ FT(0)
     end
 end
 

--- a/test/p3_quadrature_error_study.jl
+++ b/test/p3_quadrature_error_study.jl
@@ -1,0 +1,368 @@
+"""
+Quadrature error study for the P3-ice integrals.
+
+Measure the relative error of every quadrature-consuming P3 quantity against a
+high-order Gauss-Legendre reference, across a set of physically plausible
+column states, and attribute it to one of three levels:
+
+- `transport`: the sedimentation velocities and melt rate.
+- `collision_efficiency`: the components proportional to the collision
+  efficiency (`E = 1` assumed): the liquid-ice collision sources and ice
+  self-collection. Their parameterization uncertainty exceeds the quadrature
+  error, so they tolerate a coarser rule than the transport components.
+- `bulk`: the full `bulk_microphysics_tendencies` vector.
+
+The states are `generate_column_states` plus graupel/hail cores
+(`hail_core_states`), whose large mean particle sizes stress the
+size-distribution tail. The error metric is `|a - b| / max(|a|, |b|, floor)`,
+with a per-component floor of `1e-9` times the largest reference magnitude
+across states, so components that are zero by physics do not register as
+relative error.
+
+Run from the repository root:
+
+    julia --project=test -e 'include("test/p3_quadrature_error_study.jl");
+                             run_quadrature_error_study()'
+
+Keyword arguments of `run_quadrature_error_study`:
+
+- `FT`: float type. By default, `Float64`.
+- `orders`: Gauss-Legendre orders to evaluate. By default, `(5, 6, 7, 8, 10, 12)`.
+- `reference_order`: order of the reference rule. By default, `128`.
+- `include_timing`: also benchmark `bulk_microphysics_tendencies` per order on
+  a hail-core state. By default, `false`.
+
+Return a vector of `(; order, level, median, p95, max)` rows.
+
+The default-order regression test in `test/bulk_tendencies_quadrature_tests.jl`
+locks in the outcome of this study; rerun the study when changing the
+quadrature rule, the integral bounds or breakpoints, or the P3 process
+integrands, and revisit the default order recorded in
+`src/parameters/Microphysics2MParams.jl`. See #741 for the study behind the
+current default.
+"""
+
+import ClimaParams as CP
+import CloudMicrophysics as CM
+import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.P3Scheme as P3
+import CloudMicrophysics.BulkMicrophysicsTendencies as BMT
+import CloudMicrophysics.ThermodynamicsInterface as TDI
+import BenchmarkTools as BT
+import Statistics: median, quantile
+
+function generate_column_states(::Type{FT}) where {FT}
+    # A hand-curated collection of physically plausible (ρ, T, q_*) states
+    # spanning the regimes the Jouan kinematic column experiences. Each row
+    # is a NamedTuple fed directly into `bulk_microphysics_tendencies`.
+
+    # Saturation-vapor helper (local)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
+    q_vs_l(T, ρ) = TDI.saturation_vapor_specific_content_over_liquid(tps, T, ρ)
+    q_vs_i(T, ρ) = TDI.saturation_vapor_specific_content_over_ice(tps, T, ρ)
+
+    states = NamedTuple[]
+
+    # 1. Warm, cloudy, no ice, no rain — pure activation/condensation
+    let ρ = FT(1.2), T = FT(290)
+        push!(
+            states,
+            (;
+                ρ, T,
+                q_tot = q_vs_l(T, ρ) + FT(1e-3),
+                q_lcl = FT(1e-3), n_lcl = FT(1e8),
+                q_rai = FT(0), n_rai = FT(0),
+                q_ice = FT(0), n_ice = FT(0),
+                q_rim = FT(0), b_rim = FT(0),
+            ),
+        )
+    end
+
+    # 2. Warm, heavy rain, no cloud
+    let ρ = FT(1.1), T = FT(285)
+        push!(
+            states,
+            (;
+                ρ, T,
+                q_tot = q_vs_l(T, ρ) + FT(5e-4),
+                q_lcl = FT(0), n_lcl = FT(0),
+                q_rai = FT(5e-4), n_rai = FT(1e4),
+                q_ice = FT(0), n_ice = FT(0),
+                q_rim = FT(0), b_rim = FT(0),
+            ),
+        )
+    end
+
+    # 3. Freezing-level mixed phase, light ice, no rime
+    let ρ = FT(0.9), T = FT(270)
+        push!(
+            states,
+            (;
+                ρ, T,
+                q_tot = q_vs_l(T, ρ) + FT(1e-4) + FT(1e-5),
+                q_lcl = FT(1e-4), n_lcl = FT(1e8),
+                q_rai = FT(0), n_rai = FT(0),
+                q_ice = FT(1e-5), n_ice = FT(1e5),
+                q_rim = FT(0), b_rim = FT(0),
+            ),
+        )
+    end
+
+    # 4. Cold cirrus, trace ice, no rain, no cloud
+    let ρ = FT(0.5), T = FT(240)
+        push!(
+            states,
+            (;
+                ρ, T,
+                q_tot = q_vs_i(T, ρ) + FT(1e-6),
+                q_lcl = FT(0), n_lcl = FT(0),
+                q_rai = FT(0), n_rai = FT(0),
+                q_ice = FT(1e-6), n_ice = FT(1e5),
+                q_rim = FT(0), b_rim = FT(0),
+            ),
+        )
+    end
+
+    # 5. Heavy riming regime
+    let ρ = FT(0.85), T = FT(265)
+        push!(
+            states,
+            (;
+                ρ, T,
+                q_tot = q_vs_l(T, ρ) + FT(5e-4) + FT(5e-4),
+                q_lcl = FT(5e-4), n_lcl = FT(1e8),
+                q_rai = FT(2e-4), n_rai = FT(1e4),
+                q_ice = FT(5e-4), n_ice = FT(1e5),
+                q_rim = FT(1e-4), b_rim = FT(1e-4 / 300),
+            ),
+        )
+    end
+
+    # 6. Dry subsaturated, no condensate — evaporation regime
+    let ρ = FT(1.0), T = FT(290)
+        push!(
+            states,
+            (;
+                ρ, T,
+                q_tot = FT(0.5) * q_vs_l(T, ρ),
+                q_lcl = FT(0), n_lcl = FT(0),
+                q_rai = FT(1e-4), n_rai = FT(1e4),
+                q_ice = FT(0), n_ice = FT(0),
+                q_rim = FT(0), b_rim = FT(0),
+            ),
+        )
+    end
+
+    # 7. Just below 273 K — melting threshold with heavy ice
+    let ρ = FT(1.0), T = FT(272.5)
+        push!(
+            states,
+            (;
+                ρ, T,
+                q_tot = q_vs_l(T, ρ) + FT(1e-3),
+                q_lcl = FT(0), n_lcl = FT(0),
+                q_rai = FT(0), n_rai = FT(0),
+                q_ice = FT(1e-3), n_ice = FT(5e4),
+                q_rim = FT(0), b_rim = FT(0),
+            ),
+        )
+    end
+
+    # 8. Just above 273 K — melting active
+    let ρ = FT(1.0), T = FT(274.0)
+        push!(
+            states,
+            (;
+                ρ, T,
+                q_tot = q_vs_l(T, ρ) + FT(1e-3),
+                q_lcl = FT(0), n_lcl = FT(0),
+                q_rai = FT(0), n_rai = FT(0),
+                q_ice = FT(1e-3), n_ice = FT(5e4),
+                q_rim = FT(0), b_rim = FT(0),
+            ),
+        )
+    end
+
+    # 9. Strong supersaturation over ice, no liquid
+    let ρ = FT(0.7), T = FT(250)
+        push!(
+            states,
+            (;
+                ρ, T,
+                q_tot = FT(1.5) * q_vs_i(T, ρ),
+                q_lcl = FT(0), n_lcl = FT(0),
+                q_rai = FT(0), n_rai = FT(0),
+                q_ice = FT(1e-5), n_ice = FT(1e5),
+                q_rim = FT(0), b_rim = FT(0),
+            ),
+        )
+    end
+
+    # 10. Mixed-phase mid-troposphere with rain + ice
+    let ρ = FT(0.8), T = FT(268)
+        push!(
+            states,
+            (;
+                ρ, T,
+                q_tot = q_vs_l(T, ρ) + FT(3e-4) + FT(3e-4),
+                q_lcl = FT(3e-4), n_lcl = FT(1e8),
+                q_rai = FT(1e-4), n_rai = FT(5e3),
+                q_ice = FT(3e-4), n_ice = FT(1e5),
+                q_rim = FT(1e-5), b_rim = FT(1e-5 / 400),
+            ),
+        )
+    end
+
+    return states
+end
+
+"""
+    hail_core_states(FT, specs)
+
+Mixed-phase states with large mean particle sizes, one per `(F_rim, ρ_rim,
+n_ice)` row of `specs`. The size-distribution tail of these states spans
+several decades of particle diameter.
+"""
+function hail_core_states(::Type{FT}, specs) where {FT}
+    states = NamedTuple[]
+    for (F_rim, ρ_rim, n_ice) in specs
+        q_ice = 1e-3
+        q_rim = F_rim * q_ice
+        b_rim = q_rim / ρ_rim
+        push!(
+            states,
+            (;
+                ρ = FT(0.9), T = FT(262.0), q_tot = FT(4e-3),
+                q_lcl = FT(2e-4), n_lcl = FT(5e7),
+                q_rai = FT(2e-4), n_rai = FT(2e4),
+                q_ice = FT(q_ice), n_ice = FT(n_ice),
+                q_rim = FT(q_rim), b_rim = FT(b_rim),
+            ),
+        )
+    end
+    return states
+end
+
+const STUDY_HAIL_CORES = (
+    (0.5, 400.0, 1e5), (0.95, 400.0, 1e4), (0.95, 800.0, 1e4),
+    (0.8, 600.0, 1e3), (0.8, 600.0, 100.0), (0.8, 600.0, 20.0),
+    (0.95, 800.0, 50.0),
+)
+
+"""
+    evaluate_quadrature_levels(mp, tps, s)
+
+Evaluate every quadrature-consuming P3 quantity at state `s` with the
+quadrature rule stored in `mp.ice`. Return a `Dict` mapping each quantity to
+its component vector; ice quantities are absent for ice-free states.
+"""
+function evaluate_quadrature_levels(mp, tps, s)
+    (; quad, terminal_velocity, cloud_pdf, rain_pdf) = mp.ice
+    aps = mp.warm_rain.air_properties
+    (; ρ, T, q_tot, q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim) = s
+    FT = typeof(ρ)
+    out = Dict{Symbol, Vector{FT}}()
+    has_ice = q_ice > 0 && n_ice > 0
+    state = has_ice ?
+            P3.state_from_prognostic(mp.ice.scheme, ρ * q_ice, ρ * n_ice, ρ * q_rim, ρ * b_rim) :
+            nothing
+    logλ = has_ice ? P3.get_distribution_logλ(state) : FT(0)
+    t = BMT.bulk_microphysics_tendencies(
+        BMT.Microphysics2Moment(), mp, tps, ρ, T, q_tot,
+        q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim, logλ,
+    )
+    out[:bulk] = collect(FT, values(t))
+    if has_ice
+        coll = P3.bulk_liquid_ice_collision_sources(
+            state, logλ, cloud_pdf, rain_pdf, ρ * q_lcl, n_lcl, ρ * q_rai, n_rai,
+            aps, tps, terminal_velocity, ρ, T; quad,
+        )
+        out[:collision] = collect(FT, values(coll))
+        sc = P3.ice_self_collection(state, logλ, terminal_velocity, ρ; quad)
+        out[:selfcol] = [sc.dNdt]
+        out[:vN] = [P3.ice_terminal_velocity_number_weighted(terminal_velocity, ρ, state, logλ; quad)]
+        out[:vM] = [P3.ice_terminal_velocity_mass_weighted(terminal_velocity, ρ, state, logλ; quad)]
+        melt = P3.ice_melt(terminal_velocity, aps, tps, T, ρ, state, logλ; quad)
+        out[:melt] = collect(FT, values(melt))
+    end
+    return out
+end
+
+error_study_level(k) =
+    k == :bulk ? :bulk :
+    (k in (:collision, :selfcol) ? :collision_efficiency : :transport)
+
+function run_quadrature_error_study(;
+    FT = Float64,
+    orders = (5, 6, 7, 8, 10, 12),
+    reference_order = 128,
+    include_timing = false,
+)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
+    make_mp(n) =
+        CMP.Microphysics2MParams(FT; with_ice = true, quad = CM.Quadrature.GaussLegendre(FT, n))
+    states = vcat(generate_column_states(FT), hail_core_states(FT, STUDY_HAIL_CORES))
+
+    refs = [evaluate_quadrature_levels(make_mp(reference_order), tps, s) for s in states]
+    floors = Dict(
+        k =>
+            FT(1e-9) .* max.(
+                [
+                    maximum(abs(r[k][i]) for r in refs if haskey(r, k); init = FT(0)) for
+                    i in 1:maximum(length(r[k]) for r in refs if haskey(r, k))
+                ],
+                eps(FT),
+            ) for k in (:bulk, :vN, :vM, :melt, :selfcol, :collision)
+    )
+
+    results = NamedTuple[]
+    println("order | level | median | p95 | max")
+    for n in orders
+        mp = make_mp(n)
+        errs = Dict(:bulk => FT[], :collision_efficiency => FT[], :transport => FT[])
+        worst = Tuple{FT, Int, Int}[]
+        for (si, (s, r)) in enumerate(zip(states, refs))
+            e = evaluate_quadrature_levels(mp, tps, s)
+            for k in keys(r)
+                for (i, (a, b, f)) in enumerate(zip(e[k], r[k], floors[k]))
+                    err = abs(a - b) / max(abs(a), abs(b), f)
+                    push!(errs[error_study_level(k)], err)
+                    k == :bulk && push!(worst, (err, si, i))
+                end
+            end
+        end
+        for level in (:transport, :collision_efficiency, :bulk)
+            v = errs[level]
+            row = (;
+                order = n, level,
+                median = median(v), p95 = quantile(v, 0.95), max = maximum(v),
+            )
+            push!(results, row)
+            println(rpad("GL($n)", 7), " | ", rpad(level, 20), " | ",
+                rpad(round(row.median, sigdigits = 3), 10), " | ",
+                rpad(round(row.p95, sigdigits = 3), 10), " | ",
+                round(row.max, sigdigits = 3))
+        end
+        sort!(worst; rev = true)
+        println("  worst bulk components (err, state, component): ",
+            join(["($(round(e, sigdigits = 3)), $si, $i)" for (e, si, i) in worst[1:5]], " "))
+    end
+
+    if include_timing
+        s = last(states)
+        println("\norder | bulk tendency min time (μs)")
+        for n in (orders..., reference_order)
+            mp = make_mp(n)
+            (; ρ, T, q_tot, q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim) = s
+            st = P3.state_from_prognostic(mp.ice.scheme, ρ * q_ice, ρ * n_ice, ρ * q_rim, ρ * b_rim)
+            logλ = P3.get_distribution_logλ(st)
+            b = BT.@benchmark $(BMT.bulk_microphysics_tendencies)(
+                $(BMT.Microphysics2Moment()), $mp, $tps, $ρ, $T, $q_tot,
+                $q_lcl, $n_lcl, $q_rai, $n_rai, $q_ice, $n_ice, $q_rim, $b_rim, $logλ,
+            ) samples = 100 evals = 5
+            println(rpad("GL($n)", 7), " | ", round(BT.minimum(b).time / 1000, digits = 1))
+        end
+    end
+
+    return results
+end

--- a/test/p3_tests.jl
+++ b/test/p3_tests.jl
@@ -370,10 +370,10 @@ function test_bulk_terminal_velocities(FT)
 
         # Liquid fraction = 0. The `_ϕ` (aspect-ratio-on) references are below
         # their aspect-off counterparts (`cbrt(ϕ) < 1`).
-        ref_v_n = [3.64194720794662, 2.6191026241691695]
-        ref_v_n_ϕ = [1.523425288986299, 1.4660573287073728]
+        ref_v_n = [3.646059575504377, 2.6191026241691695]
+        ref_v_n_ϕ = [1.5223915218714987, 1.4656564581919258]
         ref_v_m = [7.788114224053879, 5.797675366222473]
-        ref_v_m_ϕ = [2.4275080186932736, 2.3681842506505544]
+        ref_v_m_ϕ = [2.427666066669716, 2.3683439025452544]
 
         params_noar = CMP.ParametersP3(FT; aspect_ratio = CMP.NoAspectRatio())
         for (k, F_rim) in enumerate(F_rims)
@@ -469,17 +469,6 @@ function test_numerical_integrals(FT)
     ρ_a = FT(1.2)
     ps = [1e-3, 1e-6]
 
-    @testset "Chebyshev-Gauss quadrature" begin
-        quad = P3.ChebyshevGauss(10)
-        f(x) = x^4
-        # test that integration gives the correct result
-        num_int = P3.integrate(f, 0, 1, quad)
-        @test num_int ≈ 0.2 rtol = 0.1
-        # test that increasing the number of points improves the accuracy
-        num_int2 = P3.integrate(f, 0, 1, P3.ChebyshevGauss(100))
-        @test abs(num_int2 - 0.2) < abs(num_int - 0.2)
-    end
-
     @testset "Gauss-Legendre quadrature" begin
         quad = P3.GaussLegendre(16)
         # exact for polynomials up to degree 2n-1 (here deg 4 ≤ 31)
@@ -518,19 +507,15 @@ function test_numerical_integrals(FT)
             logλ = P3.get_distribution_logλ(state)
 
             # Number concentration comparison
-            # Note: To achieve sufficient accuracy, we need to substantially
-            # increase the `order` of the quadrature rule, and set `rtol=0`.
-            # The `rtol` settings essentially forces max evaluations of the method.
-            # Note 2: For F_rim=0, L=0.002, even higher order quadrature rules are needed.
             N′ = P3.size_distribution(state, logλ)
             bnds = P3.integral_bounds(state, logλ; p = 1e-6, moment_order = 0)
-            N_estim_cheb = P3.integrate(N′, bnds, P3.ChebyshevGauss(100))
+            N_estim_gl = P3.integrate(N′, bnds, P3.GaussLegendre(FT, 32))
             N_tol = FT == Float32 ? 2e-5 : 1e-5  # native-FT gamma_inc slightly less precise than Float64-backed SF
-            @test N_ice ≈ N_estim_cheb rtol = N_tol
+            @test N_ice ≈ N_estim_gl rtol = N_tol
 
             # Compare with quadgk
             N_estim_qgk = QGK.quadgk(N′, bnds...)[1]
-            @test N_estim_cheb ≈ N_estim_qgk rtol = 1e-5
+            @test N_estim_gl ≈ N_estim_qgk rtol = 1e-5
 
 
             # Bulk velocity comparison
@@ -546,28 +531,28 @@ function test_numerical_integrals(FT)
             v_term = P3.ice_particle_terminal_velocity(Chen2022, ρ_a, state)
             g(D) = v_term(D) * N′(D)
             gm(D) = g(D) * P3.ice_mass(state, D)
-            vel_N_estim_cheb = P3.integrate(g, bnds, P3.ChebyshevGauss(10)) / N_ice
-            vel_m_estim_cheb = P3.integrate(gm, bnds, P3.ChebyshevGauss(10)) / L_ice
-            @test vel_N ≈ vel_N_estim_cheb rtol = 0.005
-            @test vel_m ≈ vel_m_estim_cheb rtol = 0.05
+            vel_N_estim_gl = P3.integrate(g, bnds, P3.GaussLegendre(FT, 32)) / N_ice
+            vel_m_estim_gl = P3.integrate(gm, bnds, P3.GaussLegendre(FT, 32)) / L_ice
+            @test vel_N ≈ vel_N_estim_gl rtol = 0.005
+            @test vel_m ≈ vel_m_estim_gl rtol = 0.05
 
             # Compare with quadgk
             vel_N_estim_qgk = QGK.quadgk(g, bnds...)[1] / N_ice
             vel_m_estim_qgk = QGK.quadgk(gm, bnds...)[1] / L_ice
 
-            @test vel_N_estim_cheb ≈ vel_N_estim_qgk rtol = 0.005
-            @test vel_m_estim_cheb ≈ vel_m_estim_qgk rtol = 0.05
+            @test vel_N_estim_gl ≈ vel_N_estim_qgk rtol = 0.005
+            @test vel_m_estim_gl ≈ vel_m_estim_qgk rtol = 0.05
 
 
             # Dₘ comparisons
             D_m = P3.D_m(state, logλ)
             D_m_func(D) = D * P3.ice_mass(state, D) * N′(D) / L_ice
-            D_m_estim_cheb = P3.integrate(D_m_func, bnds, P3.ChebyshevGauss(100))
-            @test D_m ≈ D_m_estim_cheb rtol = 5e-4
+            D_m_estim_gl = P3.integrate(D_m_func, bnds, P3.GaussLegendre(FT, 32))
+            @test D_m ≈ D_m_estim_gl rtol = 5e-4
 
             # Compare with quadgk
             D_m_estim_qgk = QGK.quadgk(D_m_func, bnds...)[1]
-            @test D_m_estim_cheb ≈ D_m_estim_qgk rtol = 5e-4
+            @test D_m_estim_gl ≈ D_m_estim_qgk rtol = 5e-4
         end
     end
 end
@@ -859,16 +844,16 @@ function test_p3_bulk_liquid_ice_collisions(FT)
         # Smoke tests, aka: Check that rates don't change with new commits.
         # `rtol = 5e-4` admits both Float32 and Float64 against these (Float64)
         # reference values.
-        @test QCFRZ ≈ 5.943946584599112e-7 rtol = 5e-4
-        @test QCSHD ≈ 2.0534323233754524e-9 rtol = 5e-4
-        @test NCCOL ≈ 60666.71757403923 rtol = 5e-4
-        @test QRFRZ ≈ 6.640489628336987e-5 rtol = 5e-4
-        @test QRSHD ≈ 3.6744506329509328e-6 rtol = 5e-4
-        @test NRCOL ≈ 172.65740739140853 rtol = 5e-4
-        @test ∫M_col ≈ 7.069157000967575e-5 rtol = 5e-4
-        @test BCCOL ≈ 3.726612278745525e-9 rtol = 5e-4
-        @test BRCOL ≈ 4.163318251255413e-7 rtol = 5e-4
-        @test ∫𝟙_wet_M_col ≈ 1.3659847784932352e-5 rtol = 5e-4
+        @test QCFRZ ≈ 5.942471550989089e-7 rtol = 5e-4
+        @test QCSHD ≈ 2.0728862241368704e-9 rtol = 5e-4
+        @test NCCOL ≈ 60651.35670910096 rtol = 5e-4
+        @test QRFRZ ≈ 6.642674674038379e-5 rtol = 5e-4
+        @test QRSHD ≈ 3.6526001759370415e-6 rtol = 5e-4
+        @test NRCOL ≈ 172.61819652435105 rtol = 5e-4
+        @test ∫M_col ≈ 7.067566695764388e-5 rtol = 5e-4
+        @test BCCOL ≈ 3.725687492783128e-9 rtol = 5e-4
+        @test BRCOL ≈ 4.164686317018988e-7 rtol = 5e-4
+        @test ∫𝟙_wet_M_col ≈ 1.5520362321253953e-5 rtol = 5e-4
 
         ### Test the bulk source function
         state = P3.P3State(params, Lᵢ, Nᵢ, F_rim, ρ_rim)
@@ -911,8 +896,27 @@ function test_p3_ice_self_collection(FT)
             P3.ice_self_collection(state_zero, logλ_zero, vel_params, ρₐ; quad = P3.GaussLegendre(FT, 12))
         @test rates_zero.dNdt == 0
 
-        # TODO: compare against an analytically derived reference
-        # For a simple size distribution and uniform velocity difference, one could compute analytical dNdt.
+        # Cross-check the triangular domain against the full-square double
+        # integral, where the ½ factor counts each unordered pair once
+        quad32 = P3.GaussLegendre(FT, 32)
+        rates32 = P3.ice_self_collection(state, logλ, vel_params, ρₐ; quad = quad32)
+        n_i = DT.size_distribution(state, logλ)
+        v_i = P3.ice_particle_terminal_velocity(vel_params, ρₐ, state)
+        bnds = P3.velocity_integral_bounds(state, logλ, v_i; p = eps(one(ρₐ)))
+        square = P3.integrate(
+            D₁ -> begin
+                v₁ = v_i(D₁)
+                collision_rate =
+                    D₂ -> P3.collision_cross_section_ice_ice(state, D₁, D₂) * abs(v₁ - v_i(D₂)) * n_i(D₂)
+                # Split the inner integral at D₂ = D₁, where |v₁ - v(D₂)| is not smooth
+                inner =
+                    P3.integrate(collision_rate, (first(bnds), D₁), quad32) +
+                    P3.integrate(collision_rate, (D₁, last(bnds)), quad32)
+                n_i(D₁) * inner
+            end,
+            bnds, quad32,
+        )
+        @test rates32.dNdt ≈ square / 2 rtol = 0.05
     end
 end
 
@@ -946,14 +950,15 @@ function test_p3_closed_form_rain_inner(FT)
             ρ′_rim = P3.compute_local_rime_density(vel, ρₐ, FT(270), state)
             D_min, D_max = bnds = CM2.get_size_distribution_bounds(psd_r, FT(L_r) / ρₐ, ρₐ, FT(N_r), p)
             D_max > D_min || continue
+            v_i = ∂ₜV.v_i
             rc = P3.get_liquid_integrals_rain_closed(
-                psd_r, vel, n_r, ρₐ, FT(L_r), FT(N_r), state, ∂ₜV,
-                m_liq, ρ′_rim, bnds; quad = P3.ChebyshevGauss(40),
+                psd_r, n_r, ρₐ, FT(L_r), FT(N_r), state, ∂ₜV,
+                m_liq, ρ′_rim, bnds; quad = P3.GaussLegendre(FT, 6),
             )
             rn = P3.get_liquid_integrals(  # numerical fallback
-                n_r, ∂ₜV, m_liq, ρ′_rim, bnds; quad = P3.ChebyshevGauss(40),
+                n_r, ∂ₜV, m_liq, ρ′_rim, bnds;
+                quad = P3.GaussLegendre(FT, 6),
             )
-            v_i = P3.ice_particle_terminal_velocity(vel, ρₐ, state)
             for Dᵢ in FT.(10 .^ range(-5, -2; length = 5))
                 vi = v_i(Dᵢ)
                 Dstar = P3.crossover_diameter(vi, v_l, D_min, D_max)
@@ -993,23 +998,23 @@ function test_p3_closed_form_rain_inner(FT)
         L_r, N_r = FT(1e-4), FT(1e3)
         (; N₀r, Dr_mean) =
             CM2.pdf_rain_parameters(psd_r, L_r / ρₐ, ρₐ, N_r)
-        Dᵢ0 = FT(3e-3)
         rᵢ0 = FT(1e-3)
         vi0 = FT(3.0)
         D_min, D_max = FT(1e-5), FT(5e-3)
         rtolAD = FT(1e-4)
+        Dstar0 = P3.crossover_diameter(vi0, v_l, D_min, D_max)
         cases = (
             ("v_i", vi0,
-                x -> P3.closed_rain_inner_NM(Dᵢ0, x, v_l, rᵢ0, ρ_w,
+                x -> P3.closed_rain_inner_NM(x, Dstar0, rᵢ0, ρ_w,
                     ai, bi, ci, D_min, D_max, N₀r, Dr_mean)),
             ("r_i", rᵢ0,
-                x -> P3.closed_rain_inner_NM(Dᵢ0, vi0, v_l, x, ρ_w,
+                x -> P3.closed_rain_inner_NM(vi0, Dstar0, x, ρ_w,
                     ai, bi, ci, D_min, D_max, N₀r, Dr_mean)),
             ("Dr", Dr_mean,
-                x -> P3.closed_rain_inner_NM(Dᵢ0, vi0, v_l, rᵢ0, ρ_w,
+                x -> P3.closed_rain_inner_NM(vi0, Dstar0, rᵢ0, ρ_w,
                     ai, bi, ci, D_min, D_max, N₀r, x)),
             ("N₀r", N₀r,
-                x -> P3.closed_rain_inner_NM(Dᵢ0, vi0, v_l, rᵢ0, ρ_w,
+                x -> P3.closed_rain_inner_NM(vi0, Dstar0, rᵢ0, ρ_w,
                     ai, bi, ci, D_min, D_max, x, Dr_mean)),
         )
         for (_, x0, g) in cases, idx in (1, 2)
@@ -1066,8 +1071,9 @@ function test_p3_closed_form_rain_inner(FT)
         r_i = FT(2e-4)
         ai, bi, ci = CO.Chen2022_vel_coeffs(vel.rain, FT(1))
         for v_i in (FT(-1), FT(1e6))
+            Dstar_i = P3.crossover_diameter(v_i, v_l, D_min, D_max)
             N, M = P3.closed_rain_inner_NM(
-                FT(1e-3), v_i, v_l, r_i, FT(1000), ai, bi, ci,
+                v_i, Dstar_i, r_i, FT(1000), ai, bi, ci,
                 D_min, D_max, FT(1e7), FT(5e-4),
             )
             @test isfinite(N) && isfinite(M)
@@ -1079,18 +1085,14 @@ function test_p3_closed_form_rain_inner(FT)
         vel = CMP.Chen2022VelType(FT)
         psd_r = CMP.SB2006(FT).pdf_r
         state = P3.P3State(params, FT(1e-3), FT(1e6), FT(0.5), FT(500))
-        rest = (
-            identity, (a, b) -> a, identity, identity, identity,
-            FT(1), FT(1e-4), FT(1e3), state,
-        )
-        m_closed = which(P3._rain_inner_integrals, typeof((psd_r, vel, rest...)))
-        m_fallback = which(P3._rain_inner_integrals, typeof((1.0, 2.0, rest...)))
-        # closed-form method: first two params are the typed bundle
+        ∂ₜV = P3.volumetric_collision_rate_integrand(vel, FT(1), state)
+        rest = (identity, identity, (FT(0), FT(1)), FT(1), FT(1e-4), FT(1e3), state)
+        # closed-form eligibility: SB2006 rain PSD with a Chen velocity curve on the kernel
+        m_closed = which(P3._rain_inner_integrals, typeof((psd_r, identity, ∂ₜV, rest...)))
+        m_fallback = which(P3._rain_inner_integrals, typeof((1.0, identity, identity, rest...)))
         @test m_closed.sig.parameters[2] <: CMP.RainParticlePDF_SB2006
-        @test m_closed.sig.parameters[3] <: CMP.Chen2022VelType
-        # fallback method: first two params are ::Any (Any === Any)
+        @test m_closed.sig.parameters[4] <: P3.VolumetricCollisionRate{<:Any, <:Any, <:CO.Chen2022VelocityCurve}
         @test m_fallback.sig.parameters[2] === Any
-        @test m_fallback.sig.parameters[3] === Any
         # and the two methods are distinct (no accidental ambiguity merge)
         @test m_closed !== m_fallback
     end

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -176,18 +176,20 @@ function benchmark_test(FT)
         P3.P3State,
         P3.P3State,
         (params_P3, L_ice, N_ice, F_rim, ρ_rim),
-        220,
+        1_000,
     )
-    bench_press(FT, P3.get_distribution_logλ, (state,), 35_000)  # 10 (F64) / 8 (F32) FixedIterations BrentsMethod, zero warp divergence
-    # The weighted-velocity integrals build a nested terminal-velocity closure
-    # that escapes into `integrate`. With `ice_particle_terminal_velocity`
-    # returning a single (concretely-typed) closure, this path is type-stable
-    # on both 1.10 and 1.12 and allocates nothing — keep the default zero
-    # allocation/memory budget so a future closure regression is caught here.
-    bench_press(FT, P3.ice_terminal_velocity_number_weighted, (ch2022, ρ_air, state, logλ), 170_000)
-    bench_press(FT, P3.ice_terminal_velocity_mass_weighted, (ch2022, ρ_air, state, logλ), 200_000)
-    bench_press(FT, P3.integrate, (x -> x^4, FT(0), FT(1)), 7_000)
-    bench_press(FT, P3.D_m, (state, logλ), 3_000)
+    bench_press(FT, P3.get_distribution_logλ, (state,), 500_000)  # 10 (F64) / 8 (F32) FixedIterations BrentsMethod
+    _glq = P3.GaussLegendre(FT, 12)
+    bench_press(
+        FT, (a, b, c, d) -> P3.ice_terminal_velocity_number_weighted(a, b, c, d; quad = _glq),
+        (ch2022, ρ_air, state, logλ), 170_000,
+    )
+    bench_press(
+        FT, (a, b, c, d) -> P3.ice_terminal_velocity_mass_weighted(a, b, c, d; quad = _glq),
+        (ch2022, ρ_air, state, logλ), 200_000,
+    )
+    bench_press(FT, P3.integrate, (x -> x^4, FT(0), FT(1), P3.GaussLegendre(FT, 6)), 7_000)
+    bench_press(FT, P3.D_m, (state, logλ), 20_000)
 
     @info "P3 Ice Nucleation"
     bench_press(
@@ -198,7 +200,7 @@ function benchmark_test(FT)
     )
     bench_press(
         @NamedTuple{dNdt::FT, dLdt::FT},
-        P3.ice_melt,
+        (vp, ap, tp, T, ρ, st, lλ) -> P3.ice_melt(vp, ap, tp, T, ρ, st, lλ; quad = _glq),
         (ch2022, aps, tps, T_air, ρ_air, state, logλ),
         150_000,
     )
@@ -320,22 +322,47 @@ function benchmark_test(FT)
         bench_press(FT, CMD.effective_radius_2M, (sb, q_liq, q_rai, N_liq, N_rai, ρ_air), 2000)
 
         @info "P3 Collisions"
-        # Julia <= 1.11 inference exceeds its depth budget on this collision
-        # assembly, widening intermediates to Any (runtime dispatch + boxing;
-        # correct but unoptimized), so the JET and allocation assertions fail
-        # spuriously there. 1.12 resolves the chain: zero JET reports, zero
-        # allocations. TODO: drop the gate once CI runs >= 1.12.
-        if VERSION >= v"1.12"
-            bench_press(@NamedTuple{∂ₜq_c::FT, ∂ₜq_r::FT, ∂ₜN_c::FT, ∂ₜN_r::FT, ∂ₜL_rim::FT, ∂ₜL_ice::FT, ∂ₜB_rim::FT},
-                P3.bulk_liquid_ice_collision_sources,
-                (
-                    state, logλ,
-                    sb.pdf_c, sb.pdf_r, ρ_air * q_liq, N_liq, ρ_air * q_rai, N_rai,
-                    aps, tps, ch2022,
-                    ρ_air, T_air,
-                ), 1e9)
-        end
+        bench_press(@NamedTuple{∂ₜq_c::FT, ∂ₜq_r::FT, ∂ₜN_c::FT, ∂ₜN_r::FT, ∂ₜL_rim::FT, ∂ₜL_ice::FT, ∂ₜB_rim::FT},
+            (st, lλ, pc, pr, Lc, Nc, Lr, Nr, ap, tp, vp, ρ, T) ->
+                P3.bulk_liquid_ice_collision_sources(st, lλ, pc, pr, Lc, Nc, Lr, Nr, ap, tp, vp, ρ, T; quad = _glq),
+            (
+                state, logλ,
+                sb.pdf_c, sb.pdf_r, ρ_air * q_liq, N_liq, ρ_air * q_rai, N_rai,
+                aps, tps, ch2022,
+                ρ_air, T_air,
+            ), 1e7)
     end
+
+    @info "2M+P3 bulk tendencies"
+    mp_2mp3 = CMP.Microphysics2MParams(FT; with_ice = true)
+    q_lcl_bmt = FT(1e-3)
+    n_lcl_bmt = FT(1e8)
+    q_rai_bmt = FT(2e-4)
+    n_rai_bmt = FT(1e6)
+    q_ice_bmt = FT(3e-4)
+    n_ice_bmt = FT(1e5)
+    q_rim_bmt = FT(1e-4)
+    b_rim_bmt = FT(1e-10)
+    state_bmt = P3.state_from_prognostic(
+        mp_2mp3.ice.scheme,
+        ρ_air * q_ice_bmt, ρ_air * n_ice_bmt, ρ_air * q_rim_bmt, ρ_air * b_rim_bmt,
+    )
+    logλ_bmt = P3.get_distribution_logλ(state_bmt)
+    bench_press(
+        @NamedTuple{
+            dq_lcl_dt::FT, dn_lcl_dt::FT, dq_rai_dt::FT, dn_rai_dt::FT,
+            dq_ice_dt::FT, dn_ice_dt::FT, dq_rim_dt::FT, db_rim_dt::FT,
+            dn_lcl_activation_dt::FT,
+        },
+        BMT.bulk_microphysics_tendencies,
+        (
+            BMT.Microphysics2Moment(), mp_2mp3, tps, ρ_air, T_air, q_tot,
+            q_lcl_bmt, n_lcl_bmt, q_rai_bmt, n_rai_bmt,
+            q_ice_bmt, n_ice_bmt, q_rim_bmt, b_rim_bmt, logλ_bmt,
+        ),
+        3e7,
+    )
+
     bench_press(FT, CMD.effective_radius_Liu_Hallet_97, (wtr, ρ_air, q_liq, N_liq, q_rai, N_rai), 300)
     bench_press(
         FT, CM2.number_tendency_from_mass_limits,


### PR DESCRIPTION
Set the default P3 quadrature rule to Gauss-Legendre of order 6, and place every known feature of the P3 size-distribution integrands on a quadrature subinterval boundary so that a low-order rule suffices.

Stacked on #757 (mechanical refactors and small fixes).

----

Each P3 size-distribution integrand has a small set of known non-smooth features: the mass-regime thresholds, the terminal-velocity regime break, the ice-liquid fall-speed crossing, the exponential decay of the distribution tail, and the wet-growth onset. Placing each feature on a subinterval boundary leaves the integrand smooth within every subinterval, where Gauss-Legendre converges geometrically. Order 6 then meets (a handwavily reasonable) target accuracy (see below).

## API

- The quadrature rule lives on `P3IceParams`. `build_quadrature` and the stored `quadrature_order` field are removed; the parameter constructors take a `quadrature_order` (or `quad`) keyword.
- `integrate` and the P3 process functions require `quad`.
- `VolumetricCollisionRate` stores the ice and liquid terminal-velocity closures as fields, so the collision integrals read the velocities and their structure from the integrand itself: the crossing bounds, the closed-form rain integrals (coefficients read from the closure), and the wet-growth onset balance.
- `velocity_breakpoints(v_term)` returns the diameters where a terminal-velocity closure changes functional form. `velocity_integral_bounds` consumes the closure, so the integral bounds no longer assume the Chen 2022 cutoff field.

## Breakpoints

- Terminal-velocity regime break (Chen small/large ice): a subinterval boundary (`velocity_integral_bounds`) for the velocity-weighted integrals, `ice_melt` (through its ventilation factor), the outer collision integral, and ice self-collection.
- Ice-liquid fall-speed crossing `v_l(D) = v_i(Dᵢ)`: a subinterval boundary of the inner collision integrals (`crossing_integral_bounds`). The rain path computes the crossover diameter once per outer node and shares it across the closed-form N and M components and the `B_rim` quadrature. With the crossing on a boundary, the collision-efficiency family (collision sources and ice self-collection) converges with order rather than saturating at a fixed error: worst-case relative error falls from 1.2e-2 at order 6 to 5.0e-6 at order 32.
- Distribution tail at three decay lengths (`3/λ`): the upper bound is the `(1 - p)` quantile, so without this breakpoint the last subinterval spans most of the `log(1/p) ≈ 11.5` decay lengths and sets the low-order error in large-mean-size states. With the breakpoint, ice self-collection in the hail-core states reaches 7.1e-5 relative error at order 12 (1.1e-2 at order 6).
- Wet-growth onset (where collected liquid mass balances the Musil freeze limit): a step in the outer integrand, through the freeze/shed `min()` partition and the wet-growth indicator. `wet_growth_onset_diameter` locates up to two balance points (the window closes again at large sizes) from a closed-form balance refined by bracketed root-finding, and places them on outer subinterval boundaries. At order 12 the shedding component reaches ~1e-7 relative error; the wet-growth-indicator component sits near 2e-4 and is nearly order-independent (2.5e-4 at order 6, 2.3e-4 at order 12), set by the onset placement rather than the node count.
- Ice self-collection integrates over the upper triangle `D₁ ≤ D₂`, which places the `D₁ = D₂` derivative discontinuity of the relative fall speed on a boundary and halves the integrand evaluations. A test cross-checks the triangle against the full-square double integral with the ½ pair-counting factor.

## Accuracy and the default order

I wrote a script that let's me test the accuracy for different orders (since I suspect  I'll revisit this in the future).
Over each P3 integral, the collision source vector, and the full 2M+P3 bulk tendency vector, across 17 "regime" states including hail cores. Baseline ("truth") is a GL(128) reference (converged). The `main` column runs the same script on `main` against `main`'s own GL(128) reference (both without breakpoints). The bulk-tendency error separates into transport components (sedimentation velocities, melt) and components proportional to the collision efficiency (collision sources, ice self-collection, rime):

| | main (GL(16) default) | GL(5) | **GL(6) (default)** | GL(7) | GL(8) |
|---|---|---|---|---|---|
| transport p95 / max | — | 1.7e-3 / 2.0e-2 | **7.1e-4 / 4.5e-3** | 3.2e-4 / 1.2e-3 | 4.4e-5 / 3.9e-4 |
| E-family p95 / max | — | 3.9e-2 / 6.9e-2 | **1.1e-2 / 1.2e-2** | 2.0e-3 / 7.8e-3 | 6.1e-4 / 1.1e-3 |
| bulk p95 / max | 1.4e-3 / 6.2e-2 | 2.8e-2 / 6.9e-2 | **8.9e-3 / 1.4e-2** | 1.5e-3 / 7.8e-3 | 2.9e-4 / 9.0e-4 |

Every bulk error above 0.45% is in a collision-efficiency component, which sets `E = 1`. The package's own single-moment scheme assigns collision efficiencies from 0.1 to 1.0 for the analogous liquid-frozen and rain-frozen collisions (`cloud_liquid_snow_collision_efficiency = 0.1`, `cloud_ice_rain_collision_efficiency = 1.0`), so the `E = 1` choice is an upper bound uncertain to a factor of order ten. That uncertainty exceeds the ~1% quadrature error on those rates, so resolving them below ~1% adds no physical accuracy while `E` is fixed. The transport components, which do not include the `E = 1` assumption, converge to at most 0.45% (worst-case 4.5e-3 at order 6). Order 5 reaches 2.0e-2 in the transport family and is rejected. Order 7 matches `main`'s bulk p95 and is far below `main` on the worst-case bulk error; order 8 is below `main` on both. Both remain one-keyword changes (`quadrature_order`). Parameterizing the collision efficiency is the top follow-up, and this table should be revisited when it lands.

## Runtime

Then testing the runtime with these changes in Float64 on Julia 1.12.

| cell | main (GL(16)) | this PR (GL(6) + breakpoints) | ratio |
|---|---|---|---|
| warm (ice-free) | 0.48 µs | 0.81 µs | 1.7 |
| mixed-phase | 5011 µs | 2063 µs | 0.41 |
| hail core | 4824 µs | 2143 µs | 0.44 |

The warm cell performs no size-distribution integrals; its sub-microsecond time differs between the two by about 0.3 µs, reproducibly across runs and negligible against the ice-path cost. The `he/p3-refactors` base (the PR base) gives the same GL(16) baseline as `main` (5011 / 4824 µs here versus 5017 / 4869 µs for `main` in a separate run, for the two ice cells), so the speedup is attributable to the order reduction, the closed-form rain integrals, and the triangle self-collection, net of the onset cost. The onset location costs about a quarter of the collision call (a log-spaced scan, RootSolvers Brent refinements of the closed-form balance, and two additional outer subintervals). Removing the step also removes a state-dependent discontinuity from the tendencies that the implicit solver's Jacobian must differentiate.

The absolute GL(16) baseline depends on the Julia version: on Julia 1.12 the 16-node collision double integral runs at ~5000 µs, roughly 1.8× the figure a lower Julia version reports, while the GL(6) time is stable across versions. The ratio above is therefore the Julia 1.12 result (on lower versions the ratio is closer to 0.75). The measurement ran on the `clima` cluster.

----

Tests:

- `test/p3_quadrature_error_study.jl` (`run_quadrature_error_study()`; usage in the developer guide) regenerates the accuracy table when the quadrature machinery or the process integrands change.
- `test/bulk_tendencies_quadrature_tests.jl` locks orders 6 through 12 as a regression test against a GL(200) reference, with graupel and hail-core states in the state set.
- The P3 and 2M integral tests use Gauss-Legendre in place of Chebyshev-Gauss, matching the default: scheme-path calls use GL(6), and the standalone reference integrals use the smallest order meeting their tolerance. On these integrands Gauss-Legendre is 1-2 orders of magnitude more accurate than Chebyshev-Gauss at matched order and cost; the endpoint behavior that originally motivated Chebyshev-Gauss was the unresolved crossing and onset structure, which the breakpoints remove.
