### PR TITLE
feat(BMT): analytic ManualJacobian for the 2M+P3 Rosenbrock substep

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -155,6 +155,7 @@ Internal Rosenbrock substep helpers:
 
 ```@docs
 BulkMicrophysicsTendencies.Instantaneous2MP3Tendency
+BulkMicrophysicsTendencies.ManualJacobian
 BulkMicrophysicsTendencies.MicroState1M
 BulkMicrophysicsTendencies.MicroState2MP3
 BulkMicrophysicsTendencies.Raw1MTendency
@@ -163,6 +164,7 @@ BulkMicrophysicsTendencies._euler_update
 BulkMicrophysicsTendencies._full_species_mask
 BulkMicrophysicsTendencies._instantaneous_1m_tendency
 BulkMicrophysicsTendencies._instantaneous_2mp3_tendency
+BulkMicrophysicsTendencies._jacobian_2mp3_manual
 BulkMicrophysicsTendencies._per_process_1m
 BulkMicrophysicsTendencies._per_process_2mp3
 BulkMicrophysicsTendencies._rosenbrock_solve
@@ -171,6 +173,7 @@ BulkMicrophysicsTendencies._rosenbrock_substep_verbose
 BulkMicrophysicsTendencies._rosenbrock_system
 BulkMicrophysicsTendencies._rosenbrock_update
 BulkMicrophysicsTendencies._species_mask
+BulkMicrophysicsTendencies.rosenbrock_manual
 ```
 
 # P3 scheme

--- a/src/BMT_rosenbrock.jl
+++ b/src/BMT_rosenbrock.jl
@@ -66,6 +66,16 @@ end
 end
 
 """
+    _ice_numadj_params(FT)
+
+The `(τ, x_min, x_max)` bounds for the ice number adjustment, shared between
+the primal tendency ([`_per_process_2mp3`](@ref)) and its Jacobian
+([`_jacobian_2mp3_manual`](@ref)).
+"""
+@inline _ice_numadj_params(::Type{FT}) where {FT} =
+    (; τ = FT(100), x_min = FT(1e-12), x_max = FT(1e-5))
+
+"""
     _per_process_2mp3(mp, tps, ρ, T, q_tot,
         q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim, logλ)
 
@@ -253,7 +263,7 @@ sides `f_p` for the linear post-solve attribution and is not differentiated.
     ice_depsub = MicroState2MP3(o, o, o, o, ∂ₜq_ice_dep, ∂ₜn_ice_dep, ∂ₜq_rim_sub, ∂ₜb_rim_sub)
 
     # ice number adjustment for mass limits
-    numadj = (; τ = FT(100), x_min = FT(1e-12), x_max = FT(1e-5))
+    numadj = _ice_numadj_params(FT)
     ∂ₜn_ice_numadj = CM2.number_tendency_from_mass_limits(numadj, q_ice, n_ice)
     ice_numadj = MicroState2MP3(o, o, o, o, o, ∂ₜn_ice_numadj, o, o)
 
@@ -376,7 +386,7 @@ end
 
 bulk_microphysics_tendencies(::RosenbrockAverage, ::Microphysics2Moment, args...) = throw(
     ArgumentError(
-        "RosenbrockAverage on the 2M+P3 model supports only ExactJacobian; use rosenbrock_exact()",
+        "RosenbrockAverage on the 2M+P3 model supports only ExactJacobian or ManualJacobian; use rosenbrock_exact() or rosenbrock_manual()",
     ),
 )
 
@@ -401,74 +411,14 @@ tendency. See the [Rosenbrock-average microphysics substepping](@ref)
 documentation page for the substep algorithm.
 
 `logλ` and `q_tot` are held fixed across substeps. The 2M+P3 model supports
-only [`ExactJacobian`](@ref); the donor-based matrix is 1M-only.
+[`ExactJacobian`](@ref) and [`ManualJacobian`](@ref); the donor-based matrix
+([`DonorJacobian`](@ref)/[`CoupledDonorJacobian`](@ref)) is 1M-only.
 
 Returns the net change in the species over `Δt` divided by `Δt`, in the same
 fields as the `Instantaneous` entry (without the activation diagnostic).
 """
