### PR TITLE
GPU performance optimizations

### DIFF
--- a/src/BulkMicrophysicsTendencies.jl
+++ b/src/BulkMicrophysicsTendencies.jl
@@ -157,48 +157,53 @@ processes are pre-routed by temperature, so consumers never need `is_warm`.
     micro = (; q_tot, q_lcl, q_icl, q_rai, q_sno)
     thermo = (; ρ, T)
 
+    # Size-distribution / fall-speed quantities (λ⁻¹, n₀, v₀ for rain/snow/ice) are
+    # pow/exp-heavy and shared by several processes per species: compute once and pass
+    # to each process via its `sd` argument so they are not recomputed per process.
+    sd = CM1._size_dist_cache(mp, micro, thermo)
+
     # --- Phase change: vapor ↔ cloud condensate (bidirectional, ±) ---
     S_phase_change_vap_lcl = CMNonEq.conv_q_vap_to_q_lcl(opts.cloud_liquid_formation, mp, tps, micro, thermo)
     S_phase_change_vap_icl = CMNonEq.conv_q_vap_to_q_icl(opts.cloud_ice_formation, mp, tps, micro, thermo)
 
     # --- Autoconversion (cloud → precipitation, ≥ 0) ---
     S_acnv_lcl_rai = CM1.conv_q_lcl_to_q_rai(opts.rain_autoconversion, mp, tps, micro, thermo)
-    S_acnv_icl_sno = CM1.conv_q_icl_to_q_sno(opts.snow_autoconversion, mp, tps, micro, thermo)
+    S_acnv_icl_sno = CM1.conv_q_icl_to_q_sno(opts.snow_autoconversion, mp, tps, micro, thermo, sd)
 
     # --- Accretion (collisions between species) ---
     is_warm = T >= TDI.T_freeze(tps)
 
     # Cloud liquid + rain → rain
-    S_accr_lcl_rai = CM1.accretion(opts.cloud_liquid_rain_accretion, mp, tps, micro, thermo)
+    S_accr_lcl_rai = CM1.accretion(opts.cloud_liquid_rain_accretion, mp, tps, micro, thermo, sd)
 
     # Cloud liquid + snow: product goes to sno (cold) or rai (warm), plus thermal melt
-    (; S_accr, S_melt) = CM1.accretion(opts.cloud_liquid_snow_accretion, mp, tps, micro, thermo)
+    (; S_accr, S_melt) = CM1.accretion(opts.cloud_liquid_snow_accretion, mp, tps, micro, thermo, sd)
     S_accr_lcl_sno_cold = ifelse(is_warm, zero(FT), S_accr)    # lcl → sno (cold)
     S_accr_lcl_sno_warm = ifelse(is_warm, S_accr, zero(FT))    # lcl → rai (warm)
     S_accr_melt_lcl_sno = S_melt                                # thermal melt of sno from warm lcl (already zero when cold)
 
     # Cloud ice + rain → snow (ice-side sink)
-    S_accr_icl_rai = CM1.accretion(opts.cloud_ice_rain_accretion, mp, tps, micro, thermo)
+    S_accr_icl_rai = CM1.accretion(opts.cloud_ice_rain_accretion, mp, tps, micro, thermo, sd)
 
     # Rain frozen in cloud ice + rain collision → snow (rain sink)
-    S_accr_freeze_icl_rai = CM1.accretion_rain_sink(opts.cloud_ice_rain_accretion, mp, tps, micro, thermo)
+    S_accr_freeze_icl_rai = CM1.accretion_rain_sink(opts.cloud_ice_rain_accretion, mp, tps, micro, thermo, sd)
 
     # Cloud ice + snow → snow
-    S_accr_icl_sno = CM1.accretion(opts.cloud_ice_snow_accretion, mp, tps, micro, thermo)
+    S_accr_icl_sno = CM1.accretion(opts.cloud_ice_snow_accretion, mp, tps, micro, thermo, sd)
 
     # Rain-snow collisions: split into cold/warm arms (inactive arm = zero)
-    (; S_rai_sno, S_sno_rai, S_melt) = CM1.accretion_snow_rain(opts.rain_snow_accretion, mp, tps, micro, thermo)
+    (; S_rai_sno, S_sno_rai, S_melt) = CM1.accretion_snow_rain(opts.rain_snow_accretion, mp, tps, micro, thermo, sd)
     S_accr_rai_sno_cold = ifelse(is_warm, zero(FT), S_rai_sno) # cold arm: rai freezes → sno
     S_accr_rai_sno_warm = ifelse(is_warm, S_sno_rai, zero(FT)) # warm arm: sno melts → rai
     S_accr_melt_rai_sno = ifelse(is_warm, S_melt, zero(FT))    # thermal melt of sno from warm rai
 
     # --- Phase change: precipitation ↔ vapor ---
-    S_phase_change_vap_rai = CM1.conv_q_rai_to_q_vap(opts.rain_condensation_evaporation, mp, tps, micro, thermo)
-    S_phase_change_vap_sno = CM1.conv_q_sno_to_q_vap(opts.snow_deposition_sublimation, mp, tps, micro, thermo)
+    S_phase_change_vap_rai = CM1.conv_q_rai_to_q_vap(opts.rain_condensation_evaporation, mp, tps, micro, thermo, sd)
+    S_phase_change_vap_sno = CM1.conv_q_sno_to_q_vap(opts.snow_deposition_sublimation, mp, tps, micro, thermo, sd)
 
     # --- Melting ---
-    S_melt_icl_lcl = CM1.conv_q_icl_to_q_lcl(opts.cloud_ice_melt, mp, tps, micro, thermo)
-    S_melt_sno_rai = CM1.conv_q_sno_to_q_rai(opts.snow_melt, mp, tps, micro, thermo)
+    S_melt_icl_lcl = CM1.conv_q_icl_to_q_lcl(opts.cloud_ice_melt, mp, tps, micro, thermo, sd)
+    S_melt_sno_rai = CM1.conv_q_sno_to_q_rai(opts.snow_melt, mp, tps, micro, thermo, sd)
 
     return (;
         S_phase_change_vap_lcl, S_phase_change_vap_icl,

--- a/src/BulkMicrophysicsTendencies.jl
+++ b/src/BulkMicrophysicsTendencies.jl
@@ -160,7 +160,7 @@ processes are pre-routed by temperature, so consumers never need `is_warm`.
     # Size-distribution / fall-speed quantities (λ⁻¹, n₀, v₀ for rain/snow/ice) are
     # pow/exp-heavy and shared by several processes per species: compute once and pass
     # to each process via its `sd` argument so they are not recomputed per process.
-    sd = CM1._size_dist_cache(mp, micro, thermo)
+    sd = CM1.size_distr_parameters(mp, micro, thermo)
 
     # --- Phase change: vapor ↔ cloud condensate (bidirectional, ±) ---
     S_phase_change_vap_lcl = CMNonEq.conv_q_vap_to_q_lcl(opts.cloud_liquid_formation, mp, tps, micro, thermo)

--- a/src/CloudDiagnostics.jl
+++ b/src/CloudDiagnostics.jl
@@ -113,7 +113,9 @@ function effective_radius_2M((; pdf_c, pdf_r)::CMP.SB2006, q_lcl, q_rai, N_lcl, 
     M3_r = notvalid(Br) ? FT(0) : DT.generalized_gamma_Mⁿ(νr, μr, Br, N_rai, n_mass) / C
 
     # 2nd moment in radius = (2/3)rd moment in mass
-    n_mass = 2 // 3
+    # (use a Float, not a Rational: a rational exponent forces a runtime
+    #  Rational{Int64}/gcd construction in GPU kernels)
+    n_mass = FT(2) / 3
     M2_c = notvalid(Bc) ? FT(0) : DT.generalized_gamma_Mⁿ(νc, μc, Bc, N_lcl, n_mass) / C^(n_mass)
     M2_r = notvalid(Br) ? FT(0) : DT.generalized_gamma_Mⁿ(νr, μr, Br, N_rai, n_mass) / C^(n_mass)
 

--- a/src/Common.jl
+++ b/src/Common.jl
@@ -47,7 +47,7 @@ numerical robustness.
 @inline function G_func_liquid(
     (; K_therm, D_vapor)::CMP.AirProperties{FT},
     tps::TDI.PS,
-    T::FT,
+    T,
 ) where {FT}
     R_v = TDI.Rᵥ(tps)
     L = TDI.Lᵥ(tps, T)
@@ -86,7 +86,7 @@ numerical robustness.
 @inline function G_func_ice(
     (; K_therm, D_vapor)::CMP.AirProperties{FT},
     tps::TDI.PS,
-    T::FT,
+    T,
 ) where {FT}
     R_v = TDI.Rᵥ(tps)
     L = TDI.Lₛ(tps, T)

--- a/src/Common.jl
+++ b/src/Common.jl
@@ -355,7 +355,10 @@ end
  - `pdf(D)`: The monodisperse particle distribution function as a function of diameter, `D`, in [m/s].
 """
 @inline function Chen2022_monodisperse_pdf(a, b, c)
-    return pdf(D) = a * D^b * exp(-c * D)
+    # Fuse D^b * exp(-c*D) = exp(b*log(D) - c*D) into a single exp (D^b alone is a
+    # pow = log+exp for runtime-float b, so this drops one exp per term). Evaluated
+    # per quadrature node in the P3 velocity integrands, the hottest GPU path.
+    return pdf(D) = a * exp(muladd(b, log(D), -c * D))
 end
 
 """
@@ -480,8 +483,9 @@ See e.g., Seifert and Beheng (2006), https://doi.org/10.1007/s00703-005-0112-4, 
     (; aᵥ, bᵥ) = vent
     (; ν_air, D_vapor) = aps
     N_sc = ν_air / D_vapor           # Schmidt number
+    cbrt_N_sc = cbrt(N_sc)           # loop-invariant over D; hoist out of F_v
     N_Re(D) = D * v_term(D) / ν_air  # Reynolds number
-    F_v(D) = aᵥ + bᵥ * cbrt(N_sc) * sqrt(N_Re(D))  # Ventilation factor
+    F_v(D) = aᵥ + bᵥ * cbrt_N_sc * sqrt(N_Re(D))  # Ventilation factor
     return F_v
 end
 

--- a/src/DistributionTools.jl
+++ b/src/DistributionTools.jl
@@ -48,6 +48,16 @@ function generalized_gamma_quantile(ν, μ, B, Y)
 end
 
 """
+    generalized_gamma_quantile_unit_μ(ν, B, Y)
+
+Quantile for the `μ == 1` special case of [`generalized_gamma_quantile`](@ref).
+With `μ = 1`, `(z/B)^(1/μ)` collapses to `z/B`, avoiding a runtime `pow` of the
+form `x^1`. Used on the hot P3 `integral_bounds` path (which always passes `μ = 1`).
+"""
+@inline generalized_gamma_quantile_unit_μ(ν, B, Y) =
+    UT.gamma_inc_inv(ν + 1, Y, 1 - Y) / B
+
+"""
     generalized_gamma_cdf(ν, μ, B, x)
 
 Calculate the cumulative distribution function (CDF) for a generalized gamma distribution

--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -135,15 +135,17 @@ average particles. The value is clipped at `r0 * 1e-5` to prevent numerical issu
     # mass(size)
     (; r0, m0, me, Δm, χm, gamma_coeff) = mass
 
-    # Branchless: clamp q, ρ to non-negative and floor the n0 denominator (for snow,
-    # n0 ∝ q^ν → 0 as q → 0) so the ratio stays finite instead of 0/0. As q → 0 the
-    # base → 0, so λ_inv → 0 and is clamped to the r0*1e-5 floor below. This matches the
-    # old `if q > ϵ` guard to within that floor for all physically relevant q, with no
-    # warp divergence (cf. PR #749).
+    # Domain sanitization only (NOT a physical threshold): `clamp_to_nonneg` on q, ρ
+    # and the `max(n0, ϵ)` floor keep the ratio finite instead of 0/0 (for snow,
+    # n0 ∝ q^ν → 0 as q → 0). As q → 0 the base → 0, so λ_inv → 0 and is clamped to the
+    # r0*1e-5 floor below, keeping λ_inv (a denominator in the rate formulas) finite so
+    # the *discarded* branch of each caller's `ifelse(q > ϵ_numerics, rate, 0)` gate
+    # cannot produce Inf/NaN. The physical "tracer absent" decision lives in those
+    # caller gates, not here.
     # Note: Julia compiles x^y to exp(y * log(x)); gamma_coeff is pre-computed in the
     # ParticleMass constructor for GPU performance.
-    qp = max(q, zero(FT))
-    ρp = max(ρ, zero(FT))
+    qp = UT.clamp_to_nonneg(q)
+    ρp = UT.clamp_to_nonneg(ρ)
     denom = χm * m0 * max(n0, UT.ϵ_numerics(FT)) * gamma_coeff
     λ_inv = (ρp * qp * r0^(me + Δm) / denom)^(1 / (me + Δm + 1))
     return max(r0 * FT(1e-5), λ_inv)
@@ -361,14 +363,16 @@ end
     return max(0, q_lcl) / (τ * (Nc / 100_000_000)^α)
 end
 
-# Size-distribution / fall-speed quantities shared across the 1-moment process rates.
+# Size-distribution / fall-speed parameters shared across the 1-moment process rates.
 # `lambda_inverse` (a `pow`), snow `get_n0` (a `pow`) and `get_v0` are each reused by
 # several processes for the same hydrometeor species, so computing them once per cell
 # avoids redundant transcendentals that the compiler cannot eliminate across the
-# (inlined) per-process calls. `BulkMicrophysicsTendencies` builds this once and threads
-# it to the process functions below via their optional `sd` argument; standalone callers
-# omit it and the default rebuilds it, and the compiler then drops the fields they don't use.
-@inline function _size_dist_cache(mp, micro, thermo)
+# (inlined) per-process calls. This is the "compute once and pass" pattern:
+# `BulkMicrophysicsTendencies` builds this once per cell and threads it to the process
+# functions below via their optional `sd` argument. The `sd = size_distr_parameters(...)`
+# default is evaluated only for standalone callers that omit it, so there is no repeated
+# computation on the BMT hot path; for such callers the compiler drops the unused fields.
+@inline function size_distr_parameters(mp, micro, thermo)
     (; q_rai, q_sno, q_icl) = micro
     ρ = thermo.ρ
     return (;
@@ -414,7 +418,7 @@ Harrington et al. (1995) and Kaul et al. (2015).
 end
 
 @inline function conv_q_icl_to_q_sno(
-    opt::CMP.WithSupersaturation, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo),
+    opt::CMP.WithSupersaturation, mp, tps, micro, thermo, sd = size_distr_parameters(mp, micro, thermo),
 )
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
@@ -708,7 +712,7 @@ delegate to the corresponding low-level Marshall-Palmer kernels.
     tps,
     micro,
     thermo,
-    sd = _size_dist_cache(mp, micro, thermo),
+    sd = size_distr_parameters(mp, micro, thermo),
 )
     q_lcl = micro.q_lcl
     q_rai = micro.q_rai
@@ -733,7 +737,7 @@ end
     tps,
     micro,
     thermo,
-    sd = _size_dist_cache(mp, micro, thermo),
+    sd = size_distr_parameters(mp, micro, thermo),
 )
     q_lcl = micro.q_lcl
     q_sno = micro.q_sno
@@ -761,7 +765,7 @@ end
     tps,
     micro,
     thermo,
-    sd = _size_dist_cache(mp, micro, thermo),
+    sd = size_distr_parameters(mp, micro, thermo),
 )
     q_icl = micro.q_icl
     q_rai = micro.q_rai
@@ -786,7 +790,7 @@ end
     tps,
     micro,
     thermo,
-    sd = _size_dist_cache(mp, micro, thermo),
+    sd = size_distr_parameters(mp, micro, thermo),
 )
     q_icl = micro.q_icl
     q_sno = micro.q_sno
@@ -814,7 +818,7 @@ end
     tps,
     micro,
     thermo,
-    sd = _size_dist_cache(mp, micro, thermo),
+    sd = size_distr_parameters(mp, micro, thermo),
 )
     q_rai = micro.q_rai
     q_sno = micro.q_sno
@@ -870,7 +874,7 @@ end
     tps,
     micro,
     thermo,
-    sd = _size_dist_cache(mp, micro, thermo),
+    sd = size_distr_parameters(mp, micro, thermo),
 )
     q_icl = micro.q_icl
     q_rai = micro.q_rai
@@ -915,7 +919,7 @@ Only evaporation is considered (sub-saturated over liquid); result is clamped �
     tps,
     micro,
     thermo,
-    sd = _size_dist_cache(mp, micro, thermo),
+    sd = size_distr_parameters(mp, micro, thermo),
 )
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
@@ -977,7 +981,7 @@ Ventilation factor parameterization follows Seifert and Beheng (2006).
     tps,
     micro,
     thermo,
-    sd = _size_dist_cache(mp, micro, thermo),
+    sd = size_distr_parameters(mp, micro, thermo),
 )
     return min(0, _snow_subl_dep_rate(mp, tps, micro, thermo, sd))
 end
@@ -988,13 +992,13 @@ end
     tps,
     micro,
     thermo,
-    sd = _size_dist_cache(mp, micro, thermo),
+    sd = size_distr_parameters(mp, micro, thermo),
 )
     return _snow_subl_dep_rate(mp, tps, micro, thermo, sd)
 end
 
 """Internal helper: snow sublimation/deposition physics kernel."""
-@inline function _snow_subl_dep_rate(mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
+@inline function _snow_subl_dep_rate(mp, tps, micro, thermo, sd = size_distr_parameters(mp, micro, thermo))
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
     (; pdf, mass, vent) = mp.precip.snow
@@ -1053,7 +1057,7 @@ Returns the tendency due to cloud ice melt.
     tps,
     micro,
     thermo,
-    sd = _size_dist_cache(mp, micro, thermo),
+    sd = size_distr_parameters(mp, micro, thermo),
 )
     q_icl = micro.q_icl
     (; ρ, T) = thermo
@@ -1086,7 +1090,7 @@ Returns the tendency due to snow melt.
 """
 @inline conv_q_sno_to_q_rai(::Nothing, mp, tps, micro, thermo, sd = nothing) = zero(thermo.T)
 
-@inline function conv_q_sno_to_q_rai(::CMP.SnowMelt, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
+@inline function conv_q_sno_to_q_rai(::CMP.SnowMelt, mp, tps, micro, thermo, sd = size_distr_parameters(mp, micro, thermo))
     q_sno = micro.q_sno
     (; ρ, T) = thermo
     (; pdf, mass, vent) = mp.precip.snow

--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -655,7 +655,23 @@ end
     v0_j = get_v0(blk1mveltype_tj, ρ)
     λ_i_inv = lambda_inverse(type_i.pdf, type_i.mass, q_i, ρ)
     λ_j_inv = lambda_inverse(type_j.pdf, type_j.mass, q_j, ρ)
-    return accretion_snow_rain(type_i, type_j, blk1mveltype_ti, blk1mveltype_tj, E_ij, coeff_disp, q_i, q_j, ρ, n0_i, n0_j, v0_i, v0_j, λ_i_inv, λ_j_inv)
+    return accretion_snow_rain(
+        type_i,
+        type_j,
+        blk1mveltype_ti,
+        blk1mveltype_tj,
+        E_ij,
+        coeff_disp,
+        q_i,
+        q_j,
+        ρ,
+        n0_i,
+        n0_j,
+        v0_i,
+        v0_j,
+        λ_i_inv,
+        λ_j_inv,
+    )
 end
 
 """
@@ -685,41 +701,120 @@ delegate to the corresponding low-level Marshall-Palmer kernels.
 # here; NamedTuple-returning processes are handled in BMT by checking `nothing` directly.
 @inline accretion(::Nothing, mp, tps, micro, thermo, sd = nothing) = zero(thermo.T)
 
-@inline function accretion(opt::CMP.CloudLiquidRainAccretion, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
+@inline function accretion(
+    opt::CMP.CloudLiquidRainAccretion,
+    mp,
+    tps,
+    micro,
+    thermo,
+    sd = _size_dist_cache(mp, micro, thermo),
+)
     q_lcl = micro.q_lcl
     q_rai = micro.q_rai
     ρ = thermo.ρ
-    return accretion(mp.cloud.liquid, mp.precip.rain, mp.terminal_velocity.rain, opt.e, q_lcl, q_rai, ρ, sd.n0_rai, sd.v0_rai, sd.λ_inv_rai)
+    return accretion(
+        mp.cloud.liquid,
+        mp.precip.rain,
+        mp.terminal_velocity.rain,
+        opt.e,
+        q_lcl,
+        q_rai,
+        ρ,
+        sd.n0_rai,
+        sd.v0_rai,
+        sd.λ_inv_rai,
+    )
 end
 
-@inline function accretion(opt::CMP.CloudLiquidSnowAccretion, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
+@inline function accretion(
+    opt::CMP.CloudLiquidSnowAccretion,
+    mp,
+    tps,
+    micro,
+    thermo,
+    sd = _size_dist_cache(mp, micro, thermo),
+)
     q_lcl = micro.q_lcl
     q_sno = micro.q_sno
     ρ = thermo.ρ
     T = thermo.T
-    S = accretion(mp.cloud.liquid, mp.precip.snow, mp.terminal_velocity.snow, opt.e, q_lcl, q_sno, ρ, sd.n0_sno, sd.v0_sno, sd.λ_inv_sno)
+    S = accretion(
+        mp.cloud.liquid,
+        mp.precip.snow,
+        mp.terminal_velocity.snow,
+        opt.e,
+        q_lcl,
+        q_sno,
+        ρ,
+        sd.n0_sno,
+        sd.v0_sno,
+        sd.λ_inv_sno,
+    )
     α = warm_accretion_melt_factor(tps, T)
     return (; S_accr = S, S_melt = α * S)
 end
 
-@inline function accretion(opt::CMP.CloudIceRainAccretion, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
+@inline function accretion(
+    opt::CMP.CloudIceRainAccretion,
+    mp,
+    tps,
+    micro,
+    thermo,
+    sd = _size_dist_cache(mp, micro, thermo),
+)
     q_icl = micro.q_icl
     q_rai = micro.q_rai
     ρ = thermo.ρ
-    return accretion(mp.cloud.ice, mp.precip.rain, mp.terminal_velocity.rain, opt.e, q_icl, q_rai, ρ, sd.n0_rai, sd.v0_rai, sd.λ_inv_rai)
+    return accretion(
+        mp.cloud.ice,
+        mp.precip.rain,
+        mp.terminal_velocity.rain,
+        opt.e,
+        q_icl,
+        q_rai,
+        ρ,
+        sd.n0_rai,
+        sd.v0_rai,
+        sd.λ_inv_rai,
+    )
 end
 
-@inline function accretion(opt::CMP.CloudIceSnowAccretion, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
+@inline function accretion(
+    opt::CMP.CloudIceSnowAccretion,
+    mp,
+    tps,
+    micro,
+    thermo,
+    sd = _size_dist_cache(mp, micro, thermo),
+)
     q_icl = micro.q_icl
     q_sno = micro.q_sno
     ρ = thermo.ρ
-    return accretion(mp.cloud.ice, mp.precip.snow, mp.terminal_velocity.snow, opt.e, q_icl, q_sno, ρ, sd.n0_sno, sd.v0_sno, sd.λ_inv_sno)
+    return accretion(
+        mp.cloud.ice,
+        mp.precip.snow,
+        mp.terminal_velocity.snow,
+        opt.e,
+        q_icl,
+        q_sno,
+        ρ,
+        sd.n0_sno,
+        sd.v0_sno,
+        sd.λ_inv_sno,
+    )
 end
 
 @inline accretion_snow_rain(::Nothing, mp, tps, micro, thermo, sd = nothing) =
     (; S_rai_sno = zero(thermo.T), S_sno_rai = zero(thermo.T), S_melt = zero(thermo.T))
 
-@inline function accretion_snow_rain(opt::CMP.RainSnowAccretion, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
+@inline function accretion_snow_rain(
+    opt::CMP.RainSnowAccretion,
+    mp,
+    tps,
+    micro,
+    thermo,
+    sd = _size_dist_cache(mp, micro, thermo),
+)
     q_rai = micro.q_rai
     q_sno = micro.q_sno
     ρ = thermo.ρ
@@ -727,8 +822,40 @@ end
     vel = mp.terminal_velocity
     sno = mp.precip.snow
     rai = mp.precip.rain
-    S_rai_sno = accretion_snow_rain(sno, rai, vel.snow, vel.rain, opt.e, opt.coeff_disp, q_sno, q_rai, ρ, sd.n0_sno, sd.n0_rai, sd.v0_sno, sd.v0_rai, sd.λ_inv_sno, sd.λ_inv_rai)
-    S_sno_rai = accretion_snow_rain(rai, sno, vel.rain, vel.snow, opt.e, opt.coeff_disp, q_rai, q_sno, ρ, sd.n0_rai, sd.n0_sno, sd.v0_rai, sd.v0_sno, sd.λ_inv_rai, sd.λ_inv_sno)
+    S_rai_sno = accretion_snow_rain(
+        sno,
+        rai,
+        vel.snow,
+        vel.rain,
+        opt.e,
+        opt.coeff_disp,
+        q_sno,
+        q_rai,
+        ρ,
+        sd.n0_sno,
+        sd.n0_rai,
+        sd.v0_sno,
+        sd.v0_rai,
+        sd.λ_inv_sno,
+        sd.λ_inv_rai,
+    )
+    S_sno_rai = accretion_snow_rain(
+        rai,
+        sno,
+        vel.rain,
+        vel.snow,
+        opt.e,
+        opt.coeff_disp,
+        q_rai,
+        q_sno,
+        ρ,
+        sd.n0_rai,
+        sd.n0_sno,
+        sd.v0_rai,
+        sd.v0_sno,
+        sd.λ_inv_rai,
+        sd.λ_inv_sno,
+    )
     α = warm_accretion_melt_factor(tps, T)
     return (; S_rai_sno, S_sno_rai, S_melt = α * S_rai_sno)
 end
@@ -736,11 +863,31 @@ end
 # Rain sink arm of cloud ice + rain accretion
 @inline accretion_rain_sink(::Nothing, mp, tps, micro, thermo, sd = nothing) = zero(thermo.T)
 
-@inline function accretion_rain_sink(opt::CMP.CloudIceRainAccretion, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
+@inline function accretion_rain_sink(
+    opt::CMP.CloudIceRainAccretion,
+    mp,
+    tps,
+    micro,
+    thermo,
+    sd = _size_dist_cache(mp, micro, thermo),
+)
     q_icl = micro.q_icl
     q_rai = micro.q_rai
     ρ = thermo.ρ
-    return accretion_rain_sink(mp.precip.rain, mp.cloud.ice, mp.terminal_velocity.rain, opt.e, q_icl, q_rai, ρ, sd.n0_icl, sd.λ_inv_icl, sd.n0_rai, sd.v0_rai, sd.λ_inv_rai)
+    return accretion_rain_sink(
+        mp.precip.rain,
+        mp.cloud.ice,
+        mp.terminal_velocity.rain,
+        opt.e,
+        q_icl,
+        q_rai,
+        ρ,
+        sd.n0_icl,
+        sd.λ_inv_icl,
+        sd.n0_rai,
+        sd.v0_rai,
+        sd.λ_inv_rai,
+    )
 end
 
 """
@@ -761,7 +908,14 @@ Only evaporation is considered (sub-saturated over liquid); result is clamped �
 """
 @inline conv_q_rai_to_q_vap(::Nothing, mp, tps, micro, thermo, sd = nothing) = zero(thermo.T)
 
-@inline function conv_q_rai_to_q_vap(::CMP.RainEvaporation, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
+@inline function conv_q_rai_to_q_vap(
+    ::CMP.RainEvaporation,
+    mp,
+    tps,
+    micro,
+    thermo,
+    sd = _size_dist_cache(mp, micro, thermo),
+)
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
     (; pdf, mass, vent) = mp.precip.rain
@@ -816,11 +970,25 @@ Ventilation factor parameterization follows Seifert and Beheng (2006).
 """
 @inline conv_q_sno_to_q_vap(::Nothing, mp, tps, micro, thermo, sd = nothing) = zero(thermo.T)
 
-@inline function conv_q_sno_to_q_vap(::CMP.SublimationOnly, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
+@inline function conv_q_sno_to_q_vap(
+    ::CMP.SublimationOnly,
+    mp,
+    tps,
+    micro,
+    thermo,
+    sd = _size_dist_cache(mp, micro, thermo),
+)
     return min(0, _snow_subl_dep_rate(mp, tps, micro, thermo, sd))
 end
 
-@inline function conv_q_sno_to_q_vap(::CMP.DepositionAndSublimation, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
+@inline function conv_q_sno_to_q_vap(
+    ::CMP.DepositionAndSublimation,
+    mp,
+    tps,
+    micro,
+    thermo,
+    sd = _size_dist_cache(mp, micro, thermo),
+)
     return _snow_subl_dep_rate(mp, tps, micro, thermo, sd)
 end
 
@@ -878,7 +1046,14 @@ Returns the tendency due to cloud ice melt.
 """
 @inline conv_q_icl_to_q_lcl(::Nothing, mp, tps, micro, thermo, sd = nothing) = zero(thermo.T)
 
-@inline function conv_q_icl_to_q_lcl(::CMP.CloudIceMelt, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
+@inline function conv_q_icl_to_q_lcl(
+    ::CMP.CloudIceMelt,
+    mp,
+    tps,
+    micro,
+    thermo,
+    sd = _size_dist_cache(mp, micro, thermo),
+)
     q_icl = micro.q_icl
     (; ρ, T) = thermo
     (; pdf, mass) = mp.cloud.ice

--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -460,6 +460,13 @@ contribution of warm liquid on snow.
     return ifelse(is_cold, zero(T), cv_l / L_f * ΔT)
 end
 
+# Gating convention for the process-rate kernels below: the rate is computed
+# unconditionally and then gated with `ifelse(cond, rate, zero(FT))` instead of an
+# `if` guard, so the kernel stays branchless (no warp divergence) on the GPU. The
+# `max(x, ϵ_numerics)` clamps on denominators (e.g. `lambda_inverse`'s floor, the
+# Schmidt-number guard) keep the discarded `ifelse` branch finite — important for
+# ForwardDiff/Dual gradients and to avoid Inf/NaN handling cost.
+
 """
     accretion(cloud, precip, vel, E, q_clo, q_pre, ρ, n0, v0, λ_inv)
 
@@ -477,12 +484,6 @@ Internal low-level kernel. Prefer the option-dispatched API.
 - `q_pre`: rain or snow specific content
 - `ρ`: air density
 """
-# Gating convention for the process-rate kernels below: the rate is computed
-# unconditionally and then gated with `ifelse(cond, rate, zero(FT))` instead of an
-# `if` guard, so the kernel stays branchless (no warp divergence) on the GPU. The
-# `max(x, ϵ_numerics)` clamps on denominators (e.g. `lambda_inverse`'s floor, the
-# Schmidt-number guard) keep the discarded `ifelse` branch finite — important for
-# ForwardDiff/Dual gradients and to avoid Inf/NaN handling cost.
 @inline function accretion(
     cloud::CMP.CloudCondensateType,
     precip::CMP.PrecipitationType,

--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -1090,7 +1090,14 @@ Returns the tendency due to snow melt.
 """
 @inline conv_q_sno_to_q_rai(::Nothing, mp, tps, micro, thermo, sd = nothing) = zero(thermo.T)
 
-@inline function conv_q_sno_to_q_rai(::CMP.SnowMelt, mp, tps, micro, thermo, sd = size_distr_parameters(mp, micro, thermo))
+@inline function conv_q_sno_to_q_rai(
+    ::CMP.SnowMelt,
+    mp,
+    tps,
+    micro,
+    thermo,
+    sd = size_distr_parameters(mp, micro, thermo),
+)
     q_sno = micro.q_sno
     (; ρ, T) = thermo
     (; pdf, mass, vent) = mp.precip.snow

--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -80,8 +80,10 @@ Returns the intercept parameter of the assumed Marshall-Palmer distribution
 - `q_sno`: snow specific content (snow only)
 - `ρ`: air density (snow only)
 """
-@inline get_n0((; ν, μ)::CMP.ParticlePDFSnow{FT}, q_sno::FT, ρ::FT) where {FT} =
-    q_sno > UT.ϵ_numerics(FT) ? μ * (ρ * q_sno)^ν : zero(FT)
+@inline function get_n0((; ν, μ)::CMP.ParticlePDFSnow{FT}, q_sno::FT, ρ::FT) where {FT}
+    safe_q_sno = max(q_sno, UT.ϵ_numerics(FT))
+    return ifelse(q_sno > UT.ϵ_numerics(FT), μ * (ρ * safe_q_sno)^ν, zero(FT))
+end
 @inline get_n0((; n0)::CMP.ParticlePDFIceRain{FT}, args...) where {FT} = n0
 
 """
@@ -133,12 +135,17 @@ average particles. The value is clipped at `r0 * 1e-5` to prevent numerical issu
     # mass(size)
     (; r0, m0, me, Δm, χm, gamma_coeff) = mass
 
-    λ_inv = FT(0)
-    if q > UT.ϵ_numerics(FT) && ρ > UT.ϵ_numerics(FT)
-        # Note: Julia compiles x^y to exp(y * log(x))
-        # gamma_coeff is pre-computed in ParticleMass constructor for GPU performance
-        λ_inv = (ρ * q * r0^(me + Δm) / (χm * m0 * n0 * gamma_coeff))^(1 / (me + Δm + 1))
-    end
+    # Branchless: clamp q, ρ to non-negative and floor the n0 denominator (for snow,
+    # n0 ∝ q^ν → 0 as q → 0) so the ratio stays finite instead of 0/0. As q → 0 the
+    # base → 0, so λ_inv → 0 and is clamped to the r0*1e-5 floor below. This matches the
+    # old `if q > ϵ` guard to within that floor for all physically relevant q, with no
+    # warp divergence (cf. PR #749).
+    # Note: Julia compiles x^y to exp(y * log(x)); gamma_coeff is pre-computed in the
+    # ParticleMass constructor for GPU performance.
+    qp = max(q, zero(FT))
+    ρp = max(ρ, zero(FT))
+    denom = χm * m0 * max(n0, UT.ϵ_numerics(FT)) * gamma_coeff
+    λ_inv = (ρp * qp * r0^(me + Δm) / denom)^(1 / (me + Δm + 1))
     return max(r0 * FT(1e-5), λ_inv)
 end
 
@@ -216,22 +223,27 @@ Fall velocity of individual particles is parameterized:
     vel::Union{CMP.Blk1MVelTypeRain{FT}, CMP.Blk1MVelTypeSnow{FT}},
     ρ::FT,
     q::FT,
+    v0::FT,
+    λ_inv::FT,
 ) where {FT}
-    if q > UT.ϵ_numerics(FT)
-        # terminal_velocity(size)
-        (; χv, ve, Δv, gamma_term) = vel
-        v0 = get_v0(vel, ρ)
-        # mass(size)
-        (; r0, me, Δm, χm, gamma_coeff) = mass
-        # size distribution
-        λ_inv = lambda_inverse(pdf, mass, q, ρ)
+    (; χv, ve, Δv, gamma_term) = vel
+    (; r0, me, Δm, χm, gamma_coeff) = mass
 
-        # gamma_term = SF.gamma(me + ve + Δm + Δv + 1) (pre-computed in vel)
-        # gamma_coeff = SF.gamma(me + Δm + 1) (pre-computed in mass)
-        return χv * v0 * (λ_inv / r0)^(ve + Δv) * gamma_term / gamma_coeff
-    else
-        return FT(0)
-    end
+    # gamma_term = SF.gamma(me + ve + Δm + Δv + 1) (pre-computed in vel)
+    # gamma_coeff = SF.gamma(me + Δm + 1) (pre-computed in mass)
+    fall_w = χv * v0 * (λ_inv / r0)^(ve + Δv) * gamma_term / gamma_coeff
+    return ifelse(q > UT.ϵ_numerics(FT), fall_w, zero(FT))
+end
+
+@inline function terminal_velocity(
+    precip::Union{CMP.Rain, CMP.Snow},
+    vel::Union{CMP.Blk1MVelTypeRain{FT}, CMP.Blk1MVelTypeSnow{FT}},
+    ρ::FT,
+    q::FT,
+) where {FT}
+    v0 = get_v0(vel, ρ)
+    λ_inv = lambda_inverse(precip.pdf, precip.mass, q, ρ)
+    return terminal_velocity(precip, vel, ρ, q, v0, λ_inv)
 end
 
 @inline function terminal_velocity(
@@ -240,22 +252,19 @@ end
     ρₐ::FT,
     q::FT,
 ) where {FT}
-    fall_w = FT(0)
-    if q > UT.ϵ_numerics(FT)
-        # coefficients from Table B1 from Chen et. al. 2022
-        aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρₐ)
-        # size distribution parameter
-        λ_inv_radius::FT = lambda_inverse(pdf, mass, q, ρₐ)
-        λ_inv_diameter = 2 * λ_inv_radius
-        # eq 20 from Chen et al 2022 (loop unrolled for GPU performance)
-        fall_w =
-            CO.Chen2022_exponential_pdf(aiu[1], bi[1], ciu[1], λ_inv_diameter, 3) +
-            CO.Chen2022_exponential_pdf(aiu[2], bi[2], ciu[2], λ_inv_diameter, 3) +
-            CO.Chen2022_exponential_pdf(aiu[3], bi[3], ciu[3], λ_inv_diameter, 3)
-        # It should be ϕ^κ * fall_w, but for rain drops ϕ = 1 and κ = 0
-        fall_w = max(FT(0), fall_w)
-    end
-    return fall_w
+    # coefficients from Table B1 from Chen et. al. 2022
+    aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρₐ)
+    # size distribution parameter
+    λ_inv_radius::FT = lambda_inverse(pdf, mass, q, ρₐ)
+    λ_inv_diameter = 2 * λ_inv_radius
+    # eq 20 from Chen et al 2022 (loop unrolled for GPU performance)
+    fall_w =
+        CO.Chen2022_exponential_pdf(aiu[1], bi[1], ciu[1], λ_inv_diameter, 3) +
+        CO.Chen2022_exponential_pdf(aiu[2], bi[2], ciu[2], λ_inv_diameter, 3) +
+        CO.Chen2022_exponential_pdf(aiu[3], bi[3], ciu[3], λ_inv_diameter, 3)
+    # It should be ϕ^κ * fall_w, but for rain drops ϕ = 1 and κ = 0
+    fall_w = max(FT(0), fall_w)
+    return ifelse(q > UT.ϵ_numerics(FT), fall_w, zero(FT))
 end
 
 @inline function terminal_velocity(
@@ -264,28 +273,25 @@ end
     ρₐ::FT,
     q::FT,
 ) where {FT}
-    fall_w = FT(0)
     # We assume the B4 table coeffs for snow and B2 table coeffs for cloud ice.
     # Instead we should do partial integrals
     # from D=125um to D=625um using B2 and D=625um to inf using B4.
-    if q > UT.ϵ_numerics(FT)
-        # coefficients from Table B4 from Chen et. al. 2022
-        aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρₐ, ρᵢ)
-        # size distribution parameter
-        λ_inv_radius::FT = lambda_inverse(pdf, mass, q, ρₐ)
-        λ_inv_diameter = 2 * λ_inv_radius
+    # coefficients from Table B4 from Chen et. al. 2022
+    aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρₐ, ρᵢ)
+    # size distribution parameter
+    λ_inv_radius::FT = lambda_inverse(pdf, mass, q, ρₐ)
+    λ_inv_diameter = 2 * λ_inv_radius
 
