### PR TITLE
Use the Frostenberg 2023 `a` and `b` coefficients in `INP_concentration_mean`

### DIFF
--- a/src/IceNucleation.jl
+++ b/src/IceNucleation.jl
@@ -231,19 +231,25 @@ Calculate the mean log(INPC) as a function of temperature.
 # Arguments
   - `params`: The [`CMP.Frostenberg2023`](@ref) INPC(T) distribution parameters, including
     + `T_freeze`: freezing temperature [K]
+    + `a`: INPC normalization coefficient [m³]
+    + `b`: temperature normalization coefficient [°C⁻¹]
   - `T`: air temperature [K]
 
-The mean `log(INPC)` is given by:
+Following Eq. (1) of [Frostenberg2023](@cite), `log(a · INPC)` is normally
+distributed with mean `μ(T) = log(-(b · T_celsius / 10)^9)`, so the mean
+`log(INPC)` returned here is
 ```
-μ(T) = log(-(T_celsius / 10)^9)
+μ(T) - log(a) = 9 log(-b · T_celsius / 10) - log(a)
 ```
-with the corresponding INPC obtained by exponentiating: `exp(μ(T))`.
+with the corresponding INPC obtained by exponentiating. The parameters `a` and
+`b` are read from `ClimaParams`; at their defaults `a = b = 1` this reduces to
+the marine-dataset curve `log((-T_celsius / 10)^9)`.
 
 For details see: [Frostenberg2023](@cite), doi.org/10.5194/acp-23-10883-2023
 """
-function INP_concentration_mean((; T_freeze)::CMP.Frostenberg2023, T)
+function INP_concentration_mean((; T_freeze, a, b)::CMP.Frostenberg2023, T)
     T_celsius = min(T - T_freeze, 0)
-    return 9log(-T_celsius / 10)  # = log((-T_celsius / 10)^9)
+    return 9log(-b * T_celsius / 10) - log(a)  # = log((-b * T_celsius / 10)^9) - log(a)
 end
 
 """

--- a/src/IceNucleation.jl
+++ b/src/IceNucleation.jl
@@ -231,8 +231,8 @@ Calculate the mean log(INPC) as a function of temperature.
 # Arguments
   - `params`: The [`CMP.Frostenberg2023`](@ref) INPC(T) distribution parameters, including
     + `T_freeze`: freezing temperature [K]
-    + `a`: INPC normalization coefficient [m³]
     + `b`: temperature normalization coefficient [°C⁻¹]
+    + `log_a`: log of the INPC normalization coefficient `a` [m³]
   - `T`: air temperature [K]
 
 Following Eq. (1) of [Frostenberg2023](@cite), `log(a · INPC)` is normally
@@ -247,9 +247,9 @@ the marine-dataset curve `log((-T_celsius / 10)^9)`.
 
 For details see: [Frostenberg2023](@cite), doi.org/10.5194/acp-23-10883-2023
 """
-function INP_concentration_mean((; T_freeze, a, b)::CMP.Frostenberg2023, T)
+function INP_concentration_mean((; T_freeze, b, log_a)::CMP.Frostenberg2023, T)
     T_celsius = min(T - T_freeze, 0)
-    return 9log(-b * T_celsius / 10) - log(a)  # = log((-b * T_celsius / 10)^9) - log(a)
+    return 9log(-b * T_celsius / 10) - log_a  # = log((-b * T_celsius / 10)^9) - log(a)
 end
 
 """

--- a/src/parameters/IceNucleation.jl
+++ b/src/parameters/IceNucleation.jl
@@ -184,6 +184,8 @@ $(DocStringExtensions.FIELDS)
     b::FT
     "freezing temperature [K]"
     T_freeze::FT
+    "log of the coefficient `a`"
+    log_a::FT = log(a)
 end
 
 function Frostenberg2023(td::CP.ParamDict)

--- a/test/heterogeneous_ice_nucleation_tests.jl
+++ b/test/heterogeneous_ice_nucleation_tests.jl
@@ -243,6 +243,41 @@ function test_heterogeneous_ice_nucleation(FT)
         ) == FT(0)
     end
 
+    TT.@testset "Frostenberg a/b coefficients" begin
+
+        # a and b are the calibratable coefficients of Eq. (1) and must actually
+        # enter the mean (regression: they were previously ignored, so the mean
+        # was independent of a and b).
+        T_cold = ip_frostenberg.T_freeze - FT(20)
+        μ_default = CMI_het.INP_concentration_mean(ip_frostenberg, T_cold)
+
+        # at the a = b = 1 defaults we recover the marine-dataset curve
+        T_celsius = min(T_cold - ip_frostenberg.T_freeze, FT(0))
+        TT.@test μ_default ≈ log((-T_celsius / 10)^9)
+
+        # a rescales INPC (log(a · INPC) is the normal variate), so the mean
+        # log(INPC) shifts by -log(a)
+        ip_a = CMP.Frostenberg2023{FT}(;
+            σ = ip_frostenberg.σ,
+            a = FT(2),
+            b = ip_frostenberg.b,
+            T_freeze = ip_frostenberg.T_freeze,
+        )
+        TT.@test CMI_het.INP_concentration_mean(ip_a, T_cold) ≈
+                 μ_default - log(FT(2))
+
+        # b rescales the (negative) temperature argument, shifting the mean by
+        # +9 log(b)
+        ip_b = CMP.Frostenberg2023{FT}(;
+            σ = ip_frostenberg.σ,
+            a = ip_frostenberg.a,
+            b = FT(2),
+            T_freeze = ip_frostenberg.T_freeze,
+        )
+        TT.@test CMI_het.INP_concentration_mean(ip_b, T_cold) ≈
+                 μ_default + 9 * log(FT(2))
+    end
+
     TT.@testset "F23 immersion limit rate" begin
 
         T_freeze = ip_frostenberg.T_freeze

--- a/test/heterogeneous_ice_nucleation_tests.jl
+++ b/test/heterogeneous_ice_nucleation_tests.jl
@@ -245,18 +245,14 @@ function test_heterogeneous_ice_nucleation(FT)
 
     TT.@testset "Frostenberg a/b coefficients" begin
 
-        # a and b are the calibratable coefficients of Eq. (1) and must actually
-        # enter the mean (regression: they were previously ignored, so the mean
-        # was independent of a and b).
+        # T_celsius = -20
         T_cold = ip_frostenberg.T_freeze - FT(20)
-        μ_default = CMI_het.INP_concentration_mean(ip_frostenberg, T_cold)
 
-        # at the a = b = 1 defaults we recover the marine-dataset curve
-        T_celsius = min(T_cold - ip_frostenberg.T_freeze, FT(0))
-        TT.@test μ_default ≈ log((-T_celsius / 10)^9)
+        # a = b = 1 defaults
+        TT.@test CMI_het.INP_concentration_mean(ip_frostenberg, T_cold) ≈
+                 FT(6.238324625039508)
 
-        # a rescales INPC (log(a · INPC) is the normal variate), so the mean
-        # log(INPC) shifts by -log(a)
+        # a shifts the mean by -log(a)
         ip_a = CMP.Frostenberg2023{FT}(;
             σ = ip_frostenberg.σ,
             a = FT(2),
@@ -264,10 +260,9 @@ function test_heterogeneous_ice_nucleation(FT)
             T_freeze = ip_frostenberg.T_freeze,
         )
         TT.@test CMI_het.INP_concentration_mean(ip_a, T_cold) ≈
-                 μ_default - log(FT(2))
+                 FT(5.545177444479562)
 
-        # b rescales the (negative) temperature argument, shifting the mean by
-        # +9 log(b)
+        # b shifts the mean by +9 log(b)
         ip_b = CMP.Frostenberg2023{FT}(;
             σ = ip_frostenberg.σ,
             a = ip_frostenberg.a,
@@ -275,7 +270,7 @@ function test_heterogeneous_ice_nucleation(FT)
             T_freeze = ip_frostenberg.T_freeze,
         )
         TT.@test CMI_het.INP_concentration_mean(ip_b, T_cold) ≈
-                 μ_default + 9 * log(FT(2))
+                 FT(12.476649250079015)
     end
 
     TT.@testset "F23 immersion limit rate" begin


### PR DESCRIPTION
## Summary

`INP_concentration_mean` for the `Frostenberg2023` immersion-freezing scheme
ignores the distribution's `a` and `b` coefficients — even though the struct
stores them, the constructor reads them from `ClimaParams`
(`Frostenberg2023_a_coefficient`, `Frostenberg2023_b_coefficient`), and the
docs describe them as the coefficients of Eq. (1). The marine-dataset curve is
effectively hardcoded, so `a` and `b` are dead knobs: setting them in
`ClimaParams` (e.g. to calibrate the INP curve) is a silent no-op.

```julia
# before — a, b never read
function INP_concentration_mean((; T_freeze)::CMP.Frostenberg2023, T)
    T_celsius = min(T - T_freeze, 0)
    return 9log(-T_celsius / 10)
end
```

## Fix

Implement Eq. (1) of [Frostenberg et al. (2023)](https://doi.org/10.5194/acp-23-10883-2023),
where `log(a · INPC)` is normally distributed with mean
`μ(T) = log(-(b · T_c / 10)^9)`. The mean `log(INPC)` this function returns is
therefore `μ(T) - log(a) = 9 log(-b · T_c / 10) - log(a)`.

```julia
function INP_concentration_mean((; T_freeze, a, b)::CMP.Frostenberg2023, T)
    T_celsius = min(T - T_freeze, 0)
    return 9log(-b * T_celsius / 10) - log(a)
end
```

At the defaults `a = 1 m³`, `b = 1 °C⁻¹` this reduces **exactly** to the
existing curve `log((-T_c / 10)^9)`, so default behavior is unchanged. The
change matches the equation already given in `docs/src/IceNucleation.md`, which
documented `a`/`b` ahead of the implementation.

## Relationship to `inpc_log_shift`

`immersion_limit_rate` already accepts an additive `inpc_log_shift`. That knob
overlaps with the `-log(a)` term but is temperature-independent, so it cannot
reach the slope coefficient `b`; this change restores the paper's own `a`/`b`
and composes cleanly with `inpc_log_shift`.

## Tests

Added a `Frostenberg a/b coefficients` testset asserting the mean shifts by
`-log(a)` and `+9 log(b)` and recovers the marine-dataset curve at the
defaults. This fails on `main` (where the mean is independent of `a` and `b`)
and passes with this change.