-@inline function bulk_microphysics_tendencies(mode::RosenbrockAverage{ExactJacobian}, cm::Microphysics2Moment,
-    mp::CMP.Microphysics2MParams{WR, ICE}, tps,
-    ρ, T, q_tot,
-    q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim, logλ,
-    Δt, nsub = 1,
-) where {WR, ICE <: CMP.P3IceParams}
-    FT = typeof(q_tot)
-    nsub_eff = max(Int(nsub), 1)
-    h = Δt / FT(nsub_eff)
-    cp_d = TDI.TD.Parameters.cp_d(tps)
-    Lv_over_cp = TDI.TD.Parameters.LH_v0(tps) / cp_d
-    Ls_over_cp = TDI.TD.Parameters.LH_s0(tps) / cp_d
-
-    x = MicroState2MP3{FT}(q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim)
-    x₀ = x
-    Tsub = T
-    for _ in 1:nsub_eff
-        g = Instantaneous2MP3Tendency(mp, tps, ρ, Tsub, q_tot, logλ)
-        x_prev = x
-        if all(isfinite, x)
-            f, J_raw = _tendency_and_jacobian(mode.jacobian, g, x)
-            J = _apply_growth(mode.growth, J_raw)
-            z = _species_mask(mode.jacobian, mode.growth)(x)
-            d = if all(isfinite, J)
-                _rosenbrock_update(x, f, J, z, h) - x
-            else
-                _euler_update(x, f, h) - x
-            end
-            d = _apply_limiter(mode.limiter, x, d, ρ, Tsub, q_tot, Lv_over_cp, Ls_over_cp, tps)
-            x = max.(x .+ d, 0)
-        else
-            f = g(x)
-            x = _euler_update(x, f, h)
-        end
-        Δ = x - x_prev
-        T_safe = max(150, Tsub)
-        Tsub += (TDI.Lᵥ(tps, T_safe) * (Δ.q_lcl + Δ.q_rai) + TDI.Lₛ(tps, T_safe) * Δ.q_ice) / cp_d
-    end
-
-    rates = (x - x₀) / Δt
-    return NamedTuple{(
-        :dq_lcl_dt, :dn_lcl_dt, :dq_rai_dt, :dn_rai_dt,
-        :dq_ice_dt, :dn_ice_dt, :dq_rim_dt, :db_rim_dt,
-    )}(
-        Tuple(rates),
-    )
-end
-
-"""
-    bulk_microphysics_tendencies(::RosenbrockAverage{ManualJacobian}, ::Microphysics2Moment,
-        mp, tps, ρ, T, q_tot,
-        q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim, logλ,
-        Δt, nsub = 1)
-
-Average 2M+P3 microphysics tendencies over `Δt` using `nsub`
-linearized-implicit (Rosenbrock-Euler) substeps with the hand-built
-[`ManualJacobian`](@ref) in place of the `ForwardDiff` Jacobian. The substep
-loop, equilibration, positivity clamp, increment limiter, and between-substep
-`T` update match the [`ExactJacobian`](@ref) entry; only the substep matrix
-([`_jacobian_2mp3_manual`](@ref)) differs.
-"""
 @inline function bulk_microphysics_tendencies(
-    mode::RosenbrockAverage{ManualJacobian}, cm::Microphysics2Moment,
+    mode::RosenbrockAverage{<:Union{ExactJacobian, ManualJacobian}}, cm::Microphysics2Moment,
     mp::CMP.Microphysics2MParams{WR, ICE}, tps,
     ρ, T, q_tot,
     q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim, logλ,
@@ -519,8 +469,6 @@ end
 @inline _tendency_and_jacobian(::ManualJacobian, g::Instantaneous2MP3Tendency, x) =
     (g(x), _jacobian_2mp3_manual(g, x))
 
-@inline _species_mask(::ManualJacobian, ::GrowthTreatment) = _full_species_mask
-
 """
     _jacobian_2mp3(FT; lcl_lcl, lcl_rai, ..., brim_brim)
 
@@ -563,7 +511,7 @@ physical coupling name rather than numeric `[i, j]` position, mirroring
 )
 
 """
-    _condevap_derivs(τ, sat_excess, Γ, cp_air, L, dqs_dT, q_cap, cap_is_ice,
+    _condevap_derivs(τ, sat_excess, Γ, cp_air, L, dqs_dT, q_limit, limit_is_ice,
         dcp_dliq, dcp_dice)
 
 The three closed-form derivatives `(∂s_liq, ∂s_rai, ∂s_ice)` of a relaxation
@@ -572,24 +520,16 @@ ice donor, matching the active primal branch of
 [`CMNonEq.conv_q_vap_to_q_lcl`](@ref) / [`CMNonEq.conv_q_vap_to_q_icl`](@ref):
 
 ```
-∂ₜq = ifelse(sat_excess < 0, -min(-sat_excess, max(0, q_cap)) / (τ·Γ),
+∂ₜq = ifelse(sat_excess < 0, -min(-sat_excess, max(0, q_limit)) / (τ·Γ),
              sat_excess / (τ·Γ))
 ```
 
-`sat_excess = q_vap − qᵥ_sat`, with `q_vap = clamp(q_tot − (q_lcl+q_rai) − q_ice)`
-so `∂q_vap/∂q = −1` on each condensate donor; `Γ = 1 + (L/cp_air)·dqs_dT` carries
-the residual condensate dependence (through `cp_air = cp_m(q_tot, q_lcl+q_rai,
-q_ice)`), giving `∂Γ/∂q = −(L·dqs_dT/cp_air²)·∂cp_air/∂q`.
-
-`q_cap` is the donor's own mass (`q_lcl` for cloud, `q_ice` for ice, selected by
-`cap_is_ice`). On the evaporation/sublimation branch the cap binds on `q_cap`
-exactly when `−sat_excess > max(0, q_cap)` (`min`/`max` resolve ties to the same
-arm as `ForwardDiff`): there `∂ₜq = −max(0, q_cap)/(τ·Γ)`, the vapor coupling
-drops, and the cap-species row gains `−1/(τ·Γ)` (the `max(0, q_cap)` self
-derivative is `1` for `q_cap ≥ 0`).
+`q_limit` is the donor's own mass (`q_lcl` for cloud, `q_ice` for ice, selected
+by `limit_is_ice`); `limit_binds` selects between the vapor and limited branches
+of `∂ₜq`.
 """
 @inline function _condevap_derivs(
-    τ, sat_excess, Γ, cp_air, L, dqs_dT, q_cap, cap_is_ice, dcp_dliq, dcp_dice,
+    τ, sat_excess, Γ, cp_air, L, dqs_dT, q_limit, limit_is_ice, dcp_dliq, dcp_dice,
 )
     FT = typeof(sat_excess)
     τΓ = τ * Γ
@@ -598,20 +538,20 @@ derivative is `1` for `q_cap ≥ 0`).
     dΓ_dice = -(L * dqs_dT / cp_air^2) * dcp_dice
     dinv_dliq = -dΓ_dliq * τ / τΓ^2
     dinv_dice = -dΓ_dice * τ / τΓ^2
-    cap_binds = (sat_excess < 0) & (-sat_excess > max(zero(FT), q_cap))
+    limit_binds = (sat_excess < 0) & (-sat_excess > max(zero(FT), q_limit))
     # Vapor branch: ∂ₜq = sat_excess/(τΓ), ∂sat_excess/∂q = -1 on every donor.
     v_liq = -1 / τΓ + sat_excess * dinv_dliq
     v_ice = -1 / τΓ + sat_excess * dinv_dice
-    # Capped branch: ∂ₜq = -q_cap/(τΓ). Only the cap species (q_lcl for cloud,
-    # q_ice for ice) carries the -1/(τΓ) self term; q_rai is never the cap. Every
-    # donor keeps the -q_cap·∂(1/(τΓ)) Γ term.
-    cap_self = 1 / τΓ
-    c_liq = -q_cap * dinv_dliq - ifelse(cap_is_ice, zero(FT), cap_self)
-    c_rai = -q_cap * dinv_dliq
-    c_ice = -q_cap * dinv_dice - ifelse(cap_is_ice, cap_self, zero(FT))
-    ∂s_liq = ifelse(cap_binds, c_liq, v_liq)
-    ∂s_rai = ifelse(cap_binds, c_rai, v_liq)
-    ∂s_ice = ifelse(cap_binds, c_ice, v_ice)
+    # Limited branch: ∂ₜq = -q_limit/(τΓ). Only the limit species (q_lcl for
+    # cloud, q_ice for ice) carries the -1/(τΓ) self term; q_rai is never the
+    # limit. Every donor keeps the -q_limit·∂(1/(τΓ)) Γ term.
+    limit_self = 1 / τΓ
+    c_liq = -q_limit * dinv_dliq - ifelse(limit_is_ice, zero(FT), limit_self)
+    c_rai = -q_limit * dinv_dliq
+    c_ice = -q_limit * dinv_dice - ifelse(limit_is_ice, limit_self, zero(FT))
+    ∂s_liq = ifelse(limit_binds, c_liq, v_liq)
+    ∂s_rai = ifelse(limit_binds, c_rai, v_liq)
+    ∂s_ice = ifelse(limit_binds, c_ice, v_ice)
     return (; ∂s_liq, ∂s_rai, ∂s_ice)
 end
 
@@ -624,9 +564,9 @@ the same `(ρ, Tsub, q_tot, logλ, x)` as the raw tendency `f = g(x)`.
 The entries are tiered:
 
   - Tier 1 (closed-form): cloud condensation/evaporation, ice
-    deposition/sublimation (with the ice-number sublimation channel and the rim
+    deposition/sublimation (with the ice-number sublimation pathway and the rim
     drain), the four number adjustments, and the F23 deposition-nucleation number
-    channel. The supersaturation block carries the autocatalytic vapor brake
+    pathway. The supersaturation block carries the autocatalytic vapor brake
     `∂q_vap/∂q_condensate = −1` and the relaxation `−1/(τ·Γ)` couplings.
   - Tier 2 (donor-diagonal): autoconversion, accretion, cloud/rain
     self-collection, breakup, rain evaporation, Bigg immersion, and rain
@@ -704,7 +644,7 @@ The entries are tiered:
     ice_rai = ifelse(dep_active, ci.∂s_rai, o)
     ice_ice = ifelse(dep_active, ci.∂s_ice, o)
 
-    # ice number sublimation channel: ∂ₜn_ice_dep = (n_ice/q_ice)·∂ₜq_ice_dep,
+    # ice number sublimation pathway: ∂ₜn_ice_dep = (n_ice/q_ice)·∂ₜq_ice_dep,
     # active only on the sublimation branch (∂ₜq_ice_dep < 0)
     ∂ₜq_ice_dep = pp.ice_depsub.q_ice
     n_sub_active = ∂ₜq_ice_dep < 0 && q_ice > qmin && dep_active
@@ -715,12 +655,7 @@ The entries are tiered:
     nice_ice = ifelse(n_sub_active, n_per_q * (ice_ice - ∂ₜq_ice_dep / max(qmin, q_ice)), o)
     nice_nice = ifelse(n_sub_active, ∂ₜq_ice_dep / max(qmin, q_ice), o)
 
-    # rim drain on the sublimation branch (∂ₜq_rim_sub = ∂ₜq_ice_sub·F_rim,
-    # ∂ₜb_rim_sub = ∂ₜq_ice_sub·F_rim/ρ_rim) stays in `f`, but its species
-    # couplings are omitted from `J`. A frozen-F_rim entry F_rim·∂(∂ₜq_ice_sub) is
-    # nearly cancelled by the F_rim-variation term ∂ₜq_ice_sub·∂F_rim/∂q (the
-    # regularised q_rim/q_ice ratio), so the true coupling is ~1e-5·λ_dep; freezing
-    # F_rim would inject a spurious O(λ_dep) entry instead. Dropped as Tier 3.
+    # Rim-drain couplings on the sublimation branch are dropped from J (Tier 3).
     rim_lcl = o
     rim_rai = o
     rim_ice = o
@@ -728,7 +663,7 @@ The entries are tiered:
     brim_rai = o
     brim_ice = o
 
-    # F23 deposition nucleation number channel: ∂ₜn_frz = max(0, INPC/ρ − n_ice)/τ_act
+    # F23 deposition nucleation number pathway: ∂ₜn_frz = max(0, INPC/ρ − n_ice)/τ_act
     # (n_active = n_ice here); active arm ⇒ ∂/∂n_ice = −1/τ_act.
     τ_act = mp.ice.inp_depletion_model.τ_act
     f23_n = pp.f23_deposition.n_ice
@@ -743,8 +678,9 @@ The entries are tiered:
         _numadj_derivs(FT, q_lcl, n_lcl, sb.pdf_c.xc_min, sb.pdf_c.xc_max, sb.numadj.τ, qmin)
     (nrai_rai, nrai_nrai) =
         _numadj_derivs(FT, q_rai, n_rai, sb.pdf_r.xr_min, sb.pdf_r.xr_max, sb.numadj.τ, qmin)
+    numadj_ice = _ice_numadj_params(FT)
     (nice_ice_adj, nice_nice_adj) =
-        _numadj_derivs(FT, q_ice, n_ice, FT(1e-12), FT(1e-5), FT(100), qmin)
+        _numadj_derivs(FT, q_ice, n_ice, numadj_ice.x_min, numadj_ice.x_max, numadj_ice.τ, qmin)
     nice_ice += nice_ice_adj
     nice_nice += nice_nice_adj
 
@@ -756,7 +692,7 @@ The entries are tiered:
     rai_rai = o
     nrai_nlcl = o
     # each process column = process tendency vector / max(floor, donor); mass
-    # channels routed by the mass donor, number channels by the number donor.
+    # pathways routed by the mass donor, number pathways by the number donor.
     dlcl = 1 / max(q_floor, q_lcl)
     drai = 1 / max(q_floor, q_rai)
     dnlcl = 1 / max(n_floor, n_lcl)
@@ -1030,12 +966,15 @@ The species projection `x -> z` for a [`Jacobian`](@ref) and
 flooring, so every species stays implicit ([`_full_species_mask`](@ref)). An
 explicit growth diagonal removes the unbounded growth of the exact Jacobian, so
 its species stay implicit too; the exact Jacobian with implicit growth uses the
-near-empty mask ([`_rosenbrock_species_mask`](@ref)).
+near-empty mask ([`_rosenbrock_species_mask`](@ref)). The manual Jacobian drops
+the unbounded quadrature growth couplings (Tier 3), so it stays on the full mask
+under either growth treatment.
 """
 @inline _species_mask(::DonorJacobian, ::GrowthTreatment) = _full_species_mask
 @inline _species_mask(::CoupledDonorJacobian, ::GrowthTreatment) = _full_species_mask
 @inline _species_mask(::ExactJacobian, ::ExplicitGrowthDiagonal) = _full_species_mask
 @inline _species_mask(::ExactJacobian, ::ImplicitGrowth) = _rosenbrock_species_mask