-        # As a next step, we could keep ϕ(r) under the integrals
-        # assume oblate shape and aspect ratio
-        (; ϕ, κ) = aspr
+    # As a next step, we could keep ϕ(r) under the integrals
+    # assume oblate shape and aspect ratio
+    (; ϕ, κ) = aspr
 
-        # eq 20 from Chen 2022 (loop unrolled for GPU performance)
-        fall_w =
-            ϕ^κ * CO.Chen2022_exponential_pdf(aiu[1], bi[1], ciu[1], λ_inv_diameter, 3) +
-            ϕ^κ * CO.Chen2022_exponential_pdf(aiu[2], bi[2], ciu[2], λ_inv_diameter, 3)
-        fall_w = max(FT(0), fall_w)
-    end
-    return fall_w
+    # eq 20 from Chen 2022 (loop unrolled for GPU performance)
+    fall_w =
+        ϕ^κ * CO.Chen2022_exponential_pdf(aiu[1], bi[1], ciu[1], λ_inv_diameter, 3) +
+        ϕ^κ * CO.Chen2022_exponential_pdf(aiu[2], bi[2], ciu[2], λ_inv_diameter, 3)
+    fall_w = max(FT(0), fall_w)
+    return ifelse(q > UT.ϵ_numerics(FT), fall_w, zero(FT))
 end
 
 @inline function terminal_velocity(
@@ -295,27 +301,24 @@ end
     q::FT,
     snow_shape::AbstractSnowShape,
 ) where {FT}
-    fall_w = FT(0)
     # see comments above about B2 vs B4 coefficients
-    if q > UT.ϵ_numerics(FT)
-        # coefficients from Table B4 from Chen et. al. 2022
-        aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρₐ, ρᵢ)
-        # size distribution parameter
-        λ_inv_radius::FT = lambda_inverse(pdf, mass, q, ρₐ)
-        λ_inv_diameter = 2 * λ_inv_radius
-        # Compute the mass weighted average aspect ratio ϕ_av
-        # As a next step, we could keep ϕ(r) under the integrals
-        (ϕ₀, α, κ) = aspect_ratio_coeffs(snow_shape, mass, area, ρᵢ)
-        # Use pre-computed gamma_aspect from Snow struct
-        gamma_aspect = snow_shape isa Oblate ? gamma_aspect_oblate : gamma_aspect_prolate
-        ϕ_av = ϕ₀ * λ_inv_radius^α * gamma_aspect
-        # eq 20 from Chen 2022 (loop unrolled for GPU performance)
-        fall_w =
-            ϕ_av^κ * CO.Chen2022_exponential_pdf(aiu[1], bi[1], ciu[1], λ_inv_diameter, 3) +
-            ϕ_av^κ * CO.Chen2022_exponential_pdf(aiu[2], bi[2], ciu[2], λ_inv_diameter, 3)
-        fall_w = max(FT(0), fall_w)
-    end
-    return fall_w
+    # coefficients from Table B4 from Chen et. al. 2022
+    aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρₐ, ρᵢ)
+    # size distribution parameter
+    λ_inv_radius::FT = lambda_inverse(pdf, mass, q, ρₐ)
+    λ_inv_diameter = 2 * λ_inv_radius
+    # Compute the mass weighted average aspect ratio ϕ_av
+    # As a next step, we could keep ϕ(r) under the integrals
+    (ϕ₀, α, κ) = aspect_ratio_coeffs(snow_shape, mass, area, ρᵢ)
+    # Use pre-computed gamma_aspect from Snow struct
+    gamma_aspect = snow_shape isa Oblate ? gamma_aspect_oblate : gamma_aspect_prolate
+    ϕ_av = ϕ₀ * λ_inv_radius^α * gamma_aspect
+    # eq 20 from Chen 2022 (loop unrolled for GPU performance)
+    fall_w =
+        ϕ_av^κ * CO.Chen2022_exponential_pdf(aiu[1], bi[1], ciu[1], λ_inv_diameter, 3) +
+        ϕ_av^κ * CO.Chen2022_exponential_pdf(aiu[2], bi[2], ciu[2], λ_inv_diameter, 3)
+    fall_w = max(FT(0), fall_w)
+    return ifelse(q > UT.ϵ_numerics(FT), fall_w, zero(FT))
 end
 
 """
@@ -358,6 +361,28 @@ end
     return max(0, q_lcl) / (τ * (Nc / 100_000_000)^α)
 end
 
+# Size-distribution / fall-speed quantities shared across the 1-moment process rates.
+# `lambda_inverse` (a `pow`), snow `get_n0` (a `pow`) and `get_v0` are each reused by
+# several processes for the same hydrometeor species, so computing them once per cell
+# avoids redundant transcendentals that the compiler cannot eliminate across the
+# (inlined) per-process calls. `BulkMicrophysicsTendencies` builds this once and threads
+# it to the process functions below via their optional `sd` argument; standalone callers
+# omit it and the default rebuilds it, and the compiler then drops the fields they don't use.
+@inline function _size_dist_cache(mp, micro, thermo)
+    (; q_rai, q_sno, q_icl) = micro
+    ρ = thermo.ρ
+    return (;
+        λ_inv_rai = lambda_inverse(mp.precip.rain.pdf, mp.precip.rain.mass, q_rai, ρ),
+        n0_rai = get_n0(mp.precip.rain.pdf, q_rai, ρ),
+        v0_rai = get_v0(mp.terminal_velocity.rain, ρ),
+        λ_inv_sno = lambda_inverse(mp.precip.snow.pdf, mp.precip.snow.mass, q_sno, ρ),
+        n0_sno = get_n0(mp.precip.snow.pdf, q_sno, ρ),
+        v0_sno = get_v0(mp.terminal_velocity.snow, ρ),
+        λ_inv_icl = lambda_inverse(mp.cloud.ice.pdf, mp.cloud.ice.mass, q_icl, ρ),
+        n0_icl = get_n0(mp.cloud.ice.pdf),
+    )
+end
+
 """
     conv_q_icl_to_q_sno(::Nothing, mp, tps, micro, thermo)
     conv_q_icl_to_q_sno(opt::NoSupersaturation, mp, tps, micro, thermo)
