### PR TITLE
Pin JuliaFormatter to v2.10.1

### DIFF
--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
       - uses: julia-actions/julia-format@v4
         with:
-          version: '2'
+          version: '2.10.1'
           suggestion-label: 'format-suggest' # leave this unset or empty to show suggestions for all PRs


### PR DESCRIPTION
This PR pins JuliaFormatter to v2.10.1. This is recommended by https://juliaeditorsupport.github.io/JuliaFormatter.jl/stable/status/#Pinning-the-JuliaFormatter-version.