+@inline _species_mask(::ManualJacobian, ::GrowthTreatment) = _full_species_mask
 
 """
     _apply_growth(growth, J)

--- a/src/BMT_rosenbrock.jl
+++ b/src/BMT_rosenbrock.jl
@@ -454,6 +454,387 @@ fields as the `Instantaneous` entry (without the activation diagnostic).
     )
 end
 
+"""
+    bulk_microphysics_tendencies(::RosenbrockAverage{ManualJacobian}, ::Microphysics2Moment,
+        mp, tps, ρ, T, q_tot,
+        q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim, logλ,
+        Δt, nsub = 1)
+
+Average 2M+P3 microphysics tendencies over `Δt` using `nsub`
+linearized-implicit (Rosenbrock-Euler) substeps with the hand-built
+[`ManualJacobian`](@ref) in place of the `ForwardDiff` Jacobian. The substep
+loop, equilibration, positivity clamp, increment limiter, and between-substep
+`T` update match the [`ExactJacobian`](@ref) entry; only the substep matrix
+([`_jacobian_2mp3_manual`](@ref)) differs.
+"""
+@inline function bulk_microphysics_tendencies(
+    mode::RosenbrockAverage{ManualJacobian}, cm::Microphysics2Moment,
+    mp::CMP.Microphysics2MParams{WR, ICE}, tps,
+    ρ, T, q_tot,
+    q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim, logλ,
+    Δt, nsub = 1,
+) where {WR, ICE <: CMP.P3IceParams}
+    FT = typeof(q_tot)
+    nsub_eff = max(Int(nsub), 1)
+    h = Δt / FT(nsub_eff)
+    cp_d = TDI.TD.Parameters.cp_d(tps)
+    Lv_over_cp = TDI.TD.Parameters.LH_v0(tps) / cp_d
+    Ls_over_cp = TDI.TD.Parameters.LH_s0(tps) / cp_d
+
+    x = MicroState2MP3{FT}(q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim)
+    x₀ = x
+    Tsub = T
+    for _ in 1:nsub_eff
+        g = Instantaneous2MP3Tendency(mp, tps, ρ, Tsub, q_tot, logλ)
+        x_prev = x
+        if all(isfinite, x)
+            f, J_raw = _tendency_and_jacobian(mode.jacobian, g, x)
+            J = _apply_growth(mode.growth, J_raw)
+            z = _species_mask(mode.jacobian, mode.growth)(x)
+            d = if all(isfinite, J)
+                _rosenbrock_update(x, f, J, z, h) - x
+            else
+                _euler_update(x, f, h) - x
+            end
+            d = _apply_limiter(mode.limiter, x, d, ρ, Tsub, q_tot, Lv_over_cp, Ls_over_cp, tps)
+            x = max.(x .+ d, 0)
+        else
+            f = g(x)
+            x = _euler_update(x, f, h)
+        end
+        Δ = x - x_prev
+        T_safe = max(150, Tsub)
+        Tsub += (TDI.Lᵥ(tps, T_safe) * (Δ.q_lcl + Δ.q_rai) + TDI.Lₛ(tps, T_safe) * Δ.q_ice) / cp_d
+    end
+
+    rates = (x - x₀) / Δt
+    return NamedTuple{(
+        :dq_lcl_dt, :dn_lcl_dt, :dq_rai_dt, :dn_rai_dt,
+        :dq_ice_dt, :dn_ice_dt, :dq_rim_dt, :db_rim_dt,
+    )}(
+        Tuple(rates),
+    )
+end
+
+@inline _tendency_and_jacobian(::ManualJacobian, g::Instantaneous2MP3Tendency, x) =
+    (g(x), _jacobian_2mp3_manual(g, x))
+
+@inline _species_mask(::ManualJacobian, ::GrowthTreatment) = _full_species_mask
+
+"""
+    _jacobian_2mp3(FT; lcl_lcl, lcl_rai, ..., brim_brim)
+
+Assemble the 8×8 Jacobian of the 2M+P3 tendency over the state
+`(q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim)` from named
+species-pair entries: keyword `<receiver>_<donor>` is
+`∂(d<receiver>/dt)/∂<donor>`. The species short names are
+`lcl`/`nlcl`/`rai`/`nrai`/`ice`/`nice`/`rim`/`brim`. Entries not supplied are
+zero. Centralizes the index layout so the hand-built Jacobian is filled by
+physical coupling name rather than numeric `[i, j]` position, mirroring
+[`_jacobian_1m`](@ref).
+"""
+@inline _jacobian_2mp3(::Type{FT};
+    lcl_lcl = zero(FT), lcl_nlcl = zero(FT), lcl_rai = zero(FT), lcl_nrai = zero(FT),
+    lcl_ice = zero(FT), lcl_nice = zero(FT), lcl_rim = zero(FT), lcl_brim = zero(FT),
+    nlcl_lcl = zero(FT), nlcl_nlcl = zero(FT), nlcl_rai = zero(FT), nlcl_nrai = zero(FT),
+    nlcl_ice = zero(FT), nlcl_nice = zero(FT), nlcl_rim = zero(FT), nlcl_brim = zero(FT),
+    rai_lcl = zero(FT), rai_nlcl = zero(FT), rai_rai = zero(FT), rai_nrai = zero(FT),
+    rai_ice = zero(FT), rai_nice = zero(FT), rai_rim = zero(FT), rai_brim = zero(FT),
+    nrai_lcl = zero(FT), nrai_nlcl = zero(FT), nrai_rai = zero(FT), nrai_nrai = zero(FT),
+    nrai_ice = zero(FT), nrai_nice = zero(FT), nrai_rim = zero(FT), nrai_brim = zero(FT),
+    ice_lcl = zero(FT), ice_nlcl = zero(FT), ice_rai = zero(FT), ice_nrai = zero(FT),
+    ice_ice = zero(FT), ice_nice = zero(FT), ice_rim = zero(FT), ice_brim = zero(FT),
+    nice_lcl = zero(FT), nice_nlcl = zero(FT), nice_rai = zero(FT), nice_nrai = zero(FT),
+    nice_ice = zero(FT), nice_nice = zero(FT), nice_rim = zero(FT), nice_brim = zero(FT),
+    rim_lcl = zero(FT), rim_nlcl = zero(FT), rim_rai = zero(FT), rim_nrai = zero(FT),
+    rim_ice = zero(FT), rim_nice = zero(FT), rim_rim = zero(FT), rim_brim = zero(FT),
+    brim_lcl = zero(FT), brim_nlcl = zero(FT), brim_rai = zero(FT), brim_nrai = zero(FT),
+    brim_ice = zero(FT), brim_nice = zero(FT), brim_rim = zero(FT), brim_brim = zero(FT),
+) where {FT} = SA.SMatrix{8, 8, FT}(
+    # column-major: each column is a donor, each row a receiver d<recv>/dt
+    lcl_lcl, nlcl_lcl, rai_lcl, nrai_lcl, ice_lcl, nice_lcl, rim_lcl, brim_lcl,       # ∂/∂q_lcl
+    lcl_nlcl, nlcl_nlcl, rai_nlcl, nrai_nlcl, ice_nlcl, nice_nlcl, rim_nlcl, brim_nlcl, # ∂/∂n_lcl
+    lcl_rai, nlcl_rai, rai_rai, nrai_rai, ice_rai, nice_rai, rim_rai, brim_rai,       # ∂/∂q_rai
+    lcl_nrai, nlcl_nrai, rai_nrai, nrai_nrai, ice_nrai, nice_nrai, rim_nrai, brim_nrai, # ∂/∂n_rai
+    lcl_ice, nlcl_ice, rai_ice, nrai_ice, ice_ice, nice_ice, rim_ice, brim_ice,       # ∂/∂q_ice
+    lcl_nice, nlcl_nice, rai_nice, nrai_nice, ice_nice, nice_nice, rim_nice, brim_nice, # ∂/∂n_ice
+    lcl_rim, nlcl_rim, rai_rim, nrai_rim, ice_rim, nice_rim, rim_rim, brim_rim,       # ∂/∂q_rim
+    lcl_brim, nlcl_brim, rai_brim, nrai_brim, ice_brim, nice_brim, rim_brim, brim_brim, # ∂/∂b_rim
+)
+
+"""
+    _condevap_derivs(τ, sat_excess, Γ, cp_air, L, dqs_dT, q_cap, cap_is_ice,
+        dcp_dliq, dcp_dice)
+
+The three closed-form derivatives `(∂s_liq, ∂s_rai, ∂s_ice)` of a relaxation
+condensate tendency with respect to the liquid donor, the rain donor, and the
+ice donor, matching the active primal branch of
+[`CMNonEq.conv_q_vap_to_q_lcl`](@ref) / [`CMNonEq.conv_q_vap_to_q_icl`](@ref):
+
+```
+∂ₜq = ifelse(sat_excess < 0, -min(-sat_excess, max(0, q_cap)) / (τ·Γ),
+             sat_excess / (τ·Γ))
+```
+
+`sat_excess = q_vap − qᵥ_sat`, with `q_vap = clamp(q_tot − (q_lcl+q_rai) − q_ice)`
+so `∂q_vap/∂q = −1` on each condensate donor; `Γ = 1 + (L/cp_air)·dqs_dT` carries
+the residual condensate dependence (through `cp_air = cp_m(q_tot, q_lcl+q_rai,
+q_ice)`), giving `∂Γ/∂q = −(L·dqs_dT/cp_air²)·∂cp_air/∂q`.
+
+`q_cap` is the donor's own mass (`q_lcl` for cloud, `q_ice` for ice, selected by
+`cap_is_ice`). On the evaporation/sublimation branch the cap binds on `q_cap`
+exactly when `−sat_excess > max(0, q_cap)` (`min`/`max` resolve ties to the same
+arm as `ForwardDiff`): there `∂ₜq = −max(0, q_cap)/(τ·Γ)`, the vapor coupling
+drops, and the cap-species row gains `−1/(τ·Γ)` (the `max(0, q_cap)` self
+derivative is `1` for `q_cap ≥ 0`).
+"""
+@inline function _condevap_derivs(
+    τ, sat_excess, Γ, cp_air, L, dqs_dT, q_cap, cap_is_ice, dcp_dliq, dcp_dice,
+)
+    FT = typeof(sat_excess)
+    τΓ = τ * Γ
+    # ∂(1/(τΓ))/∂q = -(τ/(τΓ)²)·∂Γ/∂q, ∂Γ/∂q = -(L·dqs_dT/cp²)·∂cp/∂q
+    dΓ_dliq = -(L * dqs_dT / cp_air^2) * dcp_dliq
+    dΓ_dice = -(L * dqs_dT / cp_air^2) * dcp_dice
+    dinv_dliq = -dΓ_dliq * τ / τΓ^2
+    dinv_dice = -dΓ_dice * τ / τΓ^2
+    cap_binds = (sat_excess < 0) & (-sat_excess > max(zero(FT), q_cap))
+    # Vapor branch: ∂ₜq = sat_excess/(τΓ), ∂sat_excess/∂q = -1 on every donor.
+    v_liq = -1 / τΓ + sat_excess * dinv_dliq
+    v_ice = -1 / τΓ + sat_excess * dinv_dice
+    # Capped branch: ∂ₜq = -q_cap/(τΓ). Only the cap species (q_lcl for cloud,
+    # q_ice for ice) carries the -1/(τΓ) self term; q_rai is never the cap. Every
+    # donor keeps the -q_cap·∂(1/(τΓ)) Γ term.
+    cap_self = 1 / τΓ
+    c_liq = -q_cap * dinv_dliq - ifelse(cap_is_ice, zero(FT), cap_self)
+    c_rai = -q_cap * dinv_dliq
+    c_ice = -q_cap * dinv_dice - ifelse(cap_is_ice, cap_self, zero(FT))
+    ∂s_liq = ifelse(cap_binds, c_liq, v_liq)
+    ∂s_rai = ifelse(cap_binds, c_rai, v_liq)
+    ∂s_ice = ifelse(cap_binds, c_ice, v_ice)
+    return (; ∂s_liq, ∂s_rai, ∂s_ice)
+end
+
+"""
+    _jacobian_2mp3_manual(g::Instantaneous2MP3Tendency, x::MicroState2MP3)
+
+The hand-built 2M+P3 substep Jacobian for [`ManualJacobian`](@ref), evaluated at
+the same `(ρ, Tsub, q_tot, logλ, x)` as the raw tendency `f = g(x)`.
+
+The entries are tiered:
+
+  - Tier 1 (closed-form): cloud condensation/evaporation, ice
+    deposition/sublimation (with the ice-number sublimation channel and the rim
+    drain), the four number adjustments, and the F23 deposition-nucleation number
+    channel. The supersaturation block carries the autocatalytic vapor brake
+    `∂q_vap/∂q_condensate = −1` and the relaxation `−1/(τ·Γ)` couplings.
+  - Tier 2 (donor-diagonal): autoconversion, accretion, cloud/rain
+    self-collection, breakup, rain evaporation, Bigg immersion, and rain
+    freezing, linearized in their donor species through `D = rate /
+    max(floor, q_donor)` reusing the per-process rates of
+    [`_per_process_2mp3`](@ref).
+  - Tier 3 (dropped): the quadrature liquid-ice collision, ice aggregation, and
+    ice-melt couplings are kept in `f` but omitted from `J` (no `gamma_inc`
+    shape derivative is taken).
+"""
+@inline function _jacobian_2mp3_manual(
+    g::Instantaneous2MP3Tendency, x::MicroState2MP3{FT},
+) where {FT}
+    mp = g.mp
+    tps = g.tps
+    ρ = g.ρ
+    T = g.T
+    q_tot = FT(g.q_tot)
+    logλ = g.logλ
+
+    (; q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim) = x
+    o = zero(FT)
+    # ϵₘ matches the entry's `n_ice/q_ice` and number-adjustment guards
+    qmin = UT.ϵ_numerics_2M_M(FT)
+    # donor floor for the Tier-2 linearizations (the 1M donor recipe's `q_min`)
+    q_floor = FT(TDI.TD.Parameters.q_min(tps))
+    n_floor = q_floor
+
+    # per-process primal rates (Tier-2 donor coefficients reuse these)
+    pp = _per_process_2mp3(mp, tps, ρ, T, q_tot,
+        q_lcl, n_lcl, q_rai, n_rai, q_ice, n_ice, q_rim, b_rim, logλ)
+
+    # --- shared thermodynamic constants (T, ρ, q_tot frozen in the substep) ---
+    Rᵥ = TDI.Rᵥ(tps)
+    Lᵥ = TDI.Lᵥ(tps, T)
+    Lₛ = TDI.Lₛ(tps, T)
+    cp_v = TDI.TD.Parameters.cp_v(tps)
+    cp_l = TDI.TD.Parameters.cp_l(tps)
+    cp_i = TDI.TD.Parameters.cp_i(tps)
+    T_freeze = TDI.T_freeze(tps)
+    cp_air = TDI.cpₘ(tps, q_tot, q_lcl + q_rai, q_ice)
+    # ∂cp_m/∂q: q_liq = q_lcl + q_rai, q_ice = q_ice (entry convention)
+    dcp_dliq = cp_l - cp_v  # ∂cp_m/∂q_lcl = ∂cp_m/∂q_rai
+    dcp_dice = cp_i - cp_v  # ∂cp_m/∂q_ice
+    qᵥ = TDI.q_vap(q_tot, q_lcl + q_rai, q_ice)
+
+    #####
+    ##### Tier 1 — closed-form stiff couplings
+    #####
+
+    # cloud condensation / evaporation (row q_lcl), branch matched to the primal
+    τ_l = mp.warm_rain.condevap.τ_relax
+    qᵥ_sat_liq = TDI.saturation_vapor_specific_content_over_liquid(tps, T, ρ)
+    dqsl_dT = CMNonEq.dqcld_dT(qᵥ_sat_liq, Lᵥ, Rᵥ, T)
+    Γₗ = CMNonEq.gamma_helper(Lᵥ, cp_air, dqsl_dT)
+    sat_excess_l = qᵥ - qᵥ_sat_liq
+    cl = _condevap_derivs(τ_l, sat_excess_l, Γₗ, cp_air, Lᵥ, dqsl_dT, q_lcl, false, dcp_dliq, dcp_dice)
+    lcl_lcl = cl.∂s_liq
+    lcl_rai = cl.∂s_rai
+    lcl_ice = cl.∂s_ice
+
+    # ice deposition / sublimation (rows q_ice, n_ice, q_rim, b_rim)
+    τ_i = mp.warm_rain.subdep.τ_relax
+    qᵥ_sat_ice = TDI.saturation_vapor_specific_content_over_ice(tps, T, ρ)
+    dqsi_dT = CMNonEq.dqcld_dT(qᵥ_sat_ice, Lₛ, Rᵥ, T)
+    Γᵢ = CMNonEq.gamma_helper(Lₛ, cp_air, dqsi_dT)
+    sat_excess_i = qᵥ - qᵥ_sat_ice
+    ci = _condevap_derivs(τ_i, sat_excess_i, Γᵢ, cp_air, Lₛ, dqsi_dT, q_ice, true, dcp_dliq, dcp_dice)
+    # Above freezing the INP limiter zeros a positive (deposition) tendency and the
+    # entry caps it at zero, so the derivative survives only on the sublimation
+    # branch (sat_excess_i ≤ 0); the sublimation/cap branch of `ci` is unchanged.
+    dep_suppressed = (T > T_freeze) & (sat_excess_i > 0)
+    dep_active = !dep_suppressed
+    ice_lcl = ifelse(dep_active, ci.∂s_liq, o)
+    ice_rai = ifelse(dep_active, ci.∂s_rai, o)
+    ice_ice = ifelse(dep_active, ci.∂s_ice, o)
+
+    # ice number sublimation channel: ∂ₜn_ice_dep = (n_ice/q_ice)·∂ₜq_ice_dep,
+    # active only on the sublimation branch (∂ₜq_ice_dep < 0)
+    ∂ₜq_ice_dep = pp.ice_depsub.q_ice
+    n_sub_active = ∂ₜq_ice_dep < 0 && q_ice > qmin && dep_active
+    n_per_q = n_ice / max(qmin, q_ice)
+    # ∂(n/q·∂ₜq)/∂q = (n/q)·∂(∂ₜq)/∂q − (n/q²)·∂ₜq ;  ∂(n/q·∂ₜq)/∂n = (1/q)·∂ₜq
+    nice_lcl = ifelse(n_sub_active, n_per_q * ice_lcl, o)
+    nice_rai = ifelse(n_sub_active, n_per_q * ice_rai, o)
+    nice_ice = ifelse(n_sub_active, n_per_q * (ice_ice - ∂ₜq_ice_dep / max(qmin, q_ice)), o)
+    nice_nice = ifelse(n_sub_active, ∂ₜq_ice_dep / max(qmin, q_ice), o)
+
+    # rim drain on the sublimation branch (∂ₜq_rim_sub = ∂ₜq_ice_sub·F_rim,
+    # ∂ₜb_rim_sub = ∂ₜq_ice_sub·F_rim/ρ_rim) stays in `f`, but its species
+    # couplings are omitted from `J`. A frozen-F_rim entry F_rim·∂(∂ₜq_ice_sub) is
+    # nearly cancelled by the F_rim-variation term ∂ₜq_ice_sub·∂F_rim/∂q (the
+    # regularised q_rim/q_ice ratio), so the true coupling is ~1e-5·λ_dep; freezing
+    # F_rim would inject a spurious O(λ_dep) entry instead. Dropped as Tier 3.
+    rim_lcl = o
+    rim_rai = o
+    rim_ice = o
+    brim_lcl = o
+    brim_rai = o
+    brim_ice = o
+
+    # F23 deposition nucleation number channel: ∂ₜn_frz = max(0, INPC/ρ − n_ice)/τ_act
+    # (n_active = n_ice here); active arm ⇒ ∂/∂n_ice = −1/τ_act.
+    τ_act = mp.ice.inp_depletion_model.τ_act
+    f23_n = pp.f23_deposition.n_ice
+    f23_active = f23_n > 0
+    nice_nice += ifelse(f23_active, -1 / τ_act, o)
+
+    # number adjustments (cloud, rain, ice): closed-form, see
+    # `number_tendency_from_mass_limits`. Interior ⇒ 0; clamped low/high ⇒
+    # ∂/∂n = −1/τ, ∂/∂q = 1/(x_bound·τ).
+    sb = mp.warm_rain.seifert_beheng
+    (nlcl_lcl, nlcl_nlcl) =
+        _numadj_derivs(FT, q_lcl, n_lcl, sb.pdf_c.xc_min, sb.pdf_c.xc_max, sb.numadj.τ, qmin)
+    (nrai_rai, nrai_nrai) =
+        _numadj_derivs(FT, q_rai, n_rai, sb.pdf_r.xr_min, sb.pdf_r.xr_max, sb.numadj.τ, qmin)
+    (nice_ice_adj, nice_nice_adj) =
+        _numadj_derivs(FT, q_ice, n_ice, FT(1e-12), FT(1e-5), FT(100), qmin)
+    nice_ice += nice_ice_adj
+    nice_nice += nice_nice_adj
+
+    #####
+    ##### Tier 2 — donor-diagonal linearizations of the warm-rain + freezing transfers
+    #####
+    # accumulators that receive only Tier-2 contributions (Tier-1 left them zero)
+    rai_lcl = o
+    rai_rai = o
+    nrai_nlcl = o
+    # each process column = process tendency vector / max(floor, donor); mass
+    # channels routed by the mass donor, number channels by the number donor.
+    dlcl = 1 / max(q_floor, q_lcl)
+    drai = 1 / max(q_floor, q_rai)
+    dnlcl = 1 / max(n_floor, n_lcl)
+    dnrai = 1 / max(n_floor, n_rai)
+
+    # rain evaporation: q_rai, n_rai sinks (donors q_rai, n_rai)
+    rai_rai += pp.rain_evap.q_rai * drai
+    nrai_nrai += pp.rain_evap.n_rai * dnrai
+
+    # autoconversion: mass donor q_lcl, number donor n_lcl
+    lcl_lcl += pp.autoconv.q_lcl * dlcl
+    rai_lcl += pp.autoconv.q_rai * dlcl
+    nlcl_nlcl += pp.autoconv.n_lcl * dnlcl
+    nrai_nlcl += pp.autoconv.n_rai * dnlcl
+
+    # cloud self-collection: n_lcl sink, donor n_lcl
+    nlcl_nlcl += pp.cloud_selfcol.n_lcl * dnlcl
+
+    # accretion: mass donor q_lcl, number donor n_lcl
+    lcl_lcl += pp.accretion.q_lcl * dlcl
+    rai_lcl += pp.accretion.q_rai * dlcl
+    nlcl_nlcl += pp.accretion.n_lcl * dnlcl
+
+    # rain self-collection + breakup: n_rai, donor n_rai
+    nrai_nrai += pp.rain_selfcol.n_rai * dnrai
+    nrai_nrai += pp.rain_breakup.n_rai * dnrai
+
+    # Bigg immersion (cloud → ice): mass donor q_lcl, number donor n_lcl
+    lcl_lcl += pp.bigg_immersion.q_lcl * dlcl
+    ice_lcl += pp.bigg_immersion.q_ice * dlcl
+    rim_lcl += pp.bigg_immersion.q_rim * dlcl
+    brim_lcl += pp.bigg_immersion.b_rim * dlcl
+    nlcl_nlcl += pp.bigg_immersion.n_lcl * dnlcl
+    nice_nlcl = pp.bigg_immersion.n_ice * dnlcl
+
+    # rain freezing (rain → ice): mass donor q_rai, number donor n_rai
+    rai_rai += pp.rain_freezing.q_rai * drai
+    ice_rai += pp.rain_freezing.q_ice * drai
+    rim_rai += pp.rain_freezing.q_rim * drai
+    brim_rai += pp.rain_freezing.b_rim * drai
+    nrai_nrai += pp.rain_freezing.n_rai * dnrai
+    nice_nrai = pp.rain_freezing.n_ice * dnrai
+
+    # Tier 3 (liquid-ice collision, ice aggregation, ice melt): omitted from J.
+
+    return _jacobian_2mp3(FT;
+        lcl_lcl, lcl_rai, lcl_ice,
+        nlcl_lcl, nlcl_nlcl,
+        rai_lcl, rai_rai,
+        nrai_nlcl, nrai_rai, nrai_nrai,
+        ice_lcl, ice_rai, ice_ice,
+        nice_lcl, nice_nlcl, nice_rai, nice_nrai, nice_ice, nice_nice,
+        rim_lcl, rim_rai, rim_ice,
+        brim_lcl, brim_rai, brim_ice,
+    )
+end
+
+"""
+    _numadj_derivs(FT, q, n, x_min, x_max, τ, qmin)
+
+The two non-zero closed-form derivatives `(∂q, ∂n)` of
+[`CM2.number_tendency_from_mass_limits`](@ref) `∂ₜn = (n_target − n)/τ` with
+`n_target = clamp(n, q/x_max, q/x_min)`: interior (no clamp) ⇒ both zero; the
+low clamp `n_target = q/x_max` ⇒ `(1/(x_max·τ), −1/τ)`; the high clamp
+`n_target = q/x_min` ⇒ `(1/(x_min·τ), −1/τ)`; the empty arm `q < qmin`
+(`n_target = 0`) ⇒ `(0, −1/τ)`.
+"""
+@inline function _numadj_derivs(::Type{FT}, q, n, x_min, x_max, τ, qmin) where {FT}
+    empty = q < qmin
+    lo = q / x_max
+    hi = q / x_min
+    clamp_low = !empty && n < lo
+    clamp_high = !empty && n > hi
+    ∂q = ifelse(clamp_low, 1 / (x_max * τ), ifelse(clamp_high, 1 / (x_min * τ), zero(FT)))
+    ∂n = ifelse(empty || clamp_low || clamp_high, -1 / τ, zero(FT))
+    return (∂q, ∂n)
+end
+
 #####
 ##### 1M Rosenbrock-Euler substepping (`RosenbrockAverage`)
 #####

--- a/src/BulkMicrophysicsTendencies.jl
+++ b/src/BulkMicrophysicsTendencies.jl
@@ -167,6 +167,17 @@ The exact derivative of the tendency, formed with `ForwardDiff`.
 struct ExactJacobian <: Jacobian end
 
 """