@@ -380,37 +405,40 @@ Harrington et al. (1995) and Kaul et al. (2015).
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
 - `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline conv_q_icl_to_q_sno(::Nothing, mp, tps, micro, thermo) = zero(micro.q_icl)
+@inline conv_q_icl_to_q_sno(::Nothing, mp, tps, micro, thermo, sd = nothing) = zero(micro.q_icl)
 
-@inline function conv_q_icl_to_q_sno(opt::CMP.NoSupersaturation, mp, tps, micro, thermo)
+@inline function conv_q_icl_to_q_sno(opt::CMP.NoSupersaturation, mp, tps, micro, thermo, sd = nothing)
     (; τ, q_threshold, k) = opt.acnv1M
     q_icl = micro.q_icl
     return CO.logistic_function_integral(q_icl, q_threshold, k) / τ
 end
 
-@inline function conv_q_icl_to_q_sno(opt::CMP.WithSupersaturation, mp, tps, micro, thermo)
+@inline function conv_q_icl_to_q_sno(
+    opt::CMP.WithSupersaturation, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo),
+)
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
     r_ice_snow = opt.r_ice_snow
     (; pdf, mass) = mp.cloud.ice
     aps = mp.air_properties
     FT = eltype(ρ)
-    acnv_rate = FT(0)
+    T_freeze = TDI.T_freeze(tps)
+
     S = TDI.supersaturation_over_ice(tps, q_tot, q_lcl + q_rai, q_icl + q_sno, ρ, T)
+    G = CO.G_func_ice(aps, tps, T)
+    λ_inv = sd.λ_inv_icl
 
     # Only allow ice autoconversion below freezing with positive supersaturation
-    if (q_icl > UT.ϵ_numerics(FT) && S > FT(0) && T < TDI.T_freeze(tps))
-        (; me, Δm) = mass
-        G = CO.G_func_ice(aps, tps, T)
-        n0 = get_n0(pdf)
-        λ_inv = lambda_inverse(pdf, mass, q_icl, ρ)
+    (; me, Δm) = mass
+    n0 = sd.n0_icl
 
-        acnv_rate =
-            4 * FT(π) * S * G * n0 / ρ *
-            exp(-r_ice_snow / λ_inv) *
-            (r_ice_snow^2 / (me + Δm) + (r_ice_snow / λ_inv + 1) * λ_inv^2)
-    end
-    return acnv_rate
+    acnv_rate =
+        4 * FT(π) * S * G * n0 / ρ *
+        exp(-r_ice_snow / λ_inv) *
+        (r_ice_snow^2 / (me + Δm) + (r_ice_snow / λ_inv + 1) * λ_inv^2)
+
+    cond = q_icl > UT.ϵ_numerics(FT) && S > FT(0) && T < T_freeze
+    return ifelse(cond, acnv_rate, zero(FT))
 end
 
 """
@@ -433,7 +461,7 @@ contribution of warm liquid on snow.
 end
 
 """
-    accretion(cloud, precip, vel, E, q_clo, q_pre, ρ)
+    accretion(cloud, precip, vel, E, q_clo, q_pre, ρ, n0, v0, λ_inv)
 
 Returns the source of precipitating water (rain or snow) due to collisions
 with cloud water (liquid or ice).
@@ -449,6 +477,37 @@ Internal low-level kernel. Prefer the option-dispatched API.
 - `q_pre`: rain or snow specific content
 - `ρ`: air density
 """
+# Gating convention for the process-rate kernels below: the rate is computed
+# unconditionally and then gated with `ifelse(cond, rate, zero(FT))` instead of an
+# `if` guard, so the kernel stays branchless (no warp divergence) on the GPU. The
+# `max(x, ϵ_numerics)` clamps on denominators (e.g. `lambda_inverse`'s floor, the
+# Schmidt-number guard) keep the discarded `ifelse` branch finite — important for
+# ForwardDiff/Dual gradients and to avoid Inf/NaN handling cost.
+@inline function accretion(
+    cloud::CMP.CloudCondensateType,
+    precip::CMP.PrecipitationType,
+    vel::Union{CMP.Blk1MVelTypeRain{FT}, CMP.Blk1MVelTypeSnow{FT}},
+    E::FT,
+    q_clo::FT,
+    q_pre::FT,
+    ρ::FT,
+    n0::FT,
+    v0::FT,
+    λ_inv::FT,
+) where {FT}
+    (; r0) = precip.mass
+    (; χv, ve, Δv, gamma_accr) = vel
+    (; a0, ae, χa, Δa) = precip.area
+
+    # gamma_accr = SF.gamma(ae + ve + Δa + Δv + 1) (pre-computed in vel)
+    accr_rate =
+        q_clo * E * n0 * a0 * v0 * χa * χv * λ_inv *
+        gamma_accr / (r0 / λ_inv)^(ae + ve + Δa + Δv)
+
+    cond = q_clo > UT.ϵ_numerics(FT) && q_pre > UT.ϵ_numerics(FT)
+    return ifelse(cond, accr_rate, zero(FT))
+end
+
 @inline function accretion(
     cloud::CMP.CloudCondensateType,
     precip::CMP.PrecipitationType,
@@ -458,25 +517,10 @@ Internal low-level kernel. Prefer the option-dispatched API.
     q_pre::FT,
     ρ::FT,
 ) where {FT}
-
-    accr_rate = FT(0)
-    if (q_clo > UT.ϵ_numerics(FT) && q_pre > UT.ϵ_numerics(FT))
-
-        n0::FT = get_n0(precip.pdf, q_pre, ρ)
-        v0::FT = get_v0(vel, ρ)
-
-        (; r0) = precip.mass
-        (; χv, ve, Δv, gamma_accr) = vel
-        (; a0, ae, χa, Δa) = precip.area
-
-        λ_inv = lambda_inverse(precip.pdf, precip.mass, q_pre, ρ)
-
-        # gamma_accr = SF.gamma(ae + ve + Δa + Δv + 1) (pre-computed in vel)
-        accr_rate =
-            q_clo * E * n0 * a0 * v0 * χa * χv * λ_inv *
-            gamma_accr / (r0 / λ_inv)^(ae + ve + Δa + Δv)
-    end
-    return accr_rate
+    n0::FT = get_n0(precip.pdf, q_pre, ρ)
+    v0::FT = get_v0(vel, ρ)
+    λ_inv = lambda_inverse(precip.pdf, precip.mass, q_pre, ρ)
+    return accretion(cloud, precip, vel, E, q_clo, q_pre, ρ, n0, v0, λ_inv)
 end
 
 # accretion_rain_sink(rain, ice, vel, E, q_icl, q_rai, ρ)
@@ -491,28 +535,41 @@ end
     q_icl::FT,
     q_rai::FT,
     ρ::FT,
+    n0_ice::FT,
+    λ_ice_inv::FT,
+    n0::FT,
+    v0::FT,
+    λ_inv::FT,
 ) where {FT}
-    accr_rate = FT(0)
-    if (q_icl > UT.ϵ_numerics(FT) && q_rai > UT.ϵ_numerics(FT))
+    (; r0, m0, me, Δm, χm) = rain.mass
+    (; χv, ve, Δv, gamma_accr_rain_sink) = vel
+    (; a0, ae, χa, Δa) = rain.area
 
-        n0_ice = get_n0(ice.pdf)
-        λ_ice_inv = lambda_inverse(ice.pdf, ice.mass, q_icl, ρ)
+    # gamma_accr_rain_sink = SF.gamma(me + ae + ve + Δm + Δa + Δv + 1) (pre-computed in vel)
+    accr_rate =
+        E / ρ * n0 * n0_ice * m0 * a0 * v0 * χm * χa * χv * λ_ice_inv * λ_inv *
+        gamma_accr_rain_sink /
+        (r0 / λ_inv)^FT(me + ae + ve + Δm + Δa + Δv)
 
-        n0 = get_n0(rain.pdf, q_rai, ρ)
-        v0 = get_v0(vel, ρ)
-        (; r0, m0, me, Δm, χm) = rain.mass
-        (; χv, ve, Δv, gamma_accr_rain_sink) = vel
-        (; a0, ae, χa, Δa) = rain.area
+    cond = q_icl > UT.ϵ_numerics(FT) && q_rai > UT.ϵ_numerics(FT)
+    return ifelse(cond, accr_rate, zero(FT))
+end
 
-        λ_inv = lambda_inverse(rain.pdf, rain.mass, q_rai, ρ)
-
-        # gamma_accr_rain_sink = SF.gamma(me + ae + ve + Δm + Δa + Δv + 1) (pre-computed in vel)
-        accr_rate =
-            E / ρ * n0 * n0_ice * m0 * a0 * v0 * χm * χa * χv * λ_ice_inv * λ_inv *
-            gamma_accr_rain_sink /
-            (r0 / λ_inv)^FT(me + ae + ve + Δm + Δa + Δv)
-    end
-    return accr_rate
+@inline function accretion_rain_sink(
+    rain::CMP.Rain,
+    ice::CMP.CloudIce,
+    vel::CMP.Blk1MVelTypeRain{FT},
+    E::FT,
+    q_icl::FT,
+    q_rai::FT,
+    ρ::FT,
+) where {FT}
+    n0_ice = get_n0(ice.pdf)
+    λ_ice_inv = lambda_inverse(ice.pdf, ice.mass, q_icl, ρ)
+    n0 = get_n0(rain.pdf, q_rai, ρ)
+    v0 = get_v0(vel, ρ)
+    λ_inv = lambda_inverse(rain.pdf, rain.mass, q_rai, ρ)
+    return accretion_rain_sink(rain, ice, vel, E, q_icl, q_rai, ρ, n0_ice, λ_ice_inv, n0, v0, λ_inv)
 end
 
 """
@@ -549,39 +606,56 @@ deviations are proportional to the mean fall velocities, with coefficient
     q_i::FT,
     q_j::FT,
     ρ::FT,
+    n0_i::FT,
+    n0_j::FT,
+    v0_i::FT,
+    v0_j::FT,
+    λ_i_inv::FT,
+    λ_j_inv::FT,
 ) where {FT}
+    (; r0, m0, me, Δm, χm, gamma_coeff) = type_j.mass
+    δ = me + Δm
 
-    accr_rate = FT(0)
-    if (q_i > UT.ϵ_numerics(FT) && q_j > UT.ϵ_numerics(FT))
+    v_ti = terminal_velocity(type_i, blk1mveltype_ti, ρ, q_i, v0_i, λ_i_inv)
+    v_tj = terminal_velocity(type_j, blk1mveltype_tj, ρ, q_j, v0_j, λ_j_inv)
 
-        n0_i = get_n0(type_i.pdf, q_i, ρ)
-        n0_j = get_n0(type_j.pdf, q_j, ρ)
+    # Add simple parameterization for velocity dispersion, assuming that fall velocity 
+    # standard deviations are proportional to the mean fall velocities, with coefficient 
+    # coeff_disp
+    Δv_eff = sqrt((v_ti - v_tj)^2 + coeff_disp * (v_ti^2 + v_tj^2))
 
-        (; r0, m0, me, Δm, χm, gamma_coeff) = type_j.mass
-        δ = me + Δm
+    # We use the recurrence relation Γ(x+1) = xΓ(x) to simplify gamma terms.
+    # gamma_coeff = Γ(δ + 1) is pre-computed.
+    accr_rate =
+        FT(π) / ρ * n0_i * n0_j * m0 * χm * E_ij * Δv_eff * gamma_coeff /
+        r0^δ * (
+            2 * λ_i_inv^3 * λ_j_inv^(δ + 1) +
+            2 * (δ + 1) * λ_i_inv^2 * λ_j_inv^(δ + 2) +
+            (δ + 2) * (δ + 1) * λ_i_inv * λ_j_inv^(δ + 3)
+        )
 
-        λ_i_inv = lambda_inverse(type_i.pdf, type_i.mass, q_i, ρ)
-        λ_j_inv = lambda_inverse(type_j.pdf, type_j.mass, q_j, ρ)
+    cond = q_i > UT.ϵ_numerics(FT) && q_j > UT.ϵ_numerics(FT)
+    return ifelse(cond, accr_rate, zero(FT))
+end
 
-        v_ti = terminal_velocity(type_i, blk1mveltype_ti, ρ, q_i)
-        v_tj = terminal_velocity(type_j, blk1mveltype_tj, ρ, q_j)
-
-        # Add simple parameterization for velocity dispersion, assuming that fall velocity 
-        # standard deviations are proportional to the mean fall velocities, with coefficient 
-        # coeff_disp
-        Δv_eff = sqrt((v_ti - v_tj)^2 + coeff_disp * (v_ti^2 + v_tj^2))
-
-        # We use the recurrence relation Γ(x+1) = xΓ(x) to simplify gamma terms.
-        # gamma_coeff = Γ(δ + 1) is pre-computed.
-        accr_rate =
-            FT(π) / ρ * n0_i * n0_j * m0 * χm * E_ij * Δv_eff * gamma_coeff /
-            r0^δ * (
-                2 * λ_i_inv^3 * λ_j_inv^(δ + 1) +
-                2 * (δ + 1) * λ_i_inv^2 * λ_j_inv^(δ + 2) +
-                (δ + 2) * (δ + 1) * λ_i_inv * λ_j_inv^(δ + 3)
-            )
-    end
-    return accr_rate
+@inline function accretion_snow_rain(
+    type_i::CMP.PrecipitationType,
+    type_j::CMP.PrecipitationType,
+    blk1mveltype_ti,
+    blk1mveltype_tj,
+    E_ij::FT,
+    coeff_disp::FT,
+    q_i::FT,
+    q_j::FT,
+    ρ::FT,
+) where {FT}
+    n0_i = get_n0(type_i.pdf, q_i, ρ)
+    n0_j = get_n0(type_j.pdf, q_j, ρ)
+    v0_i = get_v0(blk1mveltype_ti, ρ)
+    v0_j = get_v0(blk1mveltype_tj, ρ)
+    λ_i_inv = lambda_inverse(type_i.pdf, type_i.mass, q_i, ρ)
+    λ_j_inv = lambda_inverse(type_j.pdf, type_j.mass, q_j, ρ)
+    return accretion_snow_rain(type_i, type_j, blk1mveltype_ti, blk1mveltype_tj, E_ij, coeff_disp, q_i, q_j, ρ, n0_i, n0_j, v0_i, v0_j, λ_i_inv, λ_j_inv)
 end
 
 """
@@ -609,43 +683,43 @@ delegate to the corresponding low-level Marshall-Palmer kernels.
 # differently on it by process. BMT calls accretion() for scalar-result processes
 # and directly destructures for NamedTuple processes. We provide the scalar zero
 # here; NamedTuple-returning processes are handled in BMT by checking `nothing` directly.
-@inline accretion(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
+@inline accretion(::Nothing, mp, tps, micro, thermo, sd = nothing) = zero(thermo.T)
 
-@inline function accretion(opt::CMP.CloudLiquidRainAccretion, mp, tps, micro, thermo)
+@inline function accretion(opt::CMP.CloudLiquidRainAccretion, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
     q_lcl = micro.q_lcl
     q_rai = micro.q_rai
     ρ = thermo.ρ
-    return accretion(mp.cloud.liquid, mp.precip.rain, mp.terminal_velocity.rain, opt.e, q_lcl, q_rai, ρ)
+    return accretion(mp.cloud.liquid, mp.precip.rain, mp.terminal_velocity.rain, opt.e, q_lcl, q_rai, ρ, sd.n0_rai, sd.v0_rai, sd.λ_inv_rai)
 end
 
-@inline function accretion(opt::CMP.CloudLiquidSnowAccretion, mp, tps, micro, thermo)
+@inline function accretion(opt::CMP.CloudLiquidSnowAccretion, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
     q_lcl = micro.q_lcl
     q_sno = micro.q_sno
     ρ = thermo.ρ
     T = thermo.T
-    S = accretion(mp.cloud.liquid, mp.precip.snow, mp.terminal_velocity.snow, opt.e, q_lcl, q_sno, ρ)
+    S = accretion(mp.cloud.liquid, mp.precip.snow, mp.terminal_velocity.snow, opt.e, q_lcl, q_sno, ρ, sd.n0_sno, sd.v0_sno, sd.λ_inv_sno)
     α = warm_accretion_melt_factor(tps, T)
     return (; S_accr = S, S_melt = α * S)
 end
 
-@inline function accretion(opt::CMP.CloudIceRainAccretion, mp, tps, micro, thermo)
+@inline function accretion(opt::CMP.CloudIceRainAccretion, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
     q_icl = micro.q_icl
     q_rai = micro.q_rai
     ρ = thermo.ρ
-    return accretion(mp.cloud.ice, mp.precip.rain, mp.terminal_velocity.rain, opt.e, q_icl, q_rai, ρ)
+    return accretion(mp.cloud.ice, mp.precip.rain, mp.terminal_velocity.rain, opt.e, q_icl, q_rai, ρ, sd.n0_rai, sd.v0_rai, sd.λ_inv_rai)
 end
 
-@inline function accretion(opt::CMP.CloudIceSnowAccretion, mp, tps, micro, thermo)
+@inline function accretion(opt::CMP.CloudIceSnowAccretion, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
     q_icl = micro.q_icl
     q_sno = micro.q_sno
     ρ = thermo.ρ
-    return accretion(mp.cloud.ice, mp.precip.snow, mp.terminal_velocity.snow, opt.e, q_icl, q_sno, ρ)
+    return accretion(mp.cloud.ice, mp.precip.snow, mp.terminal_velocity.snow, opt.e, q_icl, q_sno, ρ, sd.n0_sno, sd.v0_sno, sd.λ_inv_sno)
 end
 
-@inline accretion_snow_rain(::Nothing, mp, tps, micro, thermo) =
+@inline accretion_snow_rain(::Nothing, mp, tps, micro, thermo, sd = nothing) =
     (; S_rai_sno = zero(thermo.T), S_sno_rai = zero(thermo.T), S_melt = zero(thermo.T))
 
-@inline function accretion_snow_rain(opt::CMP.RainSnowAccretion, mp, tps, micro, thermo)
+@inline function accretion_snow_rain(opt::CMP.RainSnowAccretion, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
     q_rai = micro.q_rai
     q_sno = micro.q_sno
     ρ = thermo.ρ
@@ -653,22 +727,20 @@ end
     vel = mp.terminal_velocity
     sno = mp.precip.snow
     rai = mp.precip.rain
-    # cold arm: snow is collector, rain freezes → snow
-    S_rai_sno = accretion_snow_rain(sno, rai, vel.snow, vel.rain, opt.e, opt.coeff_disp, q_sno, q_rai, ρ)
-    # warm arm: rain is collector, snow melts → rain
-    S_sno_rai = accretion_snow_rain(rai, sno, vel.rain, vel.snow, opt.e, opt.coeff_disp, q_rai, q_sno, ρ)
+    S_rai_sno = accretion_snow_rain(sno, rai, vel.snow, vel.rain, opt.e, opt.coeff_disp, q_sno, q_rai, ρ, sd.n0_sno, sd.n0_rai, sd.v0_sno, sd.v0_rai, sd.λ_inv_sno, sd.λ_inv_rai)
+    S_sno_rai = accretion_snow_rain(rai, sno, vel.rain, vel.snow, opt.e, opt.coeff_disp, q_rai, q_sno, ρ, sd.n0_rai, sd.n0_sno, sd.v0_rai, sd.v0_sno, sd.λ_inv_rai, sd.λ_inv_sno)
     α = warm_accretion_melt_factor(tps, T)
     return (; S_rai_sno, S_sno_rai, S_melt = α * S_rai_sno)
 end
 
 # Rain sink arm of cloud ice + rain accretion
-@inline accretion_rain_sink(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
+@inline accretion_rain_sink(::Nothing, mp, tps, micro, thermo, sd = nothing) = zero(thermo.T)
 
-@inline function accretion_rain_sink(opt::CMP.CloudIceRainAccretion, mp, tps, micro, thermo)
+@inline function accretion_rain_sink(opt::CMP.CloudIceRainAccretion, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
     q_icl = micro.q_icl
     q_rai = micro.q_rai
     ρ = thermo.ρ
-    return accretion_rain_sink(mp.precip.rain, mp.cloud.ice, mp.terminal_velocity.rain, opt.e, q_icl, q_rai, ρ)
+    return accretion_rain_sink(mp.precip.rain, mp.cloud.ice, mp.terminal_velocity.rain, opt.e, q_icl, q_rai, ρ, sd.n0_icl, sd.λ_inv_icl, sd.n0_rai, sd.v0_rai, sd.λ_inv_rai)
 end
 
 """
@@ -687,45 +759,44 @@ Only evaporation is considered (sub-saturated over liquid); result is clamped �
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
 - `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline conv_q_rai_to_q_vap(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
+@inline conv_q_rai_to_q_vap(::Nothing, mp, tps, micro, thermo, sd = nothing) = zero(thermo.T)
 
-@inline function conv_q_rai_to_q_vap(::CMP.RainEvaporation, mp, tps, micro, thermo)
+@inline function conv_q_rai_to_q_vap(::CMP.RainEvaporation, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
     (; pdf, mass, vent) = mp.precip.rain
     vel = mp.terminal_velocity.rain
     aps = mp.air_properties
     FT = eltype(ρ)
-    evap_rate = FT(0)
 
-    if q_rai > UT.ϵ_numerics(FT)
-        S = TDI.supersaturation_over_liquid(tps, q_tot, q_lcl + q_rai, q_icl + q_sno, ρ, T)
+    S = TDI.supersaturation_over_liquid(tps, q_tot, q_lcl + q_rai, q_icl + q_sno, ρ, T)
 
-        if S < FT(0)
-            (; ν_air, D_vapor) = aps
-            G = CO.G_func_liquid(aps, tps, T)
-            n0 = get_n0(pdf, q_rai, ρ)
-            v0 = get_v0(vel, ρ)
-            (; χv, ve, Δv, gamma_vent) = vel
-            (; r0) = mass
-            a_vent = vent.a
-            b_vent = vent.b
+    (; ν_air, D_vapor) = aps
+    G = CO.G_func_liquid(aps, tps, T)
 
-            λ_inv = lambda_inverse(pdf, mass, q_rai, ρ)
-            Sc = ν_air / max(D_vapor, UT.ϵ_numerics(FT))
+    n0 = sd.n0_rai
+    v0 = sd.v0_rai
+    λ_inv = sd.λ_inv_rai
 
-            evap_rate =
-                4 * FT(π) * n0 / ρ * S * G * λ_inv^2 *
-                (
-                    a_vent +
-                    b_vent * cbrt(Sc) /
-                    (r0 / λ_inv)^((ve + Δv) / 2) *
-                    sqrt(2 * v0 * χv / ν_air * λ_inv) *
-                    gamma_vent
-                )
-        end
-    end
-    return min(0, evap_rate)
+    (; χv, ve, Δv, gamma_vent) = vel
+    (; r0) = mass
+    a_vent = vent.a
+    b_vent = vent.b
+
+    Sc = ν_air / max(D_vapor, UT.ϵ_numerics(FT))
+
+    evap_rate =
+        4 * FT(π) * n0 / ρ * S * G * λ_inv^2 *
+        (
+            a_vent +
+            b_vent * cbrt(Sc) /
+            (r0 / λ_inv)^((ve + Δv) / 2) *
+            sqrt(2 * v0 * χv / ν_air * λ_inv) *
+            gamma_vent
+        )
+
+    cond = q_rai > UT.ϵ_numerics(FT) && S < FT(0)
+    return min(zero(FT), ifelse(cond, evap_rate, zero(FT)))
 end
 
 """
@@ -743,51 +814,52 @@ Ventilation factor parameterization follows Seifert and Beheng (2006).
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
 - `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline conv_q_sno_to_q_vap(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
+@inline conv_q_sno_to_q_vap(::Nothing, mp, tps, micro, thermo, sd = nothing) = zero(thermo.T)
 
-@inline function conv_q_sno_to_q_vap(::CMP.SublimationOnly, mp, tps, micro, thermo)
-    return min(0, _snow_subl_dep_rate(mp, tps, micro, thermo))
+@inline function conv_q_sno_to_q_vap(::CMP.SublimationOnly, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
+    return min(0, _snow_subl_dep_rate(mp, tps, micro, thermo, sd))
 end
 
-@inline function conv_q_sno_to_q_vap(::CMP.DepositionAndSublimation, mp, tps, micro, thermo)
-    return _snow_subl_dep_rate(mp, tps, micro, thermo)
+@inline function conv_q_sno_to_q_vap(::CMP.DepositionAndSublimation, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
+    return _snow_subl_dep_rate(mp, tps, micro, thermo, sd)
 end
 
 """Internal helper: snow sublimation/deposition physics kernel."""
-@inline function _snow_subl_dep_rate(mp, tps, micro, thermo)
+@inline function _snow_subl_dep_rate(mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
     (; pdf, mass, vent) = mp.precip.snow
     vel = mp.terminal_velocity.snow
     aps = mp.air_properties
     FT = eltype(ρ)
-    subl_rate = FT(0)
 
-    if q_sno > UT.ϵ_numerics(FT)
-        (; ν_air, D_vapor) = aps
-        S = TDI.supersaturation_over_ice(tps, q_tot, q_lcl + q_rai, q_icl + q_sno, ρ, T)
-        G = CO.G_func_ice(aps, tps, T)
-        n0 = get_n0(pdf, q_sno, ρ)
-        v0 = get_v0(vel, ρ)
-        (; r0) = mass
-        (; χv, ve, Δv, gamma_vent) = vel
-        a_vent = vent.a
-        b_vent = vent.b
+    (; ν_air, D_vapor) = aps
+    S = TDI.supersaturation_over_ice(tps, q_tot, q_lcl + q_rai, q_icl + q_sno, ρ, T)
+    G = CO.G_func_ice(aps, tps, T)
 
-        λ_inv = lambda_inverse(pdf, mass, q_sno, ρ)
-        Sc = ν_air / max(D_vapor, UT.ϵ_numerics(FT))
+    n0 = sd.n0_sno
+    v0 = sd.v0_sno
+    λ_inv = sd.λ_inv_sno
 
-        subl_rate =
-            4 * FT(π) * n0 / ρ * S * G * λ_inv^2 *
-            (
-                a_vent +
-                b_vent * cbrt(Sc) /
-                (r0 / λ_inv)^((ve + Δv) / 2) *
-                sqrt(2 * v0 * χv / ν_air * λ_inv) *
-                gamma_vent
-            )
-    end
-    return subl_rate
+    (; r0) = mass
+    (; χv, ve, Δv, gamma_vent) = vel
+    a_vent = vent.a
+    b_vent = vent.b
+
+    Sc = ν_air / max(D_vapor, UT.ϵ_numerics(FT))
+
+    subl_rate =
+        4 * FT(π) * n0 / ρ * S * G * λ_inv^2 *
+        (
+            a_vent +
+            b_vent * cbrt(Sc) /
+            (r0 / λ_inv)^((ve + Δv) / 2) *
+            sqrt(2 * v0 * χv / ν_air * λ_inv) *
+            gamma_vent
+        )
+
+    cond = q_sno > UT.ϵ_numerics(FT)
+    return ifelse(cond, subl_rate, zero(FT))
 end
 
 
@@ -804,24 +876,23 @@ Returns the tendency due to cloud ice melt.
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
 - `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline conv_q_icl_to_q_lcl(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
+@inline conv_q_icl_to_q_lcl(::Nothing, mp, tps, micro, thermo, sd = nothing) = zero(thermo.T)
 
-@inline function conv_q_icl_to_q_lcl(::CMP.CloudIceMelt, mp, tps, micro, thermo)
+@inline function conv_q_icl_to_q_lcl(::CMP.CloudIceMelt, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
     q_icl = micro.q_icl
     (; ρ, T) = thermo
     (; pdf, mass) = mp.cloud.ice
     (; K_therm) = mp.air_properties
     FT = eltype(ρ)
-    cloud_ice_melt_rate = FT(0)
     T_freeze = TDI.T_freeze(tps)
 
-    if (q_icl > UT.ϵ_numerics(FT) && T > T_freeze)
-        L = TDI.Lf(tps, T)
-        (; n0) = pdf
-        λ_inv = lambda_inverse(pdf, mass, q_icl, ρ)
-        cloud_ice_melt_rate = 4 * FT(π) * n0 / ρ * K_therm / L * (T - T_freeze) * λ_inv^2
-    end
-    return cloud_ice_melt_rate
+    L = TDI.Lf(tps, T)
+    (; n0) = pdf
+    λ_inv = sd.λ_inv_icl
+    cloud_ice_melt_rate = 4 * FT(π) * n0 / ρ * K_therm / L * (T - T_freeze) * λ_inv^2
+
+    cond = q_icl > UT.ϵ_numerics(FT) && T > T_freeze
+    return ifelse(cond, cloud_ice_melt_rate, zero(FT))
 end
 
 """
@@ -837,47 +908,46 @@ Returns the tendency due to snow melt.
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
 - `thermo`: thermodynamic state `(; ρ, T)`
 """
-@inline conv_q_sno_to_q_rai(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
+@inline conv_q_sno_to_q_rai(::Nothing, mp, tps, micro, thermo, sd = nothing) = zero(thermo.T)
 
-@inline function conv_q_sno_to_q_rai(::CMP.SnowMelt, mp, tps, micro, thermo)
+@inline function conv_q_sno_to_q_rai(::CMP.SnowMelt, mp, tps, micro, thermo, sd = _size_dist_cache(mp, micro, thermo))
     q_sno = micro.q_sno
     (; ρ, T) = thermo
     (; pdf, mass, vent) = mp.precip.snow
     vel = mp.terminal_velocity.snow
     aps = mp.air_properties
     FT = eltype(ρ)
-    snow_melt_rate = FT(0)
     T_freeze = TDI.T_freeze(tps)
 
-    if (q_sno > UT.ϵ_numerics(FT) && T > T_freeze)
-        (; ν_air, D_vapor, K_therm) = aps
+    (; ν_air, D_vapor, K_therm) = aps
 
-        L = TDI.Lf(tps, T)
+    L = TDI.Lf(tps, T)
 
-        n0 = get_n0(pdf, q_sno, ρ)
-        v0 = get_v0(vel, ρ)
-        (; r0) = mass
-        (; χv, ve, Δv, gamma_vent) = vel
+    n0 = sd.n0_sno
+    v0 = sd.v0_sno
+    λ_inv = sd.λ_inv_sno
 
-        a_vent = vent.a
-        b_vent = vent.b
+    (; r0) = mass
+    (; χv, ve, Δv, gamma_vent) = vel
 
-        λ_inv = lambda_inverse(pdf, mass, q_sno, ρ)
+    a_vent = vent.a
+    b_vent = vent.b
 
-        # Schmidt number (guard against division by near-zero D_vapor)
-        Sc = ν_air / max(D_vapor, UT.ϵ_numerics(FT))
+    # Schmidt number (guard against division by near-zero D_vapor)
+    Sc = ν_air / max(D_vapor, UT.ϵ_numerics(FT))
 
-        snow_melt_rate =
-            4 * FT(π) * n0 / ρ * K_therm / L * (T - T_freeze) * λ_inv^2 *
-            (
-                a_vent +
-                b_vent * cbrt(Sc) /
-                (r0 / λ_inv)^((ve + Δv) / 2) *
-                sqrt(2 * v0 * χv / ν_air * λ_inv) *
-                gamma_vent
-            )
-    end
-    return snow_melt_rate
+    snow_melt_rate =
+        4 * FT(π) * n0 / ρ * K_therm / L * (T - T_freeze) * λ_inv^2 *
+        (
+            a_vent +
+            b_vent * cbrt(Sc) /
+            (r0 / λ_inv)^((ve + Δv) / 2) *
+            sqrt(2 * v0 * χv / ν_air * λ_inv) *
+            gamma_vent
+        )
+
+    cond = q_sno > UT.ϵ_numerics(FT) && T > T_freeze
+    return ifelse(cond, snow_melt_rate, zero(FT))
 end
 
 end #module Microphysics1M.jl

--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -579,7 +579,7 @@ Returns the accretion rate when rain and snow collide.
 Collisions result in snow for T < T_freeze and rain for T > T_freeze.
 
 Uses geometric collision kernel assumption: a(r_i, r_j) = π(r_i + r_j)², with
-a velocity dispersion correction that assumes that fall velocity standard 
+a velocity dispersion correction that assumes that fall velocity standard
 deviations are proportional to the mean fall velocities, with coefficient
 `ce.coeff_disp`.
 
@@ -590,7 +590,7 @@ deviations are proportional to the mean fall velocities, with coefficient
 
 # Arguments
 - `type_i`: snow (T < T_freeze) or rain (T > T_freeze)
-- `type_j`: rain (T < T_freeze) or snow (T > T_freeze)  
+- `type_j`: rain (T < T_freeze) or snow (T > T_freeze)
 - `blk1mveltype_ti`, `blk1mveltype_tj`: 1M terminal velocity parameters
 - `ce`: collision efficiency parameters (contains `e_rai_sno`, `coeff_disp`)
 - `q_i`, `q_j`: specific contents of snow or rain [kg/kg]
@@ -619,8 +619,8 @@ deviations are proportional to the mean fall velocities, with coefficient
     v_ti = terminal_velocity(type_i, blk1mveltype_ti, ρ, q_i, v0_i, λ_i_inv)
     v_tj = terminal_velocity(type_j, blk1mveltype_tj, ρ, q_j, v0_j, λ_j_inv)
 
-    # Add simple parameterization for velocity dispersion, assuming that fall velocity 
-    # standard deviations are proportional to the mean fall velocities, with coefficient 
+    # Add simple parameterization for velocity dispersion, assuming that fall velocity
+    # standard deviations are proportional to the mean fall velocities, with coefficient
     # coeff_disp
     Δv_eff = sqrt((v_ti - v_tj)^2 + coeff_disp * (v_ti^2 + v_tj^2))
 

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -783,7 +783,7 @@ function rain_evaporation(
     S = TDI.supersaturation_over_liquid(tps, q_tot, q_lcl + q_rai, q_icl + q_sno, ρ, T)
 
     (; ν_air, D_vapor) = aps
-    (; av, bv, α, β, ρ0) = evap
+    (; α, β, ρ0) = evap
     ρw = pdf_r.ρw
     x_star = pdf_r.xr_min
     G = CO.G_func_liquid(aps, tps, T)
@@ -796,7 +796,7 @@ function rain_evaporation(
 
     t_star = cbrt(FT(6) * x_star / xr_mean)
     a_vent_0 = evap.a_vent_0_coeff * Γ_incl(FT(-1), t_star)
-    b_vent_0 = evap.b_vent_0_coeff * Γ_incl(evap.β_va, t_star)
+    b_vent_0 = evap.b_vent_0_coeff * Γ_incl(evap.β_vent_0, t_star)
 
     a_vent_1 = evap.a_vent_1
     b_vent_1 = evap.b_vent_1

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -77,6 +77,10 @@ function pdf_rain_parameters(pdf_r::CMP.RainParticlePDF_SB2006_notlimited, qᵣ,
     N₀r = λr * safe_Nᵣ
 
     Dr_mean = 1 / λr  # The inverse of λr is the mean diameter of the raindrops (units: `m`)
+    # The predicate is evaluated once into `cond`; the three `ifelse`es are predicated
+    # selects reusing it, not three re-evaluations. This replaces an early-return branch,
+    # so all warp lanes stay on one instruction stream (no GPU warp divergence) — the
+    # three extra selects are far cheaper than a data-dependent branch (cf. PR #749).
     cond = Nᵣ < UT.ϵ_numerics_2M_N(FT) || qᵣ < UT.ϵ_numerics_2M_M(FT)
     return (;
         N₀r = ifelse(cond, zero(Nᵣ), N₀r),

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -591,6 +591,9 @@ function rain_breakup(
     Dr = cbrt(xr_mean * 6 / (π * ρw))  # mean volume raindrop diameter
     ΔD = Dr - Deq
 
+    # Dr < Dr_th:  below the threshold diameter, breakup is neglected
+    # Dr ≤ Deq:    below the equilibrium diameter, breakup is a linear function
+    # Dr > Deq:    above the equilibrium diameter, breakup is an exponential function
     Φ_br = ifelse(Dr < Dr_th, FT(-1), ifelse(Dr ≤ Deq, kbr * ΔD, exp(κbr * ΔD) - 1))
     dN_rai_dt_br = -(Φ_br + 1) * dN_rai_dt_sc  # Eq. (13) from SB2006
 
@@ -707,6 +710,7 @@ function rain_terminal_velocity(
     safe_N_rai = max(N_rai, UT.ϵ_numerics_2M_N(FT))
     (; Dr_mean) = pdf_rain_parameters(pdf_r, safe_q_rai, ρ, safe_N_rai)
 
+    # It should be (ϕ^κ * vt0, ϕ^κ * vt3), but for rain drops ϕ = 1 and κ = 0
     vt0 = sum(CO.Chen2022_exponential_pdf.(aiu, bi, ciu, Dr_mean, 0))
     vt3 = sum(CO.Chen2022_exponential_pdf.(aiu, bi, ciu, Dr_mean, 3))
 

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -67,33 +67,43 @@ Return the parameters of the rain drop diameter distribution
 """
 function pdf_rain_parameters(pdf_r::CMP.RainParticlePDF_SB2006_notlimited, qᵣ, ρₐ, Nᵣ)
     FT = UT.promote_typeof(qᵣ, ρₐ, Nᵣ)
-    (Nᵣ < UT.ϵ_numerics_2M_N(FT) || qᵣ < UT.ϵ_numerics_2M_M(FT)) &&
-        return (; N₀r = zero(FT), Dr_mean = zero(FT), xr_mean = zero(FT))
     (; ρw) = pdf_r
-    Lᵣ = ρₐ * qᵣ
+    safe_qᵣ = max(qᵣ, UT.ϵ_numerics_2M_M(FT))
+    safe_Nᵣ = max(Nᵣ, UT.ϵ_numerics_2M_N(FT))
+    Lᵣ = ρₐ * safe_qᵣ
 
-    xr_mean = Lᵣ / Nᵣ
+    xr_mean = Lᵣ / safe_Nᵣ
     λr = cbrt(π * ρw / xr_mean)
-    N₀r = λr * Nᵣ
+    N₀r = λr * safe_Nᵣ
 
     Dr_mean = 1 / λr  # The inverse of λr is the mean diameter of the raindrops (units: `m`)
-    return (; N₀r, Dr_mean, xr_mean)
+    cond = Nᵣ < UT.ϵ_numerics_2M_N(FT) || qᵣ < UT.ϵ_numerics_2M_M(FT)
+    return (;
+        N₀r = ifelse(cond, zero(Nᵣ), N₀r),
+        Dr_mean = ifelse(cond, zero(qᵣ), Dr_mean),
+        xr_mean = ifelse(cond, zero(qᵣ), xr_mean),
+    )
 end
 function pdf_rain_parameters(pdf_r::CMP.RainParticlePDF_SB2006_limited, qᵣ, ρₐ, Nᵣ)
     FT = UT.promote_typeof(qᵣ, ρₐ, Nᵣ)
-    (Nᵣ < UT.ϵ_numerics_2M_N(FT) && qᵣ < UT.ϵ_numerics_2M_M(FT)) &&
-        return (; N₀r = zero(FT), Dr_mean = zero(FT), xr_mean = zero(FT))
     (; xr_min, xr_max, N0_min, N0_max, λ_min, λ_max, ρw) = pdf_r
-    Lᵣ = ρₐ * max(0, qᵣ)
+    safe_qᵣ = max(qᵣ, UT.ϵ_numerics_2M_M(FT))
+    safe_Nᵣ = max(Nᵣ, UT.ϵ_numerics_2M_N(FT))
+    Lᵣ = ρₐ * safe_qᵣ
 
     # Sequence of limiting steps in Seifert and Beheng 2006:
-    x̃r = clamp(Lᵣ / Nᵣ, xr_min, xr_max)  # Eq. (94)
-    N₀r = clamp(Nᵣ * cbrt(π * ρw / x̃r), N0_min, N0_max)  # Eq. (95)
+    x̃r = clamp(Lᵣ / safe_Nᵣ, xr_min, xr_max)  # Eq. (94)
+    N₀r = clamp(safe_Nᵣ * cbrt(π * ρw / x̃r), N0_min, N0_max)  # Eq. (95)
     λr = clamp(sqrt(sqrt(π * ρw * N₀r / Lᵣ)), λ_min, λ_max)  # Eq. (96)
     xr_mean = clamp(Lᵣ * λr / N₀r, xr_min, xr_max)  # Eq. (97)
 
     Dr_mean = 1 / λr  # The inverse of λr is the mean diameter of the raindrops (units: `m`)
-    return (; N₀r, Dr_mean, xr_mean)
+    cond = Nᵣ < UT.ϵ_numerics_2M_N(FT) && qᵣ < UT.ϵ_numerics_2M_M(FT)
+    return (;
+        N₀r = ifelse(cond, zero(Nᵣ), N₀r),
+        Dr_mean = ifelse(cond, zero(qᵣ), Dr_mean),
+        xr_mean = ifelse(cond, zero(qᵣ), xr_mean),
+    )
 end
 
 """
@@ -162,18 +172,19 @@ That is,
 """
 function log_pdf_cloud_parameters_mass(pdf_c, q, ρₐ, N)
     FT = UT.promote_typeof(q, ρₐ, N)
-    L = ρₐ * q
-    # If L or N are (essentially) zero, return `A=0` (no number per mass), `B=∞` (zero mass "length" scale)
-    (N < UT.ϵ_numerics_2M_N(FT) || L < UT.ϵ_numerics_2M_M(FT)) &&
-        return (log(zero(FT)), log(1 / zero(FT)))
+    safe_q = max(q, UT.ϵ_numerics_2M_M(FT))
+    safe_N = max(N, UT.ϵ_numerics_2M_N(FT))
+    L = ρₐ * safe_q
     (; νc, μc, loggamma_z1, loggamma_z2) = pdf_c
-    logx̄ = log(L / N)
+    logx̄ = log(L / safe_N)
     z1 = (νc + 1) / μc
     # loggamma_z1 = SF.loggamma(z1) (pre-computed in pdf_c)
     # loggamma_z2 = SF.loggamma(z2) (pre-computed in pdf_c)
     logB = -μc * (logx̄ + loggamma_z1 - loggamma_z2)
-    logA = log(μc) + log(N) + z1 * logB - loggamma_z1
-    return (logA, logB)
+    logA = log(μc) + log(safe_N) + z1 * logB - loggamma_z1
+    
+    cond = N < UT.ϵ_numerics_2M_N(FT) || q < UT.ϵ_numerics_2M_M(FT)
+    return (ifelse(cond, oftype(logA, -Inf), logA), ifelse(cond, oftype(logB, Inf), logB))
 end
 
 """
@@ -383,21 +394,18 @@ function autoconversion(
     acnv::CMP.AcnvSB2006, pdf_c::CMP.CloudParticlePDF_SB2006, q_lcl, q_rai, ρ, N_lcl,
 )
     FT = UT.promote_typeof(q_lcl, q_rai, ρ, N_lcl)
-    ϵM, ϵN = UT.ϵ_numerics_2M_M(FT), UT.ϵ_numerics_2M_N(FT)
-    if q_lcl < ϵM || N_lcl < ϵN
-        return LclRaiRates{FT}()
-    end
-
     (; kcc, x_star, ρ0, A, a, b) = acnv
     (; νc) = pdf_c
 
-    L_lcl = ρ * q_lcl
-    x_lcl = min(x_star, L_lcl / N_lcl)
-    q_rai = max(0, q_rai)
-    τ = 1 - q_lcl / (q_lcl + q_rai)  # Eq. (5) from SB2006
+    safe_q_lcl = max(q_lcl, UT.ϵ_numerics_2M_M(FT))
+    safe_N_lcl = max(N_lcl, UT.ϵ_numerics_2M_N(FT))
+    L_lcl = ρ * safe_q_lcl
+    x_lcl = min(x_star, L_lcl / safe_N_lcl)
+    safe_q_rai = max(0, q_rai)
+    τ = 1 - safe_q_lcl / (safe_q_lcl + safe_q_rai)  # Eq. (5) from SB2006
     # τ^a has a vertical tangent at τ = 0; the ifelse keeps the ForwardDiff
     # derivative w.r.t. q_rai finite at q_rai = 0 (and the code branch-free)
-    ϕ_au = ifelse(q_rai < ϵM, zero(τ), A * τ^a * (1 - τ^a)^b)
+    ϕ_au = ifelse(q_rai < UT.ϵ_numerics_2M_M(FT), zero(τ), A * τ^a * (1 - τ^a)^b)
 
     dL_rai_dt =
         kcc / 20 / x_star * (νc + 2) * (νc + 4) / (νc + 1)^2 *
@@ -406,11 +414,12 @@ function autoconversion(
     dL_lcl_dt = -dL_rai_dt
     dN_lcl_dt = -2 * dN_rai_dt
 
+    cond = q_lcl < UT.ϵ_numerics_2M_M(FT) || N_lcl < UT.ϵ_numerics_2M_N(FT)
     return LclRaiRates(
-        dq_lcl_dt = dL_lcl_dt / ρ,
-        dN_lcl_dt = dN_lcl_dt,
-        dq_rai_dt = dL_rai_dt / ρ,
-        dN_rai_dt = dN_rai_dt,
+        dq_lcl_dt = ifelse(cond, zero(FT), dL_lcl_dt / ρ),
+        dN_lcl_dt = ifelse(cond, zero(FT), dN_lcl_dt),
+        dq_rai_dt = ifelse(cond, zero(FT), dL_rai_dt / ρ),
+        dN_rai_dt = ifelse(cond, zero(FT), dN_rai_dt),
     )
 end
 
@@ -431,17 +440,16 @@ Compute accretion rate
     collisions between raindrops and cloud droplets (accretion)
 """
 function accretion((; accr)::CMP.SB2006, q_lcl, q_rai, ρ, N_lcl)
-
     FT = UT.promote_typeof(q_lcl, q_rai, ρ, N_lcl)
-    if q_lcl < UT.ϵ_numerics_2M_M(FT) || q_rai < UT.ϵ_numerics_2M_M(FT) || N_lcl < UT.ϵ_numerics_2M_N(FT)
-        return LclRaiRates{FT}()
-    end
-
     (; kcr, τ0, ρ0, c) = accr
-    L_lcl = ρ * q_lcl
-    L_rai = ρ * q_rai
-    x_lcl = L_lcl / N_lcl
-    τ = 1 - q_lcl / (q_lcl + q_rai)  # Eq. (5) from SB2006
+    safe_q_lcl = max(q_lcl, UT.ϵ_numerics_2M_M(FT))
+    safe_q_rai = max(q_rai, UT.ϵ_numerics_2M_M(FT))
+    safe_N_lcl = max(N_lcl, UT.ϵ_numerics_2M_N(FT))
+
+    L_lcl = ρ * safe_q_lcl
+    L_rai = ρ * safe_q_rai
+    x_lcl = L_lcl / safe_N_lcl
+    τ = 1 - safe_q_lcl / (safe_q_lcl + safe_q_rai)  # Eq. (5) from SB2006
     ϕ_ac = (τ / (τ + τ0))^c          # Eq. (8) from SB2006
 
     dL_rai_dt = kcr * L_lcl * L_rai * ϕ_ac * sqrt(ρ0 / ρ)  # Eq. (7) from SB2006
@@ -449,11 +457,12 @@ function accretion((; accr)::CMP.SB2006, q_lcl, q_rai, ρ, N_lcl)
     dL_lcl_dt = -dL_rai_dt
     dN_lcl_dt = dL_lcl_dt / x_lcl
 
+    cond = q_lcl < UT.ϵ_numerics_2M_M(FT) || q_rai < UT.ϵ_numerics_2M_M(FT) || N_lcl < UT.ϵ_numerics_2M_N(FT)
     return LclRaiRates(
-        dq_lcl_dt = dL_lcl_dt / ρ,
-        dN_lcl_dt = dN_lcl_dt,
-        dq_rai_dt = dL_rai_dt / ρ,
-        dN_rai_dt = dN_rai_dt,
+        dq_lcl_dt = ifelse(cond, zero(FT), dL_lcl_dt / ρ),
+        dN_lcl_dt = ifelse(cond, zero(FT), dN_lcl_dt),
+        dq_rai_dt = ifelse(cond, zero(FT), dL_rai_dt / ρ),
+        dN_rai_dt = ifelse(cond, zero(FT), dN_rai_dt),
     )
 end
 
@@ -477,18 +486,15 @@ function cloud_liquid_self_collection(
     acnv::CMP.AcnvSB2006, pdf_c::CMP.CloudParticlePDF_SB2006, q_lcl, ρ, dN_lcl_dt_au,
 )
     FT = UT.promote_typeof(q_lcl, ρ, dN_lcl_dt_au)
-    if q_lcl < UT.ϵ_numerics_2M_M(FT)
-        return FT(0)
-    end
     (; kcc, ρ0) = acnv
     (; νc) = pdf_c
 
     L_lcl = ρ * q_lcl
-
     # Eq. (9) from SB2006
     dN_lcl_dt_sc = -kcc * (νc + 2) / (νc + 1) * (ρ0 / ρ) * L_lcl^2 - dN_lcl_dt_au
 
-    return dN_lcl_dt_sc
+    cond = q_lcl < UT.ϵ_numerics_2M_M(FT)
+    return ifelse(cond, FT(0), dN_lcl_dt_sc)
 end
 
 """
@@ -537,19 +543,17 @@ function rain_self_collection(
     pdf::CMP.RainParticlePDF_SB2006, self::CMP.SelfColSB2006, q_rai, ρ, N_rai,
 )
     FT = UT.promote_typeof(q_rai, ρ, N_rai)
-
-    if q_rai < UT.ϵ_numerics_2M_M(FT) || N_rai < UT.ϵ_numerics_2M_N(FT)
-        return FT(0)
-    end
-
     (; krr, κrr, d) = self
     (; ρ0) = pdf
 
-    L_rai = ρ * q_rai
-    (; Br) = pdf_rain_parameters_mass(pdf, q_rai, ρ, N_rai)
+    safe_q_rai = max(q_rai, UT.ϵ_numerics_2M_M(FT))
+    safe_N_rai = max(N_rai, UT.ϵ_numerics_2M_N(FT))
+    L_rai = ρ * safe_q_rai
+    (; Br) = pdf_rain_parameters_mass(pdf, safe_q_rai, ρ, safe_N_rai)
     dN_rai_dt_sc = -krr * N_rai * L_rai * √(ρ0 / ρ) * (1 + κrr / Br)^d  # Eq. (11) from SB2006
 
-    return dN_rai_dt_sc
+    cond = q_rai < UT.ϵ_numerics_2M_M(FT) || N_rai < UT.ϵ_numerics_2M_N(FT)
+    return ifelse(cond, FT(0), dN_rai_dt_sc)
 end
 
 """
@@ -573,25 +577,21 @@ function rain_breakup(
     pdf::CMP.RainParticlePDF_SB2006, brek::CMP.BreakupSB2006, q_rai, ρ, N_rai, dN_rai_dt_sc,
 )
     FT = UT.promote_typeof(q_rai, ρ, N_rai, dN_rai_dt_sc)
-
-    if q_rai < UT.ϵ_numerics_2M_M(FT) || N_rai < UT.ϵ_numerics_2M_N(FT)
-        return FT(0)
-    end
     (; Deq, Dr_th, kbr, κbr) = brek
     (; ρw) = pdf
-    (; xr_mean) = pdf_rain_parameters(pdf, q_rai, ρ, N_rai)
+
+    safe_q_rai = max(q_rai, UT.ϵ_numerics_2M_M(FT))
+    safe_N_rai = max(N_rai, UT.ϵ_numerics_2M_N(FT))
+
+    (; xr_mean) = pdf_rain_parameters(pdf, safe_q_rai, ρ, safe_N_rai)
     Dr = cbrt(xr_mean * 6 / (π * ρw))  # mean volume raindrop diameter
     ΔD = Dr - Deq
-    Φ_br = if Dr < Dr_th  # Below the threshold diameter, breakup is neglected
-        FT(-1)
-    elseif Dr ≤ Deq  # Below the equilibrium diameter, breakup is parameterized as a linear function
-        kbr * ΔD
-    else
-        exp(κbr * ΔD) - 1  # Above the equilibrium diameter, breakup is parameterized as an exponential function
-    end
+    
+    Φ_br = ifelse(Dr < Dr_th, FT(-1), ifelse(Dr ≤ Deq, kbr * ΔD, exp(κbr * ΔD) - 1))
     dN_rai_dt_br = -(Φ_br + 1) * dN_rai_dt_sc  # Eq. (13) from SB2006
 
-    return dN_rai_dt_br
+    cond = q_rai < UT.ϵ_numerics_2M_M(FT) || N_rai < UT.ϵ_numerics_2M_N(FT)
+    return ifelse(cond, FT(0), dN_rai_dt_br)
 end
 
 """
@@ -644,24 +644,17 @@ function cloud_terminal_velocity(
     q_liq, ρₐ, N_liq,
 )
     FT = UT.promote_typeof(q_liq, ρₐ, N_liq)
-
-    if N_liq < UT.ϵ_numerics_2M_N(FT) || q_liq < UT.ϵ_numerics_2M_M(FT)
-        return (FT(0), FT(0))
-    end
-
     (; νc, μc) = pdf_c
-    (; Bc) = pdf_cloud_parameters_mass(pdf_c, q_liq, ρₐ, N_liq)
+    safe_q_liq = max(q_liq, UT.ϵ_numerics_2M_M(FT))
+    safe_N_liq = max(N_liq, UT.ϵ_numerics_2M_N(FT))
+    (; Bc) = pdf_cloud_parameters_mass(pdf_c, safe_q_liq, ρₐ, safe_N_liq)
 
     terminal_velocity_prefactor = FT(1 / 18) * (6 / ρw / π)^(2 // 3) * (ρw / ρₐ - 1) * grav / ν_air
-    vt0 =
-        N_liq < UT.ϵ_numerics_2M_N(FT) ? FT(0) :
-        terminal_velocity_prefactor * DT.generalized_gamma_Mⁿ(νc, μc, Bc, N_liq, FT(2 / 3)) / N_liq
-    vt1 =
-        q_liq < UT.ϵ_numerics_2M_M(FT) ? FT(0) :
-        terminal_velocity_prefactor * DT.generalized_gamma_Mⁿ(νc, μc, Bc, N_liq, FT(5 / 3)) / ρₐ / q_liq
+    vt0 = terminal_velocity_prefactor * DT.generalized_gamma_Mⁿ(νc, μc, Bc, safe_N_liq, FT(2 / 3)) / safe_N_liq
+    vt1 = terminal_velocity_prefactor * DT.generalized_gamma_Mⁿ(νc, μc, Bc, safe_N_liq, FT(5 / 3)) / ρₐ / safe_q_liq
 
-    return (vt0, vt1)
-
+    cond = N_liq < UT.ϵ_numerics_2M_N(FT) || q_liq < UT.ϵ_numerics_2M_M(FT)
+    return (ifelse(cond, FT(0), vt0), ifelse(cond, FT(0), vt1))
 end
 
 """
@@ -687,37 +680,35 @@ function rain_terminal_velocity(
     (; pdf_r)::CMP.SB2006, (; ρ0, aR, bR, cR)::CMP.SB2006VelType, q_rai, ρ, N_rai,
 )
     FT = UT.promote_typeof(q_rai, ρ, N_rai)
-    # TODO: Input argument list needs to be redesigned
+    safe_q_rai = max(q_rai, UT.ϵ_numerics_2M_M(FT))
+    safe_N_rai = max(N_rai, UT.ϵ_numerics_2M_N(FT))
 
-    (; Dr_mean) = pdf_rain_parameters(pdf_r, q_rai, ρ, N_rai)
+    (; Dr_mean) = pdf_rain_parameters(pdf_r, safe_q_rai, ρ, safe_N_rai)
     _pa0, _pb0, _pa1, _pb1 =
         _sb_rain_terminal_velocity_helper(pdf_r, 1 / Dr_mean, aR, bR, cR)
 
-    vt0 =
-        N_rai < UT.ϵ_numerics_2M_N(FT) ? FT(0) :
-        max(0, sqrt(ρ0 / ρ) * (aR * _pa0 - bR * _pb0 / (1 + cR * Dr_mean)))
-    vt1 =
-        q_rai < UT.ϵ_numerics_2M_M(FT) ? FT(0) :
-        max(0, sqrt(ρ0 / ρ) * (aR * _pa1 - bR * _pb1 / (1 + cR * Dr_mean)^4))
-    return (vt0, vt1)
+    vt0 = max(0, sqrt(ρ0 / ρ) * (aR * _pa0 - bR * _pb0 / (1 + cR * Dr_mean)))
+    vt1 = max(0, sqrt(ρ0 / ρ) * (aR * _pa1 - bR * _pb1 / (1 + cR * Dr_mean)^4))
+    
+    cond_N = N_rai < UT.ϵ_numerics_2M_N(FT)
+    cond_q = q_rai < UT.ϵ_numerics_2M_M(FT)
+    return (ifelse(cond_N, FT(0), vt0), ifelse(cond_q, FT(0), vt1))
 end
 function rain_terminal_velocity(
     (; pdf_r)::CMP.SB2006, vel::CMP.Chen2022VelTypeRain, q_rai, ρ, N_rai,
 )
     FT = UT.promote_typeof(q_rai, ρ, N_rai)
-    # coefficients from Table B1 from Chen et. al. 2022
     aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρ)
-    # size distribution parameter
-    (; Dr_mean) = pdf_rain_parameters(pdf_r, q_rai, ρ, N_rai)
+    safe_q_rai = max(q_rai, UT.ϵ_numerics_2M_M(FT))
+    safe_N_rai = max(N_rai, UT.ϵ_numerics_2M_N(FT))
+    (; Dr_mean) = pdf_rain_parameters(pdf_r, safe_q_rai, ρ, safe_N_rai)
 
-    # eq 20 from Chen et al 2022
     vt0 = sum(CO.Chen2022_exponential_pdf.(aiu, bi, ciu, Dr_mean, 0))
     vt3 = sum(CO.Chen2022_exponential_pdf.(aiu, bi, ciu, Dr_mean, 3))
 
-    vt0 = N_rai < UT.ϵ_numerics_2M_N(FT) ? FT(0) : max(0, vt0)
-    vt3 = q_rai < UT.ϵ_numerics_2M_M(FT) ? FT(0) : max(0, vt3)
-    # It should be (ϕ^κ * vt0, ϕ^κ * vt3), but for rain drops ϕ = 1 and κ = 0
-    return (vt0, vt3)
+    cond_N = N_rai < UT.ϵ_numerics_2M_N(FT)
+    cond_q = q_rai < UT.ϵ_numerics_2M_M(FT)
+    return (ifelse(cond_N, FT(0), max(0, vt0)), ifelse(cond_q, FT(0), max(0, vt3)))
 end
 function _sb_rain_terminal_velocity_helper(
     ::CMP.RainParticlePDF_SB2006_limited, λr, aR, bR, cR,
@@ -789,12 +780,7 @@ function rain_evaporation(
     ϵₘ = UT.ϵ_numerics_2M_M(FT)
     ϵₙ = UT.ϵ_numerics_2M_N(FT)
 
-    ∂ₜρn_rai = FT(0)
-    ∂ₜq_rai = FT(0)
     S = TDI.supersaturation_over_liquid(tps, q_tot, q_lcl + q_rai, q_icl + q_sno, ρ, T)
-
-    # If there are no raindrops or conditions are supersaturated, no evaporation occurs
-    (N_rai ≤ ϵₙ || S ≥ 0) && return (; ∂ₜρn_rai, ∂ₜq_rai)
 
     (; ν_air, D_vapor) = aps
     (; av, bv, α, β, ρ0) = evap
@@ -802,7 +788,10 @@ function rain_evaporation(
     x_star = pdf_r.xr_min
     G = CO.G_func_liquid(aps, tps, T)
 
-    (; xr_mean) = pdf_rain_parameters(pdf_r, q_rai, ρ, N_rai)
+    safe_q_rai = max(q_rai, ϵₘ)
+    safe_N_rai = max(N_rai, ϵₙ)
+
+    (; xr_mean) = pdf_rain_parameters(pdf_r, safe_q_rai, ρ, safe_N_rai)
     Dr = cbrt(6 * xr_mean / (π * ρw))
 
     t_star = cbrt(6 * x_star / xr_mean)
@@ -813,16 +802,20 @@ function rain_evaporation(
     b_vent_1 = evap.b_vent_1
 
     N_Re = α * xr_mean^β * sqrt(ρ0 / ρ) * Dr / ν_air
-    Fv0 = a_vent_0 + b_vent_0 * cbrt(ν_air / D_vapor) * sqrt(N_Re)
-    Fv1 = a_vent_1 + b_vent_1 * cbrt(ν_air / D_vapor) * sqrt(N_Re)
+    # cbrt(Schmidt) and sqrt(Reynolds) are identical for both ventilation moments, so compute once
+    # (libm cbrt is not reliably CSE'd across the two uses).
+    cbrt_Sc = cbrt(ν_air / max(D_vapor, UT.ϵ_numerics(FT)))
+    sqrt_N_Re = sqrt(N_Re)
+    Fv0 = a_vent_0 + b_vent_0 * cbrt_Sc * sqrt_N_Re
+    Fv1 = a_vent_1 + b_vent_1 * cbrt_Sc * sqrt_N_Re
 
-    ∂ₜρn_rai = min(0, 2 * FT(π) * G * S * N_rai * Dr * Fv0 / xr_mean)
-    ∂ₜq_rai = min(0, 2 * FT(π) * G * S * N_rai * Dr * Fv1 / ρ)
+    ∂ₜρn_rai = min(zero(FT), 2 * FT(π) * G * S * N_rai * Dr * Fv0 / xr_mean)
+    ∂ₜq_rai = min(zero(FT), 2 * FT(π) * G * S * N_rai * Dr * Fv1 / ρ)
 
     # When xr = 0, ∂ₜρn_rai becomes NaN. We replace NaN with 0 which is the limit of
     # ∂ₜρn_rai for xr -> 0.
-    ∂ₜρn_rai = ifelse(xr_mean / x_star < eps(FT), FT(0), ∂ₜρn_rai)
-    ∂ₜq_rai = ifelse(q_rai < ϵₘ, FT(0), ∂ₜq_rai)
+    ∂ₜρn_rai = ifelse(q_rai < ϵₘ || xr_mean / x_star < eps(FT) || N_rai ≤ ϵₙ || S ≥ 0, FT(0), ∂ₜρn_rai)
+    ∂ₜq_rai = ifelse(q_rai < ϵₘ || N_rai ≤ ϵₙ || S ≥ 0, FT(0), ∂ₜq_rai)
 
     return (; ∂ₜρn_rai, ∂ₜq_rai)
 end
@@ -847,8 +840,8 @@ Uses the same approximation pattern as
 )
     FT = eltype(q_tot)
     result = rain_evaporation(sb, aps, tps, q_tot, q_lcl, q_icl, q_rai, q_sno, ρ, N_rai, T)
-    ∂N_rai = N_rai > UT.ϵ_numerics_2M_N(FT) ? result.∂ₜρn_rai / N_rai : zero(result.∂ₜρn_rai)
-    ∂q_rai = q_rai > UT.ϵ_numerics_2M_M(FT) ? result.∂ₜq_rai / q_rai : zero(result.∂ₜq_rai)
+    ∂N_rai = ifelse(N_rai > UT.ϵ_numerics_2M_N(FT), result.∂ₜρn_rai / N_rai, zero(result.∂ₜρn_rai))
+    ∂q_rai = ifelse(q_rai > UT.ϵ_numerics_2M_M(FT), result.∂ₜq_rai / q_rai, zero(result.∂ₜq_rai))
     return (; ∂N_rai, ∂q_rai)
 end
 

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -83,9 +83,9 @@ function pdf_rain_parameters(pdf_r::CMP.RainParticlePDF_SB2006_notlimited, qᵣ,
     # three extra selects are far cheaper than a data-dependent branch (cf. PR #749).
     cond = Nᵣ < UT.ϵ_numerics_2M_N(FT) || qᵣ < UT.ϵ_numerics_2M_M(FT)
     return (;
-        N₀r = ifelse(cond, zero(Nᵣ), N₀r),
-        Dr_mean = ifelse(cond, zero(qᵣ), Dr_mean),
-        xr_mean = ifelse(cond, zero(qᵣ), xr_mean),
+        N₀r = ifelse(cond, zero(N₀r), N₀r),
+        Dr_mean = ifelse(cond, zero(Dr_mean), Dr_mean),
+        xr_mean = ifelse(cond, zero(xr_mean), xr_mean),
     )
 end
 function pdf_rain_parameters(pdf_r::CMP.RainParticlePDF_SB2006_limited, qᵣ, ρₐ, Nᵣ)
@@ -104,9 +104,9 @@ function pdf_rain_parameters(pdf_r::CMP.RainParticlePDF_SB2006_limited, qᵣ, ρ
     Dr_mean = 1 / λr  # The inverse of λr is the mean diameter of the raindrops (units: `m`)
     cond = Nᵣ < UT.ϵ_numerics_2M_N(FT) && qᵣ < UT.ϵ_numerics_2M_M(FT)
     return (;
-        N₀r = ifelse(cond, zero(Nᵣ), N₀r),
-        Dr_mean = ifelse(cond, zero(qᵣ), Dr_mean),
-        xr_mean = ifelse(cond, zero(qᵣ), xr_mean),
+        N₀r = ifelse(cond, zero(N₀r), N₀r),
+        Dr_mean = ifelse(cond, zero(Dr_mean), Dr_mean),
+        xr_mean = ifelse(cond, zero(xr_mean), xr_mean),
     )
 end
 

--- a/src/Microphysics2M.jl
+++ b/src/Microphysics2M.jl
@@ -182,7 +182,7 @@ function log_pdf_cloud_parameters_mass(pdf_c, q, ρₐ, N)
     # loggamma_z2 = SF.loggamma(z2) (pre-computed in pdf_c)
     logB = -μc * (logx̄ + loggamma_z1 - loggamma_z2)
     logA = log(μc) + log(safe_N) + z1 * logB - loggamma_z1
-    
+
     cond = N < UT.ϵ_numerics_2M_N(FT) || q < UT.ϵ_numerics_2M_M(FT)
     return (ifelse(cond, oftype(logA, -Inf), logA), ifelse(cond, oftype(logB, Inf), logB))
 end
@@ -586,7 +586,7 @@ function rain_breakup(
     (; xr_mean) = pdf_rain_parameters(pdf, safe_q_rai, ρ, safe_N_rai)
     Dr = cbrt(xr_mean * 6 / (π * ρw))  # mean volume raindrop diameter
     ΔD = Dr - Deq
-    
+
     Φ_br = ifelse(Dr < Dr_th, FT(-1), ifelse(Dr ≤ Deq, kbr * ΔD, exp(κbr * ΔD) - 1))
     dN_rai_dt_br = -(Φ_br + 1) * dN_rai_dt_sc  # Eq. (13) from SB2006
 
@@ -649,7 +649,7 @@ function cloud_terminal_velocity(
     safe_N_liq = max(N_liq, UT.ϵ_numerics_2M_N(FT))
     (; Bc) = pdf_cloud_parameters_mass(pdf_c, safe_q_liq, ρₐ, safe_N_liq)
 
-    terminal_velocity_prefactor = FT(1 / 18) * (6 / ρw / π)^(2 // 3) * (ρw / ρₐ - 1) * grav / ν_air
+    terminal_velocity_prefactor = FT(1 / 18) * cbrt((FT(6) / ρw / FT(π))^2) * (ρw / ρₐ - 1) * grav / ν_air
     vt0 = terminal_velocity_prefactor * DT.generalized_gamma_Mⁿ(νc, μc, Bc, safe_N_liq, FT(2 / 3)) / safe_N_liq
     vt1 = terminal_velocity_prefactor * DT.generalized_gamma_Mⁿ(νc, μc, Bc, safe_N_liq, FT(5 / 3)) / ρₐ / safe_q_liq
 
@@ -689,7 +689,7 @@ function rain_terminal_velocity(
 
     vt0 = max(0, sqrt(ρ0 / ρ) * (aR * _pa0 - bR * _pb0 / (1 + cR * Dr_mean)))
     vt1 = max(0, sqrt(ρ0 / ρ) * (aR * _pa1 - bR * _pb1 / (1 + cR * Dr_mean)^4))
-    
+
     cond_N = N_rai < UT.ϵ_numerics_2M_N(FT)
     cond_q = q_rai < UT.ϵ_numerics_2M_M(FT)
     return (ifelse(cond_N, FT(0), vt0), ifelse(cond_q, FT(0), vt1))
@@ -794,9 +794,9 @@ function rain_evaporation(
     (; xr_mean) = pdf_rain_parameters(pdf_r, safe_q_rai, ρ, safe_N_rai)
     Dr = cbrt(6 * xr_mean / (π * ρw))
 
-    t_star = cbrt(6 * x_star / xr_mean)
-    a_vent_0 = av * Γ_incl(FT(-1), t_star) / FT(6)^(-2 // 3)
-    b_vent_0 = bv * Γ_incl(-1 // 2 + 3 // 2 * β, t_star) / FT(6)^(β / 2 - 1 // 2)
+    t_star = cbrt(FT(6) * x_star / xr_mean)
+    a_vent_0 = evap.a_vent_0_coeff * Γ_incl(FT(-1), t_star)
+    b_vent_0 = evap.b_vent_0_coeff * Γ_incl(evap.β_va, t_star)
 
     a_vent_1 = evap.a_vent_1
     b_vent_1 = evap.b_vent_1

--- a/src/MicrophysicsNonEq.jl
+++ b/src/MicrophysicsNonEq.jl
@@ -246,7 +246,9 @@ function terminal_velocity(
 ) where {FT}
     # Stokes law: v(D) = C * D^2, valid for D < ~80 μm (Re < 1)
     v_term = CO.particle_terminal_velocity(vel, ρₐ)
-    safe_q = max(q, zero(FT))
+    # `clamp_to_nonneg` is domain sanitization for the cbrt below (keeps the discarded
+    # ifelse branch finite); the physical threshold is the `q > ϵ_numerics` gate.
+    safe_q = UT.clamp_to_nonneg(q)
     # Mean volume diameter from assumed number concentration
     D = cbrt(FT(6 / π) * ρₐ * safe_q / N_0 / ρw)
     fall_w = v_term(D)
@@ -260,7 +262,9 @@ function terminal_velocity(
     q::FT,
 ) where {FT}
     v_term = CO.particle_terminal_velocity(vel, ρₐ, ρᵢ)
-    safe_q = max(q, zero(FT))
+    # `clamp_to_nonneg` is domain sanitization for the cbrt below (keeps the discarded
+    # ifelse branch finite); the physical threshold is the `q > ϵ_numerics` gate.
+    safe_q = UT.clamp_to_nonneg(q)
     # Mean volume diameter from assumed number concentration
     D = cbrt(FT(6 / π) * ρₐ * safe_q / N_0 / ρᵢ)
     fall_w = max(FT(0), v_term(D))

--- a/src/MicrophysicsNonEq.jl
+++ b/src/MicrophysicsNonEq.jl
@@ -39,7 +39,8 @@ See DOI: 10.5194/acp-23-10883-2023
 
     # Compute the radius assuming spherical particles and
     # mono-modal distribution
-    r = N_icl > UT.ϵ_numerics(FT) ? cbrt((3 * q_icl) / (4 * FT(π) * N_icl * ρᵢ)) : zero(FT)
+    safe_N_icl = max(N_icl, UT.ϵ_numerics(FT))
+    r = ifelse(N_icl > UT.ϵ_numerics(FT), cbrt((3 * q_icl) / (4 * FT(π) * safe_N_icl * ρᵢ)), zero(FT))
     r0 = FT(1e-6)
     r_safe = max(r, r0)
 
@@ -107,9 +108,8 @@ Morrison & Milbrandt (2015), https://doi.org/10.1175/JAS-D-14-0065.1.
 - Cloud condensate tendency [kg/kg/s]
 """
 @inline conv_q_vap_to_q_lcl(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
-function conv_q_vap_to_q_lcl(
-    opt::CMP.CloudLiquidFormation, mp, tps::TDI.PS, micro, thermo,
-)
+@inline function conv_q_vap_to_q_lcl(
+    opt::CMP.CloudLiquidFormation, mp, tps::TDI.PS, micro, thermo)
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
     τ = opt.τ_relax
@@ -117,8 +117,8 @@ function conv_q_vap_to_q_lcl(
     Rᵥ = TDI.Rᵥ(tps)
     Lᵥ = TDI.Lᵥ(tps, T)
     cₚ_air = TDI.cpₘ(tps, q_tot, q_lcl + q_rai, q_icl + q_sno)
-
     qᵥ = TDI.q_vap(q_tot, q_lcl + q_rai, q_icl + q_sno)
+
     qᵥ_sat_liq = TDI.saturation_vapor_specific_content_over_liquid(tps, T, ρ)
 
     dqsl_dT = dqcld_dT(qᵥ_sat_liq, Lᵥ, Rᵥ, T)
@@ -155,9 +155,8 @@ Morrison & Milbrandt (2015), https://doi.org/10.1175/JAS-D-14-0065.1.
 - Cloud condensate tendency [kg/kg/s]
 """
 @inline conv_q_vap_to_q_icl(::Nothing, mp, tps, micro, thermo) = zero(thermo.T)
-function conv_q_vap_to_q_icl(
-    opt::CMP.ConstantTimescale, mp, tps::TDI.PS, micro, thermo,
-)
+@inline function conv_q_vap_to_q_icl(
+    opt::CMP.ConstantTimescale, mp, tps::TDI.PS, micro, thermo)
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
     τ = opt.τ_relax
@@ -165,8 +164,8 @@ function conv_q_vap_to_q_icl(
     Rᵥ = TDI.Rᵥ(tps)
     Lₛ = TDI.Lₛ(tps, T)
     cₚ_air = TDI.cpₘ(tps, q_tot, q_lcl + q_rai, q_icl + q_sno)
-
     qᵥ = TDI.q_vap(q_tot, q_lcl + q_rai, q_icl + q_sno)
+
     qᵥ_sat_ice = TDI.saturation_vapor_specific_content_over_ice(tps, T, ρ)
 
     dqsi_dT = dqcld_dT(qᵥ_sat_ice, Lₛ, Rᵥ, T)
@@ -184,9 +183,8 @@ function conv_q_vap_to_q_icl(
     limiter = INP_limiter(tendency, tps, T)
     return ifelse(limiter, zero(tendency), tendency)
 end
-function conv_q_vap_to_q_icl(
-    opt::CMP.TemperatureDependent, mp, tps::TDI.PS, micro, thermo,
-)
+@inline function conv_q_vap_to_q_icl(
+    opt::CMP.TemperatureDependent, mp, tps::TDI.PS, micro, thermo)
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
     τ_sub = opt.τ_relax
@@ -195,8 +193,8 @@ function conv_q_vap_to_q_icl(
     Rᵥ = TDI.Rᵥ(tps)
     Lₛ = TDI.Lₛ(tps, T)
     cₚ_air = TDI.cpₘ(tps, q_tot, q_lcl + q_rai, q_icl + q_sno)
-
     qᵥ = TDI.q_vap(q_tot, q_lcl + q_rai, q_icl + q_sno)
+
     qᵥ_sat_ice = TDI.saturation_vapor_specific_content_over_ice(tps, T, ρ)
 
     dqsi_dT = dqcld_dT(qᵥ_sat_ice, Lₛ, Rᵥ, T)
@@ -246,15 +244,13 @@ function terminal_velocity(
     ρₐ::FT,
     q::FT,
 ) where {FT}
-    fall_w = FT(0)
-    if q > UT.ϵ_numerics(FT)
-        # Stokes law: v(D) = C * D^2, valid for D < ~80 μm (Re < 1)
-        v_term = CO.particle_terminal_velocity(vel, ρₐ)
-        # Mean volume diameter from assumed number concentration
-        D = cbrt(FT(6 / π) * ρₐ * q / N_0 / ρw)
-        fall_w = v_term(D)
-    end
-    return fall_w
+    # Stokes law: v(D) = C * D^2, valid for D < ~80 μm (Re < 1)
+    v_term = CO.particle_terminal_velocity(vel, ρₐ)
+    safe_q = max(q, zero(FT))
+    # Mean volume diameter from assumed number concentration
+    D = cbrt(FT(6 / π) * ρₐ * safe_q / N_0 / ρw)
+    fall_w = v_term(D)
+    return ifelse(q > UT.ϵ_numerics(FT), fall_w, zero(FT))
 end
 
 function terminal_velocity(
@@ -263,14 +259,12 @@ function terminal_velocity(
     ρₐ::FT,
     q::FT,
 ) where {FT}
-    fall_w = FT(0)
-    if q > UT.ϵ_numerics(FT)
-        v_term = CO.particle_terminal_velocity(vel, ρₐ, ρᵢ)
-        # Mean volume diameter from assumed number concentration
-        D = cbrt(FT(6 / π) * ρₐ * q / N_0 / ρᵢ)
-        fall_w = max(FT(0), v_term(D))
-    end
-    return fall_w
+    v_term = CO.particle_terminal_velocity(vel, ρₐ, ρᵢ)
+    safe_q = max(q, zero(FT))
+    # Mean volume diameter from assumed number concentration
+    D = cbrt(FT(6 / π) * ρₐ * safe_q / N_0 / ρᵢ)
+    fall_w = max(FT(0), v_term(D))
+    return ifelse(q > UT.ϵ_numerics(FT), fall_w, zero(FT))
 end
 
 end #module MicrophysicsNonEq.jl

--- a/src/P3_integral_properties.jl
+++ b/src/P3_integral_properties.jl
@@ -31,11 +31,13 @@ Compute the integration bounds for the P3 size distribution,
 # Returns
 - `bnds`: The integration bounds (a `Tuple`), for use in numerical integration (c.f. [`integrate`](@ref)).
 """
-function integral_bounds(state::P3State{FT}, logλ; p, moment_order = 0) where {FT}
+@inline function integral_bounds(state::P3State{FT}, logλ; p, moment_order = 0) where {FT}
     # Get reduced lower and upper bounds from quantiles
     k = get_μ(state, logλ) + moment_order
-    D_min = DT.generalized_gamma_quantile(k, FT(1), exp(logλ), FT(p))
-    D_max = DT.generalized_gamma_quantile(k, FT(1), exp(logλ), FT(1 - p))
+    λ = exp(logλ)
+    # μ == 1 here, so use the unit-μ quantile (avoids a `(z/λ)^1` runtime pow per bound)
+    D_min = DT.generalized_gamma_quantile_unit_μ(k, λ, FT(p))
+    D_max = DT.generalized_gamma_quantile_unit_μ(k, λ, FT(1 - p))
 
     # Only integrate up to the maximum diameter, `D_max`, including intermediate thresholds
     # If `F_rim` is very close to 1, `D_cr` may be greater than `D_max`, in which case it is disregarded.

--- a/src/P3_particle_properties.jl
+++ b/src/P3_particle_properties.jl
@@ -322,6 +322,11 @@ function ice_mass_coeffs(state::P3State, D)
     (; ρ_i) = params
     (; α_va, β_va) = params.mass
 
+    # Four particle-size-based regimes (Morrison & Milbrandt 2015), selected in order:
+    #   cond1  (D < D_th)                : small spherical ice, m = ρ_i·(π/6)·D³
+    #   cond2  (unrimed || D < D_gr)     : dense nonspherical ice, m = α_va·D^β_va
+    #   cond3  (D < D_cr)                : graupel (rimed spherical), m = ρ_g·(π/6)·D³
+    #   else   (D ≥ D_cr)               : partially rimed, m = α_va/(1-F_rim)·D^β_va
     unrimed = iszero(F_rim)
     cond1 = D < D_th
     cond2 = unrimed || D < D_gr
@@ -398,9 +403,14 @@ Return the cross-sectional area of a particle based on where it falls in the
 function ice_area(state::P3State, D)
     (; params, F_rim, D_th, D_gr, D_cr) = state
     (; γ, σ) = params.area
-    s_area = D^2 * π / 4
-    ns_area = γ * D^σ
+    s_area = D^2 * π / 4  # spherical cross-sectional area
+    ns_area = γ * D^σ     # nonspherical area–dimension power law
 
+    # Same four regimes as `ice_mass_coeffs` (Morrison & Milbrandt 2015):
+    #   cond1  (D < D_th)            : small spherical ice        → s_area
+    #   cond2  (unrimed || D < D_gr) : dense nonspherical ice     → ns_area
+    #   cond3  (D < D_cr)            : graupel (rimed spherical)  → s_area
+    #   else   (D ≥ D_cr)           : partially rimed → F_rim-weighted blend of the two
     unrimed = iszero(F_rim)
     cond1 = D < D_th
     cond2 = unrimed || D < D_gr

--- a/src/P3_particle_properties.jl
+++ b/src/P3_particle_properties.jl
@@ -327,7 +327,11 @@ function ice_mass_coeffs(state::P3State, D)
     cond2 = unrimed || D < D_gr
     cond3 = D < D_cr
 
-    a = ifelse(cond1, FT(ρ_i * π / 6), ifelse(cond2, α_va, ifelse(cond3, FT(ρ_g * π / 6), α_va / max(1 - F_rim, UT.ϵ_numerics_P3_B(FT)))))
+    a = ifelse(
+        cond1,
+        FT(ρ_i * π / 6),
+        ifelse(cond2, α_va, ifelse(cond3, FT(ρ_g * π / 6), α_va / max(1 - F_rim, UT.ϵ_numerics_P3_B(FT)))),
+    )
     b = ifelse(cond1, FT(3), ifelse(cond2, β_va, ifelse(cond3, FT(3), β_va)))
     return (a, b)
 end
@@ -402,7 +406,11 @@ function ice_area(state::P3State, D)
     cond2 = unrimed || D < D_gr
     cond3 = D < D_cr
 
-    return ifelse(cond1, s_area, ifelse(cond2, ns_area, ifelse(cond3, s_area, weighted_average(F_rim, s_area, ns_area))))
+    return ifelse(
+        cond1,
+        s_area,
+        ifelse(cond2, ns_area, ifelse(cond3, s_area, weighted_average(F_rim, s_area, ns_area))),
+    )
 end
 
 """

--- a/src/P3_particle_properties.jl
+++ b/src/P3_particle_properties.jl
@@ -321,18 +321,15 @@ function ice_mass_coeffs(state::P3State, D)
     (; params, F_rim, ρ_g, D_th, D_gr, D_cr) = state
     (; ρ_i) = params
     (; α_va, β_va) = params.mass
-    a, b = if D < D_th       # small spherical ice
-        (ρ_i * π / 6, 3)
-    elseif iszero(F_rim)     # large nonspherical unrimed ice
-        (α_va, β_va)
-    elseif D_th ≤ D < D_gr   # dense nonspherical rimed ice
-        (α_va, β_va)
-    elseif D_gr ≤ D < D_cr   # graupel (rimed)
-        (ρ_g * π / 6, 3)
-    else # D_cr ≤ D          # partially rimed ice
-        (α_va / (1 - F_rim), β_va)
-    end
-    return FT(a), FT(b)
+
+    unrimed = iszero(F_rim)
+    cond1 = D < D_th
+    cond2 = unrimed || D < D_gr
+    cond3 = D < D_cr
+
+    a = ifelse(cond1, FT(ρ_i * π / 6), ifelse(cond2, α_va, ifelse(cond3, FT(ρ_g * π / 6), α_va / max(1 - F_rim, UT.ϵ_numerics_P3_B(FT)))))
+    b = ifelse(cond1, FT(3), ifelse(cond2, β_va, ifelse(cond3, FT(3), β_va)))
+    return (a, b)
 end
 
 """
@@ -397,19 +394,15 @@ Return the cross-sectional area of a particle based on where it falls in the
 function ice_area(state::P3State, D)
     (; params, F_rim, D_th, D_gr, D_cr) = state
     (; γ, σ) = params.area
-    spherical_area(D) = D^2 * π / 4
-    nonspherical_area(D) = γ * D^σ
-    return if D < D_th       # small spherical ice
-        spherical_area(D)
-    elseif iszero(F_rim)     # large nonspherical unrimed ice
-        nonspherical_area(D)
-    elseif D_th ≤ D < D_gr   # dense nonspherical rimed ice
-        nonspherical_area(D)
-    elseif D_gr ≤ D < D_cr   # graupel (rimed)
-        spherical_area(D)
-    else # D_cr ≤ D          # partially rimed ice
-        weighted_average(F_rim, spherical_area(D), nonspherical_area(D))
-    end
+    s_area = D^2 * π / 4
+    ns_area = γ * D^σ
+
+    unrimed = iszero(F_rim)
+    cond1 = D < D_th
+    cond2 = unrimed || D < D_gr
+    cond3 = D < D_cr
+
+    return ifelse(cond1, s_area, ifelse(cond2, ns_area, ifelse(cond3, s_area, weighted_average(F_rim, s_area, ns_area))))
 end
 
 """
@@ -426,14 +419,15 @@ Returns the aspect ratio (ϕ) for an ice particle with diameter `D`
  divided by the volume of a spherical particle with the same D_max [MorrisonMilbrandt2015](@cite).
  Assuming zero liquid fraction and oblate shape.
 """
-function ϕᵢ(state::P3State, D)
+@inline function ϕᵢ(state::P3State, D)
     FT = eltype(D)
-    mᵢ = ice_mass(state, D)
     aᵢ = ice_area(state, D)
-    ρᵢ = mᵢ / CO.volume_sphere_D(D)
+    vol = CO.volume_sphere_D(D)
 
     # TODO - prolate or oblate?
-    ϕ_ob = min(1, 3 * sqrt(FT(π)) * mᵢ / (4 * ρᵢ * aᵢ^FT(1.5))) # κ =  1/3
+    # aᵢ^1.5 = aᵢ*sqrt(aᵢ): a runtime-float pow (which also incurs an f32→f64
+    # promotion) becomes one hardware sqrt + a mul. Evaluated per quadrature node.
+    ϕ_ob = min(1, 3 * sqrt(FT(π)) * vol / (4 * (aᵢ * sqrt(aᵢ)))) # κ =  1/3
     #ϕ_pr = max(1, 16 * ρᵢ^2 * aᵢ^3 / (9 * FT(π) * mᵢ^2))       # κ = -1/6
 
     return ifelse(D == 0, zero(ϕ_ob), ϕ_ob)

--- a/src/P3_processes.jl
+++ b/src/P3_processes.jl
@@ -682,11 +682,16 @@ A `NamedTuple` of `(; dNdt)`, where:
     function inner_integral(D_1)
         v1 = v_ice(D_1)
         r1 = sqrt(ice_area(state, D_1) / π)
+        # Volumetric collision rate integrand: E · K · |v₁ − v₂| · n(D₂)
+        # where E = 1 (collision efficiency),
+        #       K = π (r₁ + r₂)² is the geometric collision cross-section,
+        #       |v₁ − v₂| is the differential sedimentation speed,
+        #       r = √(A/π) is the effective radius from projected ice area A.
         integrand = D_2 -> begin
             v2 = v_ice(D_2)
             r2 = sqrt(ice_area(state, D_2) / π)
-            K = π * (r1 + r2)^2
-            return K * abs(v1 - v2) * n_i(D_2)
+            K = π * (r1 + r2)^2                    # collision cross section
+            return K * abs(v1 - v2) * n_i(D_2)     # E = 1 implied
         end
         # Split the inner integral at the |v1 - v2| cusp (D_2 = D_1, where the relative
         # fall speed vanishes and the integrand has a kink). Each half is then smooth, so

--- a/src/P3_processes.jl
+++ b/src/P3_processes.jl
@@ -451,6 +451,11 @@ A tuple of 8 integrands, see [`∫liquid_ice_collisions`](@ref) for details.
     cloud_integrals,
     rain_integrals,
     ice_bounds;
+    # Chebyshev–Gauss (not the Gauss–Legendre default used elsewhere):
+    # this integrand has √-type endpoint/weight behavior that Gauss–Legendre resolves
+    # poorly, so a higher node count is used here. TODO: run the same convergence check
+    # used for the Gauss-Legendre default and lower this to the smallest node count within
+    # tolerance.
     quad = ChebyshevGauss(100),
 )
     function liquid_ice_collisions_integrands(Dᵢ)

--- a/src/P3_processes.jl
+++ b/src/P3_processes.jl
@@ -445,7 +445,14 @@ Computes the bulk collision rate integrands between ice and liquid particles.
 # Returns
 A tuple of 8 integrands, see [`∫liquid_ice_collisions`](@ref) for details.
 """
-@inline function ∫liquid_ice_collisions(n_i, ∂ₜM_max, cloud_integrals, rain_integrals, ice_bounds; quad = ChebyshevGauss(100))
+@inline function ∫liquid_ice_collisions(
+    n_i,
+    ∂ₜM_max,
+    cloud_integrals,
+    rain_integrals,
+    ice_bounds;
+    quad = ChebyshevGauss(100),
+)
     function liquid_ice_collisions_integrands(Dᵢ)
         # Inner integrals over liquid particle diameters
         ∂ₜN_c_col, ∂ₜM_c_col, ∂ₜB_c_col = cloud_integrals(Dᵢ)
@@ -688,6 +695,7 @@ A `NamedTuple` of `(; dNdt)`, where:
     total_rate = integrate(inner_integral, ice_bounds, quad)
 
     # The 0.5 factor accounts for double-counting in self-collection
-    dNdt = (1 // 2) * total_rate
+    FT = eltype(state)
+    dNdt = FT(0.5) * total_rate
     return (; dNdt)
 end

--- a/src/P3_processes.jl
+++ b/src/P3_processes.jl
@@ -61,7 +61,7 @@ end
 
 Returns the melting rate of ice (QIMLT in Morrison and Mildbrandt (2015)).
 """
-function ice_melt(
+@inline function ice_melt(
     velocity_params, aps::CMP.AirProperties, tps::TDI.PS,
     Tₐ, ρₐ, state::P3State, logλ;
     quad = ChebyshevGauss(100),
@@ -301,17 +301,17 @@ The function `liquid_integrals(Dᵢ)` returns a tuple `(∂ₜN_col, ∂ₜM_col
 - `∂ₜM_col`: mass collision rate [kg/s]
 - `∂ₜB_col`: rime volume collision rate [m³/s]
 """
-function get_liquid_integrals(n, ∂ₜV, m_liq, ρ′_rim, liq_bounds; quad = ChebyshevGauss(100))
+@inline function get_liquid_integrals(n, ∂ₜV, m_liq, ρ′_rim, liq_bounds; quad = ChebyshevGauss(100))
     function liquid_integrals(Dᵢ)
-        integrand =
-            D -> SA.SVector(
-                # ∂ₜN_col = ∫ ∂ₜV ⋅ n ⋅ dD
-                ∂ₜV(Dᵢ, D) * n(D),
-                # ∂ₜM_col = ∫ ∂ₜV ⋅ n ⋅ m_liq ⋅ dD
-                ∂ₜV(Dᵢ, D) * n(D) * m_liq(D),
-                # ∂ₜB_col = ∫ ∂ₜV ⋅ n ⋅ m_liq / ρ′_rim ⋅ dD
-                ∂ₜV(Dᵢ, D) * n(D) * m_liq(D) / ρ′_rim(Dᵢ, D),
-            )
+        integrand = D -> begin
+            V_val = ∂ₜV(Dᵢ, D)
+            n_val = n(D)
+            m_val = m_liq(D)
+            term1 = V_val * n_val
+            term2 = term1 * m_val
+            term3 = term2 / ρ′_rim(Dᵢ, D)
+            return SA.SVector(term1, term2, term3)
+        end
         (∂ₜN_col, ∂ₜM_col, ∂ₜB_col) = integrate(integrand, liq_bounds, quad)
         return ∂ₜN_col, ∂ₜM_col, ∂ₜB_col
     end
@@ -378,7 +378,7 @@ Returns a function `liquid_integrals(Dᵢ) -> (∂ₜN_col, ∂ₜM_col, ∂ₜB
 where N and M are the exact incomplete-gamma closed form and 
 B_rim is computed by quadrature
 """
-function get_liquid_integrals_rain_closed(
+@inline function get_liquid_integrals_rain_closed(
     psd_r::CMP.RainParticlePDF_SB2006, vel::CMP.Chen2022VelType,
     n_r, ρₐ, L_r, N_r, state, ∂ₜV, m_liq, ρ′_rim, bounds_r; quad,
 )
@@ -413,14 +413,14 @@ function get_liquid_integrals_rain_closed(
     return liquid_integrals
 end
 
-_rain_inner_integrals(
+@inline _rain_inner_integrals(
     psd_r::CMP.RainParticlePDF_SB2006, vel::CMP.Chen2022VelType,
     n_r, ∂ₜV, m_liq, ρ′_rim, bounds_r, ρₐ, L_r, N_r, state; quad,
 ) = get_liquid_integrals_rain_closed(
     psd_r, vel, n_r, ρₐ, L_r, N_r, state, ∂ₜV, m_liq, ρ′_rim, bounds_r;
     quad,
 )
-_rain_inner_integrals(
+@inline _rain_inner_integrals(
     ::Any, ::Any,
     n_r, ∂ₜV, m_liq, ρ′_rim, bounds_r, ρₐ, L_r, N_r, state; quad,
 ) = get_liquid_integrals(n_r, ∂ₜV, m_liq, ρ′_rim, bounds_r; quad)
@@ -445,7 +445,7 @@ Computes the bulk collision rate integrands between ice and liquid particles.
 # Returns
 A tuple of 8 integrands, see [`∫liquid_ice_collisions`](@ref) for details.
 """
-function ∫liquid_ice_collisions(n_i, ∂ₜM_max, cloud_integrals, rain_integrals, ice_bounds; quad = ChebyshevGauss(100))
+@inline function ∫liquid_ice_collisions(n_i, ∂ₜM_max, cloud_integrals, rain_integrals, ice_bounds; quad = ChebyshevGauss(100))
     function liquid_ice_collisions_integrands(Dᵢ)
         # Inner integrals over liquid particle diameters
         ∂ₜN_c_col, ∂ₜM_c_col, ∂ₜB_c_col = cloud_integrals(Dᵢ)
@@ -517,7 +517,7 @@ A tuple `(QCFRZ, QCSHD, NCCOL, QRFRZ, QRSHD, NRCOL, ∫M_col, BCCOL, BRCOL, ∫�
 7. `BRCOL` - Rain rime volume source [m³/m³/s]
 8. `∫𝟙_wet_M_col` - Wet growth indicator [kg/s]
 """
-function ∫liquid_ice_collisions(
+@inline function ∫liquid_ice_collisions(
     state, logλ,
     psd_c, psd_r, L_c, N_c, L_r, N_r,
     aps, tps, vel, ρₐ, T, m_liq; quad,
@@ -590,7 +590,7 @@ A `NamedTuple` of `(; ∂ₜq_c, ∂ₜq_r, ∂ₜN_c, ∂ₜN_r, ∂ₜL_rim, �
 6. `∂ₜL_ice`: ice water content tendency [kg/m³/s]
 7. `∂ₜB_rim`: rime volume tendency [m³/m³/s]
 """
-function bulk_liquid_ice_collision_sources(
+@inline function bulk_liquid_ice_collision_sources(
     state, logλ,
     psd_c, psd_r, L_c, N_c, L_r, N_r,
     aps, tps, vel, ρₐ, T; quad = ChebyshevGauss(100),
@@ -641,39 +641,6 @@ function bulk_liquid_ice_collision_sources(
     )
 end
 
-
-function collision_cross_section_ice_ice(state, D_1, D_2)
-    r_eff(D) = √(ice_area(state, D) / π)
-    return π * (r_eff(D_1) + r_eff(D_2))^2  # collision cross section
-end
-
-"""
-    volumetric_ice_ice_collision_rate_integrand(state, velocity_params, ρₐ)
-
-Returns a function that computes the volumetric collision rate integrand for ice-ice collisions [m³/s].
-
-# Arguments
-- `state`: [`P3State`](@ref)
-- `velocity_params`: velocity parameterization, e.g. [`CMP.Chen2022VelType`](@ref)
-- `ρₐ`: air density
-
-# Returns
-A function `(D_1, D_2) -> E * K * |vᵢ(D_1) - vᵢ(D_2)|` where:
-- `D_1` and `D_2` are the (maximum) diameters of the ice particles
-- `E` is the collision efficiency
-- `K` is the collision cross section
-- `vᵢ` is the terminal velocity of ice particles
-"""
-function volumetric_ice_ice_collision_rate_integrand(velocity_params, ρₐ, state)
-    v_ice = ice_particle_terminal_velocity(velocity_params, ρₐ, state)
-    function integrand(D_1::FT, D_2::FT) where {FT}
-        E = FT(1)  # Collision efficiency
-        K = collision_cross_section_ice_ice(state, D_1, D_2)
-        return E * K * abs(v_ice(D_1) - v_ice(D_2))
-    end
-    return integrand
-end
-
 """
     ice_self_collection(state, logλ, vel, ρₐ; [quad])
 
@@ -693,16 +660,28 @@ while leaving mass, rime mass, and rime volume unchanged.
 A `NamedTuple` of `(; dNdt)`, where:
 1. `dNdt`: ice number concentration tendency due to self-collection [1/m³/s] (always positive or zero, represents a loss rate)
 """
-function ice_self_collection(state, logλ, vel, ρₐ; quad = ChebyshevGauss(100))
+@inline function ice_self_collection(state, logλ, vel, ρₐ; quad = ChebyshevGauss(100))
     n_i = DT.size_distribution(state, logλ)
-    ∂ₜV = volumetric_ice_ice_collision_rate_integrand(vel, ρₐ, state)
+    v_ice = ice_particle_terminal_velocity(vel, ρₐ, state)
 
     p = eps(one(ρₐ))
     ice_bounds = integral_bounds(state, logλ; p)
 
     function inner_integral(D_1)
-        integrand = D_2 -> ∂ₜV(D_1, D_2) * n_i(D_2)
-        rate_at_D1 = integrate(integrand, ice_bounds, quad)
+        v1 = v_ice(D_1)
+        r1 = sqrt(ice_area(state, D_1) / π)
+        integrand = D_2 -> begin
+            v2 = v_ice(D_2)
+            r2 = sqrt(ice_area(state, D_2) / π)
+            K = π * (r1 + r2)^2
+            return K * abs(v1 - v2) * n_i(D_2)
+        end
+        # Split the inner integral at the |v1 - v2| cusp (D_2 = D_1, where the relative
+        # fall speed vanishes and the integrand has a kink). Each half is then smooth, so
+        # the quadrature converges like the other (cusp-free) P3 integrals rather than
+        # being cusp-limited, letting a much lower node count reach target accuracy.
+        D_lo, D_hi = first(ice_bounds), last(ice_bounds)
+        rate_at_D1 = integrate(integrand, (D_lo, D_1), quad) + integrate(integrand, (D_1, D_hi), quad)
         return rate_at_D1 * n_i(D_1)
     end
 

--- a/src/P3_size_distribution.jl
+++ b/src/P3_size_distribution.jl
@@ -1,6 +1,10 @@
 import CloudMicrophysics.DistributionTools: size_distribution
 
 # Callable returned by `logN′ice`: evaluates `log(N′(D))` for a fixed state and slope.
+# We store `λ = exp(logλ)` (computed once when the functor is built) rather than `logλ`
+# so the slope term is a single multiply `λ * D` in the quadrature hot loop, instead of
+# `exp(logλ + logD)` (a transcendental per evaluation). `logD = log(D)` is still needed
+# for the `μ * logD` term.
 struct P3LogNumberFunctor{FT} <: Function
     log_N₀::FT
     μ::FT

--- a/src/P3_size_distribution.jl
+++ b/src/P3_size_distribution.jl
@@ -1,14 +1,14 @@
 import CloudMicrophysics.DistributionTools: size_distribution
 
 # Callable returned by `logN′ice`: evaluates `log(N′(D))` for a fixed state and slope.
-struct P3LogNumberFunctor{FT, T} <: Function
+struct P3LogNumberFunctor{FT} <: Function
     log_N₀::FT
     μ::FT
-    logλ::T
+    λ::FT
 end
 @inline function (f::P3LogNumberFunctor)(D)
     logD = log(D)
-    return f.log_N₀ + f.μ * logD - exp(f.logλ + logD)
+    return f.log_N₀ + f.μ * logD - f.λ * D
 end
 
 """
@@ -23,7 +23,8 @@ function logN′ice(state::P3State, logλ)
     # Promote to a common type: differentiating w.r.t. the ice number makes
     # `log_N₀` a `Dual` while `μ` (a function of the fixed `logλ`) stays a plain
     # float, and `P3LogNumberFunctor` stores both in a single field type.
-    return P3LogNumberFunctor(promote(log_N₀, μ)..., logλ)
+    λ = exp(logλ)
+    return P3LogNumberFunctor(promote(log_N₀, μ)..., λ)
 end
 
 # Callable returned by `size_distribution`: `n(D) = exp(logN′(D))`.

--- a/src/P3_size_distribution.jl
+++ b/src/P3_size_distribution.jl
@@ -28,7 +28,7 @@ function logN′ice(state::P3State, logλ)
     # `log_N₀` a `Dual` while `μ` (a function of the fixed `logλ`) stays a plain
     # float, and `P3LogNumberFunctor` stores both in a single field type.
     λ = exp(logλ)
-    return P3LogNumberFunctor(promote(log_N₀, μ)..., λ)
+    return P3LogNumberFunctor(promote(log_N₀, μ, λ)...)
 end
 
 # Callable returned by `size_distribution`: `n(D) = exp(logN′(D))`.

--- a/src/P3_terminal_velocity.jl
+++ b/src/P3_terminal_velocity.jl
@@ -9,8 +9,8 @@ struct P3IceParticleVelocityFunctor{FT, VS, VL, S} <: Function
     use_aspect_ratio::Bool
 end
 @inline function (f::P3IceParticleVelocityFunctor)(D)
-    vₜ = D <= f.D_cutoff ? f.v_term_small(D) : f.v_term_large(D)
-    return f.use_aspect_ratio ? cbrt(ϕᵢ(f.state, D)) * vₜ : vₜ
+    vₜ = ifelse(D <= f.D_cutoff, f.v_term_small(D), f.v_term_large(D))
+    return ifelse(f.use_aspect_ratio, cbrt(ϕᵢ(f.state, D)) * vₜ, vₜ)
 end
 
 """

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -86,11 +86,11 @@ end
     return (FD.Dual{T}(P, z), FD.Dual{T}(Q, z))
 end
 
-# `lΓa = SF.loggamma(a)` is passed in so callers that evaluate this repeatedly for a
+# `loggamma_a = SF.loggamma(a)` is passed in so callers that evaluate this repeatedly for a
 # fixed `a` (e.g. the Halley loop in `_gamma_inc_inv`) compute the expensive loggamma
 # once instead of every iteration. The 2-arg form computes it for one-off callers.
 @inline _gamma_inc(a::FT, x::FT) where {FT <: Real} = _gamma_inc(a, x, SF.loggamma(a))
-@inline function _gamma_inc(a::FT, x::FT, lΓa::FT) where {FT <: Real}
+@inline function _gamma_inc(a::FT, x::FT, loggamma_a::FT) where {FT <: Real}
     if x <= 0
         return (zero(FT), one(FT))
     elseif isinf(x)
@@ -99,7 +99,7 @@ end
 
     # factor = x^a * e^-x / Gamma(a)
     # Using loggamma for numerical stability
-    factor = exp(a * log(x) - x - lΓa)
+    factor = exp(a * log(x) - x - loggamma_a)
     maxiters = FT === Float32 ? 20 : 30
 
     if x < a + 1
@@ -221,12 +221,12 @@ end
     use_q = p > FT(0.5)
     # loggamma(a) is loop-invariant, so compute once and thread it into `_gamma_inc`
     # and the derivative below (was recomputed ~2×/iteration, up to ~30×/call).
-    lΓa = SF.loggamma(a)
+    loggamma_a = SF.loggamma(a)
     for i in 1:15
-        P, Q = _gamma_inc(a, x, lΓa)
+        P, Q = _gamma_inc(a, x, loggamma_a)
         f = use_q ? Q - q : P - p
         # Derivative: dP/dx = x^(a-1) e^-x / Gamma(a), dQ/dx = -dP/dx
-        fprime = exp((a - 1) * log(x) - x - lΓa)
+        fprime = exp((a - 1) * log(x) - x - loggamma_a)
         # When using Q-q, the derivative is -fprime
         fprime = use_q ? -fprime : fprime
         if fprime == 0
@@ -251,11 +251,41 @@ end
     return x
 end
 
+# ---------------------------------------------------------------------------
+# Small-number handling: two distinct roles, kept deliberately separate.
+#
+# 1. Domain sanitization (NOT a physical threshold): `clamp_to_nonneg` and the
+#    `max(x, ϵ)` floors on arguments of `cbrt`/`log`/`^`. These only keep an
+#    expression finite (e.g. so the *discarded* branch of a branchless
+#    `ifelse(cond, rate, 0)` cannot produce Inf/NaN, which matters for
+#    ForwardDiff gradients). They do not decide whether a tracer is "present".
+#
+# 2. Physical thresholds: the `ϵ_numerics*` functions below, used as `q > ϵ`
+#    gates that treat a tracer as absent. There is exactly one threshold per
+#    moment class, always called from here so the value has a single source of
+#    truth (no bare literals/zeros scattered across the schemes).
+#
+# The threshold values intentionally differ by moment class:
+#   - `ϵ_numerics`      = cbrt(floatmin(FT))  (≈3.8e-13 @ f32) — a floatmin-derived
+#     floor, sized so cbrt/pow arguments stay above `floatmin` (its cube is
+#     `floatmin`). Used by the 1-moment scheme.
+#   - `ϵ_numerics_2M_*` = eps(FT)             (≈1.2e-7  @ f32) — a relative round-off
+#     threshold for the 2-moment mass/number variables.
+#   - `ϵ_numerics_P3_B` = eps(FT)                                — same, for the P3
+#     rime-volume (B_rim) variable.
+# The ~6 orders of magnitude gap reflects the different roles (underflow-avoiding
+# floor vs. relative-precision threshold), not an oversight. If a scheme needs a
+# different value, change it here rather than at the call sites.
+# ---------------------------------------------------------------------------
+
 """
     clamp_to_nonneg(x)
 
-Clamp values to be non-negative.
-Compatible with dual numbers (AD) and GPUs.
+Clamp values to be non-negative. Compatible with dual numbers (AD) and GPUs.
+
+This is **domain sanitization**, not a physical threshold: use it to keep an
+argument of `cbrt`/`log`/`^` finite, not to decide whether a tracer is present
+(use the `ϵ_numerics*` gates for that).
 
 # Arguments
 - `x`: value to clamp
@@ -275,30 +305,32 @@ Integer factorial `n!`, valid for `0 ≤ n ≤ 20`.
 """
     ϵ_numerics(FT)
 
-Smallest number that is different than zero for the purpose of microphysics
-computations. Returns `cbrt(floatmin(FT))` to avoid underflow issues.
+Physical smallness threshold for the **1-moment** scheme: below this a tracer is
+treated as absent. Returns `cbrt(floatmin(FT))`, a floatmin-derived floor that
+also keeps `cbrt`/`^` arguments above `floatmin`. See the note above for how this
+relates to the 2-moment/P3 thresholds.
 """
 @inline ϵ_numerics(FT) = cbrt(floatmin(FT))
 
 """
     ϵ_numerics_2M_M(FT)
 
-Numerical epsilon for 2-moment mass calculations.
+Physical smallness threshold for **2-moment mass** variables (`eps(FT)`).
 """
 @inline ϵ_numerics_2M_M(FT) = eps(FT)
 
 """
     ϵ_numerics_2M_N(FT)
 
-Numerical epsilon for 2-moment number calculations.
+Physical smallness threshold for **2-moment number** variables (`eps(FT)`).
 """
 @inline ϵ_numerics_2M_N(FT) = eps(FT)
 
 """
     ϵ_numerics_P3_B(FT)
 
-Numerical epsilon for P3 bulk microphysics mass calculations
-    relating to rim volume, B_rim.
+Physical smallness threshold for the **P3** rime-volume variable `B_rim`
+(`eps(FT)`).
 """
 @inline ϵ_numerics_P3_B(FT) = eps(FT)
 

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -86,7 +86,11 @@ end
     return (FD.Dual{T}(P, z), FD.Dual{T}(Q, z))
 end
 
-@inline function _gamma_inc(a::FT, x::FT) where {FT <: Real}
+# `lΓa = SF.loggamma(a)` is passed in so callers that evaluate this repeatedly for a
+# fixed `a` (e.g. the Halley loop in `_gamma_inc_inv`) compute the expensive loggamma
+# once instead of every iteration. The 2-arg form computes it for one-off callers.
+@inline _gamma_inc(a::FT, x::FT) where {FT <: Real} = _gamma_inc(a, x, SF.loggamma(a))
+@inline function _gamma_inc(a::FT, x::FT, lΓa::FT) where {FT <: Real}
     if x <= 0
         return (zero(FT), one(FT))
     elseif isinf(x)
@@ -95,7 +99,7 @@ end
 
     # factor = x^a * e^-x / Gamma(a)
     # Using loggamma for numerical stability
-    factor = exp(a * log(x) - x - SF.loggamma(a))
+    factor = exp(a * log(x) - x - lΓa)
     maxiters = FT === Float32 ? 20 : 30
 
     if x < a + 1
@@ -215,11 +219,14 @@ end
     # Halley's method
     # Use Q-q residual when p > 0.5 to avoid catastrophic cancellation
     use_q = p > FT(0.5)
+    # loggamma(a) is loop-invariant, so compute once and thread it into `_gamma_inc`
+    # and the derivative below (was recomputed ~2×/iteration, up to ~30×/call).
+    lΓa = SF.loggamma(a)
     for i in 1:15
-        P, Q = _gamma_inc(a, x)
+        P, Q = _gamma_inc(a, x, lΓa)
         f = use_q ? Q - q : P - p
         # Derivative: dP/dx = x^(a-1) e^-x / Gamma(a), dQ/dx = -dP/dx
-        fprime = exp((a - 1) * log(x) - x - SF.loggamma(a))
+        fprime = exp((a - 1) * log(x) - x - lΓa)
         # When using Q-q, the derivative is -fprime
         fprime = use_q ? -fprime : fprime
         if fprime == 0

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -274,8 +274,8 @@ end
 #   - `ϵ_numerics_P3_B` = eps(FT)                                — same, for the P3
 #     rime-volume (B_rim) variable.
 # The ~6 orders of magnitude gap reflects the different roles (underflow-avoiding
-# floor vs. relative-precision threshold), not an oversight. If a scheme needs a
-# different value, change it here rather than at the call sites.
+# floor vs. relative-precision threshold). If a scheme needs a different value, 
+# change it here rather than at the call sites.
 # ---------------------------------------------------------------------------
 
 """

--- a/src/parameters/Microphysics2M.jl
+++ b/src/parameters/Microphysics2M.jl
@@ -583,8 +583,8 @@ $(DocStringExtensions.FIELDS)
     a_vent_0_coeff::FT
     "pre-computed bv / 6^(β/2 - 1/2)"
     b_vent_0_coeff::FT
-    "pre-computed -1/2 + 3β/2"
-    β_va::FT
+    "pre-computed incomplete-gamma exponent for the 0th ventilation moment: -1/2 + 3β/2"
+    β_vent_0::FT
 end
 
 function EvaporationSB2006(td::CP.ParamDict)
@@ -602,8 +602,8 @@ function EvaporationSB2006(td::CP.ParamDict)
     b_vent_1 = bv * SF.gamma(FT(5 // 2) + FT(3 // 2) * β) / FT(6)^(β / 2 + FT(1 // 2))
     a_vent_0_coeff = av * cbrt(FT(36))
     b_vent_0_coeff = bv / FT(6)^(β / 2 - FT(0.5))
-    β_va = FT(-0.5) + FT(1.5) * β
-    return EvaporationSB2006(; parameters..., a_vent_1, b_vent_1, a_vent_0_coeff, b_vent_0_coeff, β_va)
+    β_vent_0 = FT(-0.5) + FT(1.5) * β
+    return EvaporationSB2006(; parameters..., a_vent_1, b_vent_1, a_vent_0_coeff, b_vent_0_coeff, β_vent_0)
 end
 
 """

--- a/src/parameters/Microphysics2M.jl
+++ b/src/parameters/Microphysics2M.jl
@@ -579,6 +579,12 @@ $(DocStringExtensions.FIELDS)
     a_vent_1::FT
     "pre-computed bv * Γ(5/2 + 3β/2) / 6^(β/2 + 1/2)"
     b_vent_1::FT
+    "pre-computed av * 6^(2/3) = av * cbrt(36)"
+    a_vent_0_coeff::FT
+    "pre-computed bv / 6^(β/2 - 1/2)"
+    b_vent_0_coeff::FT
+    "pre-computed -1/2 + 3β/2"
+    β_va::FT
 end
 
 function EvaporationSB2006(td::CP.ParamDict)
@@ -591,9 +597,13 @@ function EvaporationSB2006(td::CP.ParamDict)
     )
     parameters = CP.get_parameter_values(td, name_map, "CloudMicrophysics")
     (; av, bv, β) = parameters
-    a_vent_1 = av / cbrt(typeof(av)(6))
-    b_vent_1 = bv * SF.gamma(typeof(bv)(5 // 2) + typeof(bv)(3 // 2) * β) / typeof(bv)(6)^(β / 2 + typeof(bv)(1 // 2))
-    return EvaporationSB2006(; parameters..., a_vent_1, b_vent_1)
+    FT = typeof(av)
+    a_vent_1 = av / cbrt(FT(6))
+    b_vent_1 = bv * SF.gamma(FT(5 // 2) + FT(3 // 2) * β) / FT(6)^(β / 2 + FT(1 // 2))
+    a_vent_0_coeff = av * cbrt(FT(36))
+    b_vent_0_coeff = bv / FT(6)^(β / 2 - FT(0.5))
+    β_va = FT(-0.5) + FT(1.5) * β
+    return EvaporationSB2006(; parameters..., a_vent_1, b_vent_1, a_vent_0_coeff, b_vent_0_coeff, β_va)
 end
 
 """

--- a/src/parameters/Microphysics2MParams.jl
+++ b/src/parameters/Microphysics2MParams.jl
@@ -73,10 +73,13 @@ which constructs the parameterization with components:
     inp_depletion_model::INPDM = NIceProxyDepletion()
     "Number of quadrature nodes used for size-distribution integrals
     (deposition / sublimation, melting, riming, ice-rain collection,
-    sedimentation). Lower → faster, slightly less accurate. Default 100
-    matches the original P3 paper sensitivity studies; n_elem=128 KiD runs
-    show ~5× speed-up at qorder=40 with negligible bulk error."
-    quadrature_order::Int = 100
+    sedimentation). Lower → faster, slightly less accurate. Default 16
+    auto-selects Gauss-Legendre (see [`Quadrature.build_quadrature`](@ref)),
+    giving < 0.5% worst-case error vs a 200-node reference on the full P3
+    tendency vector. The `ice_self_collection` cusp (the historical accuracy
+    limiter) is now split at the |Δv|=0 diagonal, so this low node count
+    suffices; bump to 32 for < 0.2% if extra margin is wanted."
+    quadrature_order::Int = 16
     "Pre-constructed quadrature rule for the size-distribution integrals,
     built once (host-side) from `quadrature_order` via
     [`Quadrature.build_quadrature`](@ref) and reused in the (GPU) hot loop.
@@ -88,7 +91,7 @@ Base.show(io::IO, mime::MIME"text/plain", x::P3IceParams) =
     ShowMethods.verbose_show_type_and_fields(io, mime, x)
 
 P3IceParams(toml_dict::CP.ParamDict;
-    is_limited = true, quadrature_order::Int = 100,
+    is_limited = true, quadrature_order::Int = 16,
     inp_depletion_model = NIceProxyDepletion(τ_act = 300),
 ) = P3IceParams(;
     scheme = ParametersP3(toml_dict),
@@ -147,7 +150,7 @@ Create a `Microphysics2MParams` object from a ClimaParams TOML dictionary.
 """
 Microphysics2MParams(toml_dict::CP.ParamDict;
     with_ice = false, is_limited = true,
-    quadrature_order::Int = 100,
+    quadrature_order::Int = 16,
     inp_depletion_model = NIceProxyDepletion(τ_act = 300),
 ) = Microphysics2MParams(;
     # Warm rain parameters (always present)

--- a/test/gpu_performance.jl
+++ b/test/gpu_performance.jl
@@ -248,12 +248,12 @@ function run_gpu_performance_benchmarks(FT)
         ρ_rim = constant_data(FT(400.0); ndrange)
 
         kernel_p3! = benchmark_p3_kernel!(backend, work_groups)
-        t_compile_p3 = @elapsed kernel_p3!(p3_params, Ch2022, output, L_ice, N_ice, F_rim, ρ_rim, ρ; ndrange)
+        t_compile_p3 = @elapsed kernel_p3!(p3_params, Ch2022, output, L_ice, N_ice, F_rim, ρ_rim, ρ_arr; ndrange)
         KernelAbstractions.synchronize(backend)
         @info "P3 Kernel first call (compile + run time): $(round(t_compile_p3, digits=4)) seconds"
 
         b_p3 = BT.@benchmark (
-            $kernel_p3!($p3_params, $Ch2022, $output, $L_ice, $N_ice, $F_rim, $ρ_rim, $ρ; ndrange = $ndrange);
+            $kernel_p3!($p3_params, $Ch2022, $output, $L_ice, $N_ice, $F_rim, $ρ_rim, $ρ_arr; ndrange = $ndrange);
             KernelAbstractions.synchronize($backend)
         )
         @info "P3 Kernel runtime benchmark:" BT.minimum(b_p3)

--- a/test/gpu_performance.jl
+++ b/test/gpu_performance.jl
@@ -11,6 +11,8 @@ import ClimaParams as CP
 # Modules to test
 import CloudMicrophysics.Parameters as CMP
 import CloudMicrophysics.ThermodynamicsInterface as TDI
+const TD = TDI.TD
+import Random
 import CloudMicrophysics.AerosolModel as AM
 import CloudMicrophysics.AerosolActivation as AA
 import CloudMicrophysics.Common as CO
@@ -34,28 +36,24 @@ else
     @info "No CUDA GPU found. GPU Performance Tests running on CPU fallback via KernelAbstractions" backend ArrayType
 end
 
-@kernel inbounds = true function benchmark_1m_accretion_kernel!(
-    lcl, rain, icl, snow, e_lr, e_is, e_ls, e_ir, e_rs, coeff_disp, blk1mvel, output, ρ, qi, qs, ql, qr,
+@kernel inbounds = true function benchmark_1m_bulk_tendencies_kernel!(
+    mp, tps, output, ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno,
 )
     i = @index(Global, Linear)
-    liq_rai = CM1.accretion(lcl, rain, blk1mvel.rain, e_lr, ql[i], qr[i], ρ[i])
-    ice_sno = CM1.accretion(icl, snow, blk1mvel.snow, e_is, qi[i], qs[i], ρ[i])
-    liq_sno = CM1.accretion(lcl, snow, blk1mvel.snow, e_ls, ql[i], qs[i], ρ[i])
-    ice_rai = CM1.accretion(icl, rain, blk1mvel.rain, e_ir, qi[i], qr[i], ρ[i])
-    sno_rai = CM1.accretion_snow_rain(
-        snow, rain, blk1mvel.snow, blk1mvel.rain, e_rs, coeff_disp, qs[i], qr[i], ρ[i],
+    output[i] = BMT.bulk_microphysics_tendencies(
+        BMT.Instantaneous(), BMT.Microphysics1Moment(), mp, tps,
+        ρ[i], T[i], q_tot[i], q_lcl[i], q_icl[i], q_rai[i], q_sno[i],
     )
-    output[i] = (; liq_rai, ice_sno, liq_sno, ice_rai, sno_rai)
 end
 
-@kernel inbounds = true function benchmark_2m_kernel!(
-    KK2000, B1994, TC1980, LD2004, output, ql, qr, ρ, Nd,
+@kernel inbounds = true function benchmark_2m_bulk_tendencies_kernel!(
+    mp, tps, output, ρ, T, q_tot, q_lcl, q_rai, n_lcl, n_rai,
 )
     i = @index(Global, Linear)
-    S_LD2004 = CM2.conv_q_lcl_to_q_rai(LD2004, ql[i], ρ[i], Nd[i])
-    S_KK2000 = CM2.accretion(KK2000, ql[i], qr[i], ρ[i])
-    S_B1994 = CM2.accretion(B1994, ql[i], qr[i], ρ[i])
-    output[i] = (; S_LD2004, S_KK2000, S_B1994)
+    output[i] = BMT.bulk_microphysics_tendencies(
+        BMT.Microphysics2Moment(), mp, tps,
+        ρ[i], T[i], q_tot[i], q_lcl[i], n_lcl[i], q_rai[i], n_rai[i],
+    )
 end
 
 @kernel inbounds = true function benchmark_p3_kernel!(
@@ -77,6 +75,64 @@ end
 function constant_data(value; ndrange)
     FT = eltype(value)
     return fill!(allocate(backend, FT, ndrange), value)
+end
+
+function generate_atmospheric_states(N_states, FT, tps)
+    # Construct realistic atmospheric states using DecayingTemperatureProfile
+    z_arr = FT.(range(0, 15000, length = N_states))
+    profile = TD.TemperatureProfiles.DecayingTemperatureProfile{FT}(tps, FT(300), FT(215))
+    RH_arr = FT.(range(0.05, 1.05, length = N_states))
+    rng = Random.MersenneTwister(1234)
+
+    T_vec = Vector{FT}(undef, N_states)
+    ρ_vec = Vector{FT}(undef, N_states)
+    q_tot_vec = Vector{FT}(undef, N_states)
+    q_lcl_vec = Vector{FT}(undef, N_states)
+    q_icl_vec = Vector{FT}(undef, N_states)
+    q_rai_vec = Vector{FT}(undef, N_states)
+    q_sno_vec = Vector{FT}(undef, N_states)
+
+    for i in 1:N_states
+        T, p = profile(tps, z_arr[i])
+        T_vec[i] = T
+        RH = RH_arr[i]
+
+        q_vap = TD.q_vap_from_RH(tps, p, T, RH, TD.Liquid())
+        ρ = TD.air_density(tps, T, p, q_vap, zero(FT), zero(FT))
+        ρ_vec[i] = ρ
+
+        q_sat_liq = TD.q_vap_saturation(tps, T, ρ, TD.Liquid())
+        q_sat_ice = TD.q_vap_saturation(tps, T, ρ, TD.Ice())
+
+        # Construct liquid and ice condensates from supersaturation + random noise
+        excess_liq = max(zero(FT), q_vap - q_sat_liq)
+        excess_ice = max(zero(FT), q_vap - q_sat_ice)
+
+        noise_lcl = FT(rand(rng, FT) * 1e-4)
+        noise_icl = FT(rand(rng, FT) * 1e-4)
+        noise_rai = FT(rand(rng, FT) * 1e-4)
+        noise_sno = FT(rand(rng, FT) * 1e-4)
+
+        q_lcl = excess_liq + noise_lcl
+        q_icl = excess_ice + noise_icl
+
+        q_lcl_vec[i] = q_lcl
+        q_icl_vec[i] = q_icl
+        q_rai_vec[i] = noise_rai
+        q_sno_vec[i] = noise_sno
+
+        q_tot_vec[i] = q_vap + q_lcl + q_icl + noise_rai + noise_sno
+    end
+
+    return (
+        T = ArrayType(T_vec),
+        ρ = ArrayType(ρ_vec),
+        q_tot = ArrayType(q_tot_vec),
+        q_lcl = ArrayType(q_lcl_vec),
+        q_icl = ArrayType(q_icl_vec),
+        q_rai = ArrayType(q_rai_vec),
+        q_sno = ArrayType(q_sno_vec),
+    )
 end
 
 function run_gpu_performance_benchmarks(FT)
@@ -116,110 +172,76 @@ function run_gpu_performance_benchmarks(FT)
         @info "gamma_inc_inv benchmark (SF vs UT):" SF=BT.minimum(b_inv_sf) UT=BT.minimum(b_inv_ut)
     end
 
-    # 2. Kernel Benchmarks (1-Moment, 2-Moment, P3)
+    # 2. Kernel Benchmarks (1-Moment BMT, 2-Moment BMT, P3)
     TT.@testset "Kernel Performance & Compile Time ($FT)" begin
-        # 1-Moment setup
-        lcl = CMP.CloudLiquid(FT)
-        icl = CMP.CloudIce(FT)
-        rain = CMP.Rain(FT)
-        snow = CMP.Snow(FT)
-        mp = CMP.Microphysics1MParams(FT)
-        opts = mp.options
-        e_lr = opts.cloud_liquid_rain_accretion.e
-        e_is = opts.cloud_ice_snow_accretion.e
-        e_ls = opts.cloud_liquid_snow_accretion.e
-        e_ir = opts.cloud_ice_rain_accretion.e
-        e_rs = opts.rain_snow_accretion.e
-        coeff_disp = opts.rain_snow_accretion.coeff_disp
-        blk1mvel = CMP.Blk1MVelType(FT)
+        tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
+        N_states = 1024
+        states = generate_atmospheric_states(N_states, FT, tps)
 
-        DT1 = @NamedTuple{liq_rai::FT, ice_sno::FT, liq_sno::FT, ice_rai::FT, sno_rai::FT}
-        (; output, ndrange) = setup_output(1000, DT1)
-        ρ = constant_data(FT(1.2); ndrange)
-        qi = constant_data(FT(5e-4); ndrange)
-        qs = constant_data(FT(5e-4); ndrange)
-        ql = constant_data(FT(5e-4); ndrange)
-        qr = constant_data(FT(5e-4); ndrange)
+        # 1-Moment Bulk Tendencies setup (realistic atmospheric states)
+        mp_bulk = CMP.Microphysics1MParams(FT)
+        DT_bulk = @NamedTuple{dq_lcl_dt::FT, dq_icl_dt::FT, dq_rai_dt::FT, dq_sno_dt::FT}
+        (; output, ndrange) = setup_output(N_states, DT_bulk)
 
-        kernel_1m! = benchmark_1m_accretion_kernel!(backend, work_groups)
+        T_arr = states.T
+        ρ_arr = states.ρ
+        q_tot_arr = states.q_tot
+        q_lcl_arr = states.q_lcl
+        q_icl_arr = states.q_icl
+        q_rai_arr = states.q_rai
+        q_sno_arr = states.q_sno
 
-        # Measure compile time (first execution)
-        t_compile_1m = @elapsed kernel_1m!(
-            lcl,
-            rain,
-            icl,
-            snow,
-            e_lr,
-            e_is,
-            e_ls,
-            e_ir,
-            e_rs,
-            coeff_disp,
-            blk1mvel,
-            output,
-            ρ,
-            qi,
-            qs,
-            ql,
-            qr;
-            ndrange,
+        kernel_1m_bulk! = benchmark_1m_bulk_tendencies_kernel!(backend, work_groups)
+        t_compile_1m_bulk = @elapsed kernel_1m_bulk!(
+            mp_bulk, tps, output, ρ_arr, T_arr, q_tot_arr, q_lcl_arr, q_icl_arr, q_rai_arr, q_sno_arr; ndrange,
         )
         KernelAbstractions.synchronize(backend)
-        @info "1-Moment Accretion Kernel first call (compile + run time): $(round(t_compile_1m, digits=4)) seconds"
+        @info "1-Moment Bulk Tendencies Kernel first call (compile + run time): $(round(t_compile_1m_bulk, digits=4)) seconds"
 
-        b_1m = BT.@benchmark (
-            $kernel_1m!(
-                $lcl,
-                $rain,
-                $icl,
-                $snow,
-                $e_lr,
-                $e_is,
-                $e_ls,
-                $e_ir,
-                $e_rs,
-                $coeff_disp,
-                $blk1mvel,
-                $output,
-                $ρ,
-                $qi,
-                $qs,
-                $ql,
-                $qr;
+        b_1m_bulk = BT.@benchmark (
+            $kernel_1m_bulk!(
+                $mp_bulk, $tps, $output, $ρ_arr, $T_arr, $q_tot_arr, $q_lcl_arr, $q_icl_arr, $q_rai_arr, $q_sno_arr;
                 ndrange = $ndrange,
             );
             KernelAbstractions.synchronize($backend)
         )
-        @info "1-Moment Accretion Kernel runtime benchmark:" BT.minimum(b_1m)
+        @info "1-Moment Bulk Tendencies Kernel runtime benchmark:" BT.minimum(b_1m_bulk)
 
-        # 2-Moment setup
-        KK2000 = CMP.KK2000(FT)
-        B1994 = CMP.B1994(FT)
-        TC1980 = CMP.TC1980(FT)
-        LD2004 = CMP.LD2004(FT)
+        # 2-Moment Bulk Tendencies setup (warm rain only, realistic atmospheric states)
+        mp_2m = CMP.Microphysics2MParams(FT)
+        DT_2m_bulk = @NamedTuple{
+            dq_lcl_dt::FT, dn_lcl_dt::FT, dq_rai_dt::FT, dn_rai_dt::FT,
+            dq_ice_dt::FT, dq_rim_dt::FT, db_rim_dt::FT, dn_lcl_activation_dt::FT,
+        }
+        (; output, ndrange) = setup_output(N_states, DT_2m_bulk)
 
-        DT2 = @NamedTuple{S_LD2004::FT, S_KK2000::FT, S_B1994::FT}
-        (; output, ndrange) = setup_output(1000, DT2)
-        Nd = constant_data(FT(1e8); ndrange)
+        # Realistic number concentrations for cloud and rain
+        n_lcl_arr = constant_data(FT(1e8); ndrange)   # typical cloud droplet number
+        n_rai_arr = constant_data(FT(1e4); ndrange)   # typical raindrop number
 
-        kernel_2m! = benchmark_2m_kernel!(backend, work_groups)
-        t_compile_2m = @elapsed kernel_2m!(KK2000, B1994, TC1980, LD2004, output, ql, qr, ρ, Nd; ndrange)
+        kernel_2m_bulk! = benchmark_2m_bulk_tendencies_kernel!(backend, work_groups)
+        t_compile_2m_bulk = @elapsed kernel_2m_bulk!(
+            mp_2m, tps, output, ρ_arr, T_arr, q_tot_arr, q_lcl_arr, q_rai_arr, n_lcl_arr, n_rai_arr; ndrange,
+        )
         KernelAbstractions.synchronize(backend)
-        @info "2-Moment Kernel first call (compile + run time): $(round(t_compile_2m, digits=4)) seconds"
+        @info "2-Moment Bulk Tendencies Kernel first call (compile + run time): $(round(t_compile_2m_bulk, digits=4)) seconds"
 
-        b_2m = BT.@benchmark (
-            $kernel_2m!($KK2000, $B1994, $TC1980, $LD2004, $output, $ql, $qr, $ρ, $Nd; ndrange = $ndrange);
+        b_2m_bulk = BT.@benchmark (
+            $kernel_2m_bulk!(
+                $mp_2m, $tps, $output, $ρ_arr, $T_arr, $q_tot_arr, $q_lcl_arr, $q_rai_arr, $n_lcl_arr, $n_rai_arr;
+                ndrange = $ndrange,
+            );
             KernelAbstractions.synchronize($backend)
         )
-        @info "2-Moment Kernel runtime benchmark:" BT.minimum(b_2m)
+        @info "2-Moment Bulk Tendencies Kernel runtime benchmark:" BT.minimum(b_2m_bulk)
 
         # P3 setup
         p3_params = CMP.ParametersP3(FT)
         Ch2022 = CMP.Chen2022VelType(FT)
 
         DT3 = @NamedTuple{logλ::FT, sc::@NamedTuple{dNdt::FT}}
-        (; output, ndrange) = setup_output(1000, DT3)
-        L_ice = constant_data(FT(5e-4 * 1.2); ndrange)
+        (; output, ndrange) = setup_output(N_states, DT3)
+        L_ice = ArrayType(states.ρ .* states.q_icl)
 
         N_ice = constant_data(FT(1e8 * 1.2); ndrange)
         F_rim = constant_data(FT(0.95); ndrange)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

Improve GPU performance of 1M, 2M, and P3 microphysics by removing branches and reducing transcendental function calls (e.g., inside quadratures and other hot paths).

## Changes
- **1M / NonEq**: replace `if q > ϵ` guards with branchless `ifelse`; simplify `lambda_inverse`; compute the shared size-distribution quantities (λ⁻¹, n₀, v₀ for rain/snow/ice) once per cell and thread them via an `sd` argument instead of recomputing per process.
- **2M**: branchless SB2006 rates and terminal velocities; compute `cbrt(Sc)` / `sqrt(Re)` once in rain evaporation.
- **P3**: fuse the Chen velocity `D^b·exp(-c·D)` into one `exp`; `ϕᵢ`: `aᵢ^1.5 → aᵢ·√aᵢ`; hoist `loggamma` out of the `gamma_inc_inv` loop; add a μ=1 fast-path quantile; split `ice_self_collection` at the `|Δv|=0` cusp; lower the `quadrature_order` default **100 → 16** (auto-selects Gauss-Legendre).
- **Replace rational exponents** by `FT`.  This is an important lesson for our code stack: Internally, for an expression such as `x::Float32 ^ (-2 // 3)`, Julia constructs a `Rational{Int64}` struct on the GPU thread's local stack. To do so, it runs a 64-bit integer Greatest Common Divisor (`divgcd`) routine along with 64-bit overflow checks on the GPU. Then it lowers numerator and denominator to f32 and computes the power--all in all, with a massive overhead. (**Changing the rational exponents alone achieved ~7x speedup for 2M.**)

## Results

## GPU Performance: `main` (27bbdeb1) vs `ts/cmp-gpu-opt` (b0e306f5) [based on array of 1024 CMP evaluations in `test/gpu_performance.jl']
| Microphysics Kernel | Precision | `main` Runtime | `ts/cmp-gpu-opt` Runtime | Speedup vs `main` |
|:---|:---|---:|---:|:---|
| **1-Moment Bulk Tendencies** | Float64 | 261.2 μs (83 allocs) | 57.5 μs (43 allocs) | **4.54×** |
| | Float32 | 51.9 μs (45 allocs) | 31.3 μs (42 allocs) | **1.66×** |
| **2-Moment Bulk Tendencies** | Float64 | 1,947.0 μs (298 allocs) | 43.6 μs (48 allocs) | **44.6×** |
| | Float32 | 1,713.0 μs (298 allocs) | 29.9 μs (41 allocs) | **57.3×** |
| **P3 Ice Microphysics** | Float64 | 127.3 ms (294 allocs) | 101.2 ms (294 allocs) | **1.26×** |
| | Float32 | 45.4 ms (294 allocs) | 46.8 ms (294 allocs) | 0.97× |

* All allocations are CPU-side kernel launch tracking overhead from KernelAbstractions/CUDA.jl
* ~6% speedup of 1M bulk microphysics comes from branch removal (at f32 on GPU); most of the rest from caching special function evaluations. 
* A factor 7 of the 2M speedup comes from replacing rational exponents.