### PR TITLE
feat(Utilities): add safe_call for type-inferred conditional fallbacks

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -388,6 +388,7 @@ Lightweight numerical utility functions shared across modules.
 Utilities
 Utilities.clamp_to_nonneg
 Utilities.promote_typeof
+Utilities.safe_call
 Utilities.ϵ_numerics
 Utilities.ϵ_numerics_2M_M
 Utilities.ϵ_numerics_2M_N

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -13,6 +13,7 @@ import ForwardDiff as FD
 export clamp_to_nonneg, ϵ_numerics, ϵ_numerics_2M_M, ϵ_numerics_2M_N, ϵ_numerics_P3_B
 export promote_typeof
 export fac
+export safe_call
 
 """
     promote_typeof(args...)
@@ -26,6 +27,19 @@ caller mixes plain floats with `ForwardDiff.Dual`s (or float widths) across
 arguments — non-concrete, heap-boxed, and silent.
 """
 @inline promote_typeof(args...) = Base.promote_typeof(args...)
+
+"""
+    safe_call(f, cond; otherwise = zero)
+
+Return `f()` when `cond` is `true`, and `otherwise(FT)` when `cond` is `false`,
+where `FT` is the inferred return type of `f`. `f` is evaluated only when `cond`
+is `true`.
+"""
+@inline function safe_call(f::F, cond; otherwise = zero) where {F}
+    FT = Core.Compiler.return_type(f, Tuple{})
+    cond ? f() : otherwise(FT)
+end
+
 export unrolled_logsumexp
 export sgs_weight_function, rime_mass_fraction, rime_density
 export gamma_inc, gamma_inc_inv

--- a/test/ad_compat_tests.jl
+++ b/test/ad_compat_tests.jl
@@ -8,6 +8,7 @@ import CloudMicrophysics.P3Scheme as P3
 import CloudMicrophysics.DistributionTools as DT
 import CloudMicrophysics.Microphysics2M as CM2
 import CloudMicrophysics.ThermodynamicsInterface as TDI
+import CloudMicrophysics.Utilities as UT
 import ForwardDiff as FD
 import SpecialFunctions as SF
 
@@ -166,6 +167,39 @@ end
         @test isfinite(logλ)
         @test logλ == P3.get_distribution_logλ(st)
     end
+end
+
+@testset "safe_call typed fallback" begin
+    # the closure is not evaluated on the fallback branch
+    risky(x) = UT.safe_call(x > 0) do
+        sqrt(x)
+    end
+    @test risky(4.0) == 2.0
+    @test risky(-1.0) == 0.0
+
+    # a value-threshold fires at the degenerate point: the fallback derivative
+    # is a clean zero, not a NaN
+    g(x) = UT.safe_call(x > eps(typeof(x))) do
+        inv(x)
+    end
+    @test g(0.0) == 0.0
+    @test FD.derivative(g, 0.0) == 0.0
+    @test FD.derivative(g, 2.0) ≈ -0.25
+
+    # the fallback shares the element type the closure produces, so the result
+    # is concrete when arguments mix floats and `Dual`s
+    h(a, b) = UT.safe_call(a > 0) do
+        a / b
+    end
+    @test h(1.0, 2.0) === 0.5
+    @test @inferred(FD.derivative(x -> h(x, 2.0), -1.0)) === 0.0
+
+    # a non-default `otherwise`
+    k(x) = UT.safe_call(x > 0; otherwise = one) do
+        sqrt(x)
+    end
+    @test k(4.0) == 2.0
+    @test k(-1.0) == 1.0
 end
 
 test_ad_compatibility(Float64)


### PR DESCRIPTION
## Summary

Add `Utilities.safe_call`, a higher-order helper for conditional values whose fallback type is inferred from the computation rather than from its inputs:

```julia
safe_call(q_ice > ϵ; otherwise = zero) do
    n_ice / q_ice
end
```

It returns the `do` block when `cond` is `true` and `otherwise(FT)` when it is `false`, where `FT = Core.Compiler.return_type(f, Tuple{})`.

## Motivation

The recurring `zero(promote_typeof(args...))` idiom has a weakness that `safe_call` removes:

- `promote_typeof` types the fallback from the *inputs*, and every derivative-carrying argument must be listed by hand; omitting one returns a `Union`, which is non-concrete when using `ForwardDiff` on the GPU. `safe_call` takes the type from the function's *range*, so it cannot omit an argument.

## Notes for review

- `Core.Compiler.return_type` is internal and inference-directed: the fallback type is correct only where the computation is type-stable; this is required for the code to run on GPUs anyways. Where inference widens (Union type), this will fail.
- No call site is converted here, though I have tested it on `_regularised_ratio` in the same module. With that, it is type-stable and allocation-free through `ForwardDiff` on CUDA, for the default and overridden `otherwise`.