+    ManualJacobian <: Jacobian
+
+A hand-built 2M+P3 substep Jacobian: the stiff condensation/deposition and
+number-adjustment couplings carried as closed-form analytic derivatives, the
+warm-rain and freezing transfers as donor-based linearizations, and the
+quadrature ice-collision couplings dropped. Avoids the `ForwardDiff` pass and
+its `gamma_inc` shape-derivative block.
+"""
+struct ManualJacobian <: Jacobian end
+
+"""
     GrowthTreatment
 
 Abstract type selecting how the positive (growth) diagonal of the Jacobian
@@ -258,6 +269,15 @@ and the end-state saturation adjustment.
 """
 rosenbrock_exact() =
     RosenbrockAverage(ExactJacobian(), ExplicitGrowthDiagonal(), EndStateSaturationAdjustment())
+
+"""
+    rosenbrock_manual()
+
+[`RosenbrockAverage`](@ref) with the hand-built 2M+P3 [`ManualJacobian`](@ref),
+implicit growth, and the end-state saturation adjustment.
+"""
+rosenbrock_manual() =
+    RosenbrockAverage(ManualJacobian(), ImplicitGrowth(), EndStateSaturationAdjustment())
 
 """
     Verbose(mode) <: TendencyMode

--- a/test/rosenbrock_framework_tests.jl
+++ b/test/rosenbrock_framework_tests.jl
@@ -9,12 +9,19 @@ import CloudMicrophysics.Parameters as CMP
 import CloudMicrophysics.BulkMicrophysicsTendencies as BMT
 import CloudMicrophysics.P3Scheme as P3
 import CloudMicrophysics.ThermodynamicsInterface as TDI
+import CloudMicrophysics.MicrophysicsNonEq as CMNonEq
+import CloudMicrophysics.Microphysics2M as CM2
+import CloudMicrophysics.HetIceNucleation as CM_HetIce
+import CloudMicrophysics.Common as CO
+import CloudMicrophysics.Utilities as UT
+import ForwardDiff as FD
 import StaticArrays: SVector
 
 # The unified `RosenbrockAverage{Jacobian, GrowthTreatment, TendencyLimiter}`
 # framework: presets (`rosenbrock_donor`, `rosenbrock_coupled`,
-# `rosenbrock_exact`), the keyword constructor, the `LinearizedAverage` ≡ donor
-# equivalence, the `Verbose` wrapper, and the 2M+P3 `ExactJacobian`-only contract.
+# `rosenbrock_exact`, `rosenbrock_manual`), the keyword constructor, the
+# `LinearizedAverage` ≡ donor equivalence, the `Verbose` wrapper, and the 2M+P3
+# `ExactJacobian`/`ManualJacobian` contract.
 
 net_vec_1m(t) = SVector(t.dq_lcl_dt, t.dq_icl_dt, t.dq_rai_dt, t.dq_sno_dt)
 
@@ -132,6 +139,7 @@ function test_framework_2m(FT)
     tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
     mp = CMP.Microphysics2MParams(FT; with_ice = true, is_limited = true)
     p3 = mp.ice.scheme
+    T_frz = TDI.T_freeze(tps)
 
     consistent_logλ(ρ, x) =
         P3.get_distribution_logλ(P3.state_from_prognostic(p3, ρ * x[5], ρ * x[6], ρ * x[7], ρ * x[8]))
@@ -151,6 +159,269 @@ function test_framework_2m(FT)
             )
             @test all(isfinite, values(t))
         end
+    end
+
+    @testset "rosenbrock_manual() on Microphysics2Moment works ($FT)" begin
+        for nsub in (1, 2, 8), Δt in (FT(60), FT(300))
+            t = BMT.bulk_microphysics_tendencies(
+                BMT.rosenbrock_manual(), BMT.Microphysics2Moment(), mp, tps,
+                ρ, T, q_tot, x..., logλ, Δt, nsub,
+            )
+            @test all(isfinite, values(t))
+        end
+    end
+
+    @testset "_jacobian_2mp3_manual Tier-1 closed-form entries match ForwardDiff ($FT)" begin
+        # Validates the closed-form Tier-1 pieces (`_condevap_derivs`, the
+        # ice-number sublimation pathway, the F23 pathway, and `_numadj_derivs`)
+        # against ForwardDiff of the primal functions they linearize, across the
+        # branches `_jacobian_2mp3_manual` selects between. Full-matrix agreement
+        # is not asserted here: Tier 2 (donor-diagonal) and Tier 3 (dropped
+        # quadrature couplings) are approximations by design. See #743 EVIDENCE.
+        rtol = FT == Float64 ? FT(1e-9) : FT(1e-2)
+        atol = FT == Float64 ? FT(1e-12) : FT(1e-6)
+        qmin = UT.ϵ_numerics_2M_M(FT)
+
+        cp_l = TDI.TD.Parameters.cp_l(tps)
+        cp_v = TDI.TD.Parameters.cp_v(tps)
+        cp_i = TDI.TD.Parameters.cp_i(tps)
+        dcp_dliq = cp_l - cp_v
+        dcp_dice = cp_i - cp_v
+        τ_l = mp.warm_rain.condevap.τ_relax
+        τ_i = mp.warm_rain.subdep.τ_relax
+
+        micro(v) = (; q_tot = v[5], q_lcl = v[1], q_icl = v[3], q_rai = v[2], q_sno = zero(v[1]))
+
+        function condevap_manual_and_fd(ρ, T, q_tot, q_lcl, q_rai, q_ice, is_ice)
+            τ = is_ice ? τ_i : τ_l
+            L = is_ice ? TDI.Lₛ(tps, T) : TDI.Lᵥ(tps, T)
+            qᵥ_sat =
+                is_ice ?
+                TDI.saturation_vapor_specific_content_over_ice(tps, T, ρ) :
+                TDI.saturation_vapor_specific_content_over_liquid(tps, T, ρ)
+            dqs_dT = CMNonEq.dqcld_dT(qᵥ_sat, L, TDI.Rᵥ(tps), T)
+            cp_air = TDI.cpₘ(tps, q_tot, q_lcl + q_rai, q_ice)
+            Γ = CMNonEq.gamma_helper(L, cp_air, dqs_dT)
+            sat_excess = TDI.q_vap(q_tot, q_lcl + q_rai, q_ice) - qᵥ_sat
+            q_limit = is_ice ? q_ice : q_lcl
+            d = BMT._condevap_derivs(τ, sat_excess, Γ, cp_air, L, dqs_dT, q_limit, is_ice, dcp_dliq, dcp_dice)
+            dep_active = !(is_ice && (T > T_frz) && (sat_excess > 0))
+            manual = dep_active ? [d.∂s_liq, d.∂s_rai, d.∂s_ice] : zeros(FT, 3)
+            h(v) =
+                if is_ice
+                    raw = CMNonEq.conv_q_vap_to_q_icl(CMP.ConstantTimescale(τ), nothing, tps, micro(v), (; ρ, T))
+                    ifelse(T > T_frz, min(raw, zero(raw)), raw)
+                else
+                    CMNonEq.conv_q_vap_to_q_lcl(CMP.CloudLiquidFormation(τ), nothing, tps, micro(v), (; ρ, T))
+                end
+            fd = FD.gradient(h, FT[q_lcl, q_rai, q_ice, zero(q_ice), q_tot])[1:3]
+            return manual, fd, dep_active
+        end
+
+        # cap_binds true/false for cloud and ice; dep_suppressed for ice.
+        condevap_states = (
+            (;
+                ρ = FT(1.0),
+                T = FT(290),
+                q_tot = FT(0.02),
+                q_lcl = FT(2e-4),
+                q_rai = FT(1e-4),
+                q_ice = FT(1e-4),
+                is_ice = false,
+            ),   # cloud, vapor branch (limit_binds=false)
+            (;
+                ρ = FT(0.9),
+                T = FT(290),
+                q_tot = FT(0.0005),
+                q_lcl = FT(2e-5),
+                q_rai = FT(2e-5),
+                q_ice = FT(1e-8),
+                is_ice = false,
+            ), # cloud, limited branch (limit_binds=true)
+            (;
+                ρ = FT(0.9),
+                T = FT(260),
+                q_tot = FT(0.008),
+                q_lcl = FT(2e-4),
+                q_rai = FT(1e-4),
+                q_ice = FT(1e-4),
+                is_ice = true,
+            ),   # ice, dep active, vapor branch
+            (;
+                ρ = FT(0.9),
+                T = FT(250),
+                q_tot = FT(0.0003),
+                q_lcl = FT(2e-5),
+                q_rai = FT(2e-5),
+                q_ice = FT(1e-8),
+                is_ice = true,
+            ),  # ice, dep active, limited branch
+            (;
+                ρ = FT(0.9),
+                T = FT(280),
+                q_tot = FT(0.02),
+                q_lcl = FT(2e-4),
+                q_rai = FT(1e-4),
+                q_ice = FT(1e-4),
+                is_ice = true,
+            ),    # ice, dep_suppressed
+        )
+        dep_active_flags = Bool[]
+        for s in condevap_states
+            manual, fd, dep_active = condevap_manual_and_fd(s.ρ, s.T, s.q_tot, s.q_lcl, s.q_rai, s.q_ice, s.is_ice)
+            push!(dep_active_flags, dep_active)
+            @test all(isapprox.(manual, fd; rtol, atol))
+        end
+        # confirm both branches of `dep_active` were exercised
+        @test any(dep_active_flags)
+        @test any(!f for f in dep_active_flags)
+
+        # ice-number sublimation pathway: n_per_q · ∂ₜq_ice_dep, active only when
+        # subsaturated (sublimating) with q_ice above the numerics floor.
+        function n_sub_manual_and_fd(ρ, T, q_tot, q_lcl, q_rai, q_ice, n_ice)
+            qᵥ_sat = TDI.saturation_vapor_specific_content_over_ice(tps, T, ρ)
+            dqs_dT = CMNonEq.dqcld_dT(qᵥ_sat, TDI.Lₛ(tps, T), TDI.Rᵥ(tps), T)
+            cp_air = TDI.cpₘ(tps, q_tot, q_lcl + q_rai, q_ice)
+            Γ = CMNonEq.gamma_helper(TDI.Lₛ(tps, T), cp_air, dqs_dT)
+            sat_excess = TDI.q_vap(q_tot, q_lcl + q_rai, q_ice) - qᵥ_sat
+            ci = BMT._condevap_derivs(
+                τ_i,
+                sat_excess,
+                Γ,
+                cp_air,
+                TDI.Lₛ(tps, T),
+                dqs_dT,
+                q_ice,
+                true,
+                dcp_dliq,
+                dcp_dice,
+            )
+            dep_active = !((T > T_frz) && (sat_excess > 0))
+            raw = CMNonEq.conv_q_vap_to_q_icl(CMP.ConstantTimescale(τ_i), nothing, tps,
+                (; q_tot, q_lcl, q_icl = q_ice, q_rai, q_sno = zero(q_ice)), (; ρ, T))
+            ∂ₜq_ice_dep = ifelse(T > T_frz, min(raw, zero(raw)), raw)
+            n_sub_active = ∂ₜq_ice_dep < 0 && q_ice > qmin && dep_active
+            n_per_q = n_ice / max(qmin, q_ice)
+            manual =
+                n_sub_active ?
+                [
+                    n_per_q * ci.∂s_liq,
+                    n_per_q * ci.∂s_rai,
+                    n_per_q * (ci.∂s_ice - ∂ₜq_ice_dep / max(qmin, q_ice)),
+                    ∂ₜq_ice_dep / max(qmin, q_ice),
+                ] :
+                zeros(FT, 4)
+            h(v) = begin
+                raw_h = CMNonEq.conv_q_vap_to_q_icl(CMP.ConstantTimescale(τ_i), nothing, tps,
+                    (; q_tot, q_lcl = v[1], q_icl = v[3], q_rai = v[2], q_sno = zero(v[1])), (; ρ, T))
+                dqdep = ifelse(T > T_frz, min(raw_h, zero(raw_h)), raw_h)
+                n_per_q_h = v[4] / max(qmin, v[3])
+                ifelse(dqdep < 0, n_per_q_h * dqdep, zero(dqdep))
+            end
+            fd = FD.gradient(h, FT[q_lcl, q_rai, q_ice, n_ice])
+            return manual, fd, n_sub_active
+        end
+        n_sub_states = (
+            (;
+                ρ = FT(0.9),
+                T = FT(250),
+                q_tot = FT(0.0005),
+                q_lcl = FT(2e-5),
+                q_rai = FT(2e-5),
+                q_ice = FT(1e-5),
+                n_ice = FT(1e-3),
+            ), # subsaturated ⇒ active
+            (;
+                ρ = FT(0.9),
+                T = FT(260),
+                q_tot = FT(0.008),
+                q_lcl = FT(2e-4),
+                q_rai = FT(1e-4),
+                q_ice = FT(1e-4),
+                n_ice = FT(1e-3),
+            ),  # supersaturated (growth) ⇒ inactive
+        )
+        # The nice_ice component subtracts two comparable-magnitude terms
+        # (∂s_ice and ∂ₜq_ice_dep / q_ice); the residual is amplified by
+        # n_ice / q_ice, loosening the achievable tolerance relative to the
+        # other Tier-1 entries.
+        atol_nsub = FT == Float64 ? FT(1e-9) : FT(1e-3)
+        for s in n_sub_states
+            manual, fd, nsa = n_sub_manual_and_fd(s.ρ, s.T, s.q_tot, s.q_lcl, s.q_rai, s.q_ice, s.n_ice)
+            @test all(isapprox.(manual, fd; rtol, atol = atol_nsub))
+        end
+        @test n_sub_manual_and_fd(n_sub_states[1]...)[3]
+        @test !n_sub_manual_and_fd(n_sub_states[2]...)[3]
+
+        # F23 deposition-nucleation number pathway.
+        ice_nucleation = mp.ice.ice_nucleation
+        τ_act = mp.ice.inp_depletion_model.τ_act
+        D_nuc = FT(10e-6)
+        m_nuc = p3.ρ_i * CO.volume_sphere_D(D_nuc)
+        function f23_manual_and_fd(ρ, T, q_tot, q_liq, q_ice, n_ice)
+            h(n) = CM_HetIce.deposition_rate(
+                ice_nucleation,
+                tps,
+                T,
+                ρ,
+                q_tot,
+                q_liq,
+                q_ice,
+                n;
+                m_nuc,
+                τ_act,
+                inpc_log_shift = zero(ρ),
+            ).∂ₜn_frz
+            fd = FD.derivative(h, n_ice)
+            f23_active = h(n_ice) > 0
+            manual = f23_active ? -1 / τ_act : zero(FT)
+            return manual, fd, f23_active
+        end
+        f23_active_state =
+            (; ρ = FT(0.9), T = FT(250), q_tot = FT(0.005), q_liq = FT(2e-4), q_ice = FT(1e-4), n_ice = FT(1e2))
+        f23_inactive_state =
+            (; ρ = FT(0.9), T = FT(290), q_tot = FT(0.02), q_liq = FT(2e-4), q_ice = FT(1e-4), n_ice = FT(2e5))
+        for s in (f23_active_state, f23_inactive_state)
+            manual, fd, _ = f23_manual_and_fd(s.ρ, s.T, s.q_tot, s.q_liq, s.q_ice, s.n_ice)
+            @test isapprox(manual, fd; rtol, atol)
+        end
+        @test f23_manual_and_fd(f23_active_state...)[3]
+        @test !f23_manual_and_fd(f23_inactive_state...)[3]
+
+        # `_numadj_derivs` against `CM2.number_tendency_from_mass_limits`, across
+        # the interior/low/high/empty regimes, for the cloud, rain, and ice bounds.
+        sb = mp.warm_rain.seifert_beheng
+        numadj_species = (
+            (sb.pdf_c.xc_min, sb.pdf_c.xc_max, sb.numadj.τ),
+            (sb.pdf_r.xr_min, sb.pdf_r.xr_max, sb.numadj.τ),
+            (FT(1e-12), FT(1e-5), FT(100)),
+        )
+        for (x_min, x_max, τ) in numadj_species
+            q = FT(2e-4)
+            n_mid = q / sqrt(x_min * x_max)
+            for (q_test, n_test) in (
+                (q, q / x_max * FT(0.5)),  # low clamp
+                (q, n_mid),                # interior
+                (q, q / x_min * FT(2)),    # high clamp
+                (qmin / 2, n_mid),         # empty
+            )
+                manual = collect(BMT._numadj_derivs(FT, q_test, n_test, x_min, x_max, τ, qmin))
+                h(v) = CM2.number_tendency_from_mass_limits((; x_min, x_max, τ), v[1], v[2])
+                fd = FD.gradient(h, FT[q_test, n_test])
+                @test all(isapprox.(manual, fd; rtol, atol))
+            end
+        end
+
+        # The full 8×8 `_jacobian_2mp3_manual(g, x)` does not match
+        # `FD.jacobian(g, x)` to the commit's stated ~3e-12: whenever ice,
+        # cloud, and rain are simultaneously present, the dropped Tier-3
+        # quadrature collision couplings and the approximate Tier-2
+        # donor-diagonal couplings dominate the disagreement (measured up to
+        # ~2e13 absolute in the base regime below). See EVIDENCE.md (#743).
+        # g = BMT.Instantaneous2MP3Tendency(mp, tps, ρ, T, q_tot, logλ)
+        # Jm = BMT._jacobian_2mp3_manual(g, BMT.MicroState2MP3{FT}(x...))
+        # Jf = FD.jacobian(g, BMT.MicroState2MP3{FT}(x...))
+        # @test isapprox(Jm, Jf; rtol, atol)
     end
 
     @testset "non-Exact RosenbrockAverage on Microphysics2Moment throws ($FT)" begin


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

Add a manually-linearized Jacobian (`ManualJacobian` + `rosenbrock_manual()`) for the two-moment + P3 microphysics Rosenbrock substep, as an alternative to the ForwardDiff `ExactJacobian` (which is ~2.7x the tendency and dominates the substep cost). Tiered after the one-moment donor Jacobians:

- Tier 1 (closed form): cloud condensation/evaporation and ice deposition/sublimation (including the ice-number sublimation pathway), the number adjustments, and the F23 nucleation number pathway -- the stiff autocatalytic supersaturation block, captured exactly (checked against ForwardDiff).
- Tier 2 (donor-diagonal): the warm-rain transfers and freezing, linearized in their donor species via `D = rate / max(q_min, q_donor)`.
- Tier 3 (dropped from the Jacobian): the quadrature ice collision / aggregation / melt couplings, kept explicit in the tendency. This avoids any `gamma_inc` shape derivative.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
