### PR TITLE
fix(P3): correct the Cober-List impact-factor sign in the local rime density

### DIFF
--- a/src/P3_processes.jl
+++ b/src/P3_processes.jl
@@ -238,10 +238,10 @@ A function that computes the local rime density [kg/m³] using the equation:
 ```
 where
 ```math
-R_i = \\frac{ 10^6 ⋅ D_{liq} ⋅ |v_{liq} - v_{ice}| }{ 2 T_{sfc} }
+R_i = -\\frac{ 10^6 ⋅ D_{liq} ⋅ |v_{liq} - v_{ice}| }{ 2 T_{sfc} }
 ```
-and ``T_{sfc}`` is the surface temperature [°C], ``D_{liq}`` is the liquid particle
-diameter [m], ``v_{liq/ice}`` is the particle terminal velocity [m/s].
+and ``T_{sfc} < 0`` is the sub-zero surface temperature [°C], ``D_{liq}`` is the liquid
+particle diameter [m], ``v_{liq/ice}`` is the particle terminal velocity [m/s].
 So the units of ``R_i`` are [m² s⁻¹ °C⁻¹]. The units of ``ρ'_{rim}`` are [kg/m³].
 
 We assume for simplicity that ``T_{sfc}`` equals ``T``, the ambient air temperature.
@@ -257,6 +257,8 @@ See also [`LocalRimeDensity`](@ref CloudMicrophysics.Parameters.LocalRimeDensity
  See also the P3 fortran code, `microphy_p3.f90`, Line 3315-3323,
  which extends the range of the calculation to ``R_i ≤ 12``, the upper limit of which
  then equals the solid bulk ice density, ``ρ_ice = 916.7 kg/m^3``.
+ The sub-zero bound on ``T_{sfc}`` also follows the fortran code, Line 3380
+ (`iTc = 1/min(-0.001, Tc)`).
 
  Note that Morrison & Milbrandt (2015) [MorrisonMilbrandt2015](@cite) only uses this
  parameterization for collisions with cloud droplets.
@@ -265,14 +267,15 @@ See also [`LocalRimeDensity`](@ref CloudMicrophysics.Parameters.LocalRimeDensity
 """
 function compute_local_rime_density(velocity_params, ρₐ, T, state)
     (; T_freeze, ρ_rim_local) = state.params
-    T°C = T - T_freeze  # Convert to °C
-    μm = 1_000_000  # Note: m to μm factor, c.f. units of rₘ in Eq. 16 in Cober and List (1993)
+    # Sub-zero surface temperature [°C], bounded strictly below 0°C
+    T°C = min(T - T_freeze, -oftype(T_freeze, 1e-3))
+    μm = 1_000_000  # m to μm factor, c.f. units of rₘ in Eq. 16 in Cober and List (1993)
 
     v_ice = ice_particle_terminal_velocity(velocity_params, ρₐ, state)
     v_liq = CO.particle_terminal_velocity(velocity_params.rain, ρₐ)
     function ρ′_rim(Dᵢ, Dₗ)
         v_term = abs(v_ice(Dᵢ) - v_liq(Dₗ))
-        Rᵢ = (Dₗ * μm * v_term) / (2 * T°C)  # Eq. 16 in Cober and List (1993). Note: no `-` due to absolute value in v_term
+        Rᵢ = -(Dₗ * μm * v_term) / (2 * T°C)  # Eq. 16 in Cober and List (1993)
         return ρ_rim_local(Rᵢ)
     end
     return ρ′_rim

--- a/test/p3_tests.jl
+++ b/test/p3_tests.jl
@@ -711,19 +711,36 @@ function test_p3_bulk_liquid_ice_collisions(FT)
     end
 
     @testset "local rime density" begin
-        Tₐ = T_freeze - 1 // 10
-        ρ′_rim_func = P3.compute_local_rime_density(vel_params, ρₐ, Tₐ, state)
-        @test ρ′_rim_func(D̄, D̄) ≈ FT(159.5) rtol = 1e-6
-
         a, b, c = 51, 114, -11 // 2 # coeffs for Eq. 17 in Cober and List (1993), converted to [kg / m³]
         ρ′_rim_CL93(Rᵢ) = a + b * Rᵢ + c * Rᵢ^2  # Eq. 17 in Cober and List (1993), in [kg / m³], valid for 1 ≤ Rᵢ ≤ 8
         ρ_ice = FT(916.7)  # density of solid bulk ice
-
         ρ_rim_local = params.ρ_rim_local
 
         @test ρ_rim_local(1) == ρ′_rim_CL93(1)
+        @test ρ_rim_local(2) == ρ′_rim_CL93(2)
+        @test ρ_rim_local(4) == ρ′_rim_CL93(4)
+        @test ρ_rim_local(6) == ρ′_rim_CL93(6)
         @test ρ_rim_local(8) == ρ′_rim_CL93(8)
+        @test ρ_rim_local(10) ≈ (ρ′_rim_CL93(8) + ρ_ice) / 2  # linear interpolation, 8 < Rᵢ ≤ 12
         @test ρ_rim_local(12) == ρ_ice
+        @test ρ_rim_local(0) == ρ′_rim_CL93(1)   # Rᵢ clamped to [1, 12]
+        @test ρ_rim_local(-5) == ρ′_rim_CL93(1)
+        @test ρ_rim_local(20) == ρ_ice
+
+        # Subfreezing Rᵢ is positive, so ρ′_rim densifies toward ρ_ice as T → T_freeze
+        Dₗ = FT(200e-6)
+        ρ′_rim(T) = P3.compute_local_rime_density(vel_params, ρₐ, FT(T), state)(D̄, Dₗ)
+        ρ_subfreezing = ρ′_rim.((240, 250, 260, 265, 270))
+        @test issorted(ρ_subfreezing)   # densifies toward ρ_ice as T → T_freeze
+        @test all(ρ_subfreezing .≥ ρ′_rim_CL93(1))
+        @test all(ρ_subfreezing .≤ ρ_ice)
+        @test ρ′_rim(240) ≈ FT(294.188) rtol = 1e-4
+
+        # At and above T_freeze, T°C bounded below 0 ⟹ Rᵢ → clamp(12) → ρ_ice; finite, no NaN
+        for T in (T_freeze, T_freeze + 1 // 10, T_freeze + 5)
+            @test ρ′_rim(T) ≈ ρ_ice
+        end
+        @test !isnan(P3.compute_local_rime_density(vel_params, ρₐ, T_freeze, state)(D̄, D̄))
     end
 
     @testset "∫liquid_ice_collisions" begin
@@ -866,8 +883,8 @@ function test_p3_bulk_liquid_ice_collisions(FT)
         @test QRSHD ≈ 3.6744506329509328e-6 rtol = 5e-4
         @test NRCOL ≈ 172.65740739140853 rtol = 5e-4
         @test ∫M_col ≈ 7.069157000967575e-5 rtol = 5e-4
-        @test BCCOL ≈ 3.726612278745525e-9 rtol = 5e-4
-        @test BRCOL ≈ 4.163318251255413e-7 rtol = 5e-4
+        @test BCCOL ≈ 3.508183075042488e-9 rtol = 5e-4
+        @test BRCOL ≈ 7.244274484995898e-8 rtol = 5e-4
         @test ∫𝟙_wet_M_col ≈ 1.3659847784932352e-5 rtol = 5e-4
 
         ### Test the bulk source function


### PR DESCRIPTION
`compute_local_rime_density` divides the Cober and List (1993) Eq. 16 impact factor by the signed Celsius temperature. Every subfreezing temperature therefore produced a negative impact factor, the `[1, 12]` range clamp pinned it at 1, and the local rime density was a constant 159.5 kg/m3 at all temperatures. The parameterization was effectively inert: rime never densified toward the solid-ice limit approaching the freezing point, and all rime-volume (`B_rim`) sources used floor-density rime.

The fix follows the Cober and List convention with the sub-zero surface temperature bounded strictly below 0 C, `min(T - T_freeze, -1e-3)`, matching the P3 fortran code (`microphy_p3.f90`, `iTc = 1/min(-0.001, Tc)`), and applies the sign so the impact factor is positive for subfreezing temperatures.

Impact: at the collision smoke-test state, `BCCOL` decreases by ~6% and `BRCOL` by a factor of ~5.7 (large raindrops now produce near-solid rime instead of floor-density rime). The local rime density at fixed sizes now ranges from ~294 kg/m3 at 240 K to the solid-ice limit approaching the freezing point, instead of a constant 159.5 kg/m3. Downstream, this changes the `B_rim` sources and hence the predicted rime density `rho_rim`.

Semantics at and above the freezing point (flagged for review): the temperature bound makes the impact factor large, so the clamp returns the solid-ice density. Collisions are evaluated in melt regimes too, and this choice keeps the function finite and monotone there; alternatives (e.g. reusing the 400 kg/m3 default) are possible if preferred.

Tests: interior Cober-List polynomial values, clamp limits, subfreezing densification monotonicity, a pinned value at 240 K, and the freezing-point edge. The two rime-volume smoke-test references are updated to the corrected values; all other collision outputs are unchanged, as expected since only the `B_rim` components depend on the local rime density.