### PR TITLE
Add deprecations to avoid breaking interface

### DIFF
--- a/docs/src/plots/Microphysics1M_plots.jl
+++ b/docs/src/plots/Microphysics1M_plots.jl
@@ -75,14 +75,14 @@ q_icl_to_q_sno_rate = function (T)
     map(q_icl_range) do q_icl
         micro = (; q_tot, q_lcl = FT(0), q_icl, q_rai, q_sno)
         thermo = (; ρ = ρ_air, T)
-        CM1.conv_q_icl_to_q_sno(mp_ss.options.snow_autoconversion, mp_ss, tps, micro, thermo)
+        CM1.conv_q_icl_to_q_sno(mp_ss.processes.snow_autoconversion, mp_ss, tps, micro, thermo)
     end
 end
 MK.lines!(
     q_lcl_range * 1e3,
     [
         CM1.conv_q_lcl_to_q_rai(
-            mp.options.rain_autoconversion, mp, tps,
+            mp.processes.rain_autoconversion, mp, tps,
             (; q_tot, q_lcl = q, q_icl, q_rai, q_sno),
             (; ρ = ρ_air, T),
         ) for q in q_lcl_range
@@ -102,7 +102,7 @@ MK.lines!(
     q_rain_range * 1e3,
     [
         CM1.accretion(
-            mp.options.cloud_liquid_rain_accretion, mp, tps,
+            mp.processes.cloud_liquid_rain_accretion, mp, tps,
             (; q_tot, q_lcl, q_icl, q_rai = q_rai_val, q_sno),
             (; ρ = ρ_air, T),
         ) for q_rai_val in q_rain_range
@@ -113,7 +113,7 @@ MK.lines!(
     q_rain_range * 1e3,
     [
         CM1.accretion(
-            mp.options.cloud_ice_rain_accretion, mp, tps,
+            mp.processes.cloud_ice_rain_accretion, mp, tps,
             (; q_tot, q_lcl, q_icl, q_rai = q_rai_val, q_sno),
             (; ρ = ρ_air, T),
         ) for q_rai_val in q_rain_range
@@ -123,7 +123,7 @@ MK.lines!(
 MK.lines!(
     q_snow_range * 1e3,
     [
-        CM1.accretion(mp.options.cloud_liquid_snow_accretion, mp, tps,
+        CM1.accretion(mp.processes.cloud_liquid_snow_accretion, mp, tps,
             (; q_tot, q_lcl, q_icl, q_rai, q_sno = q_sno_val),
             (; ρ = ρ_air, T),
         ).S_accr for q_sno_val in q_snow_range
@@ -133,7 +133,7 @@ MK.lines!(
 MK.lines!(
     q_snow_range * 1e3,
     [
-        CM1.accretion(mp.options.cloud_ice_snow_accretion, mp, tps,
+        CM1.accretion(mp.processes.cloud_ice_snow_accretion, mp, tps,
             (; q_tot, q_lcl, q_icl, q_rai, q_sno = q_sno_val),
             (; ρ = ρ_air, T),
         ) for q_sno_val in q_snow_range
@@ -152,7 +152,7 @@ fig = MK.Figure()
 ax = MK.Axis(fig[1, 1]; xlabel = "q_rain or q_snow [g/kg]", ylabel = "accretion rain sink rate [1/s]", limits)
 _accr_rain_sink(q_icl_val) = [
     CM1.accretion_rain_sink(
-        mp.options.cloud_ice_rain_accretion, mp, tps,
+        mp.processes.cloud_ice_rain_accretion, mp, tps,
         (; q_tot, q_lcl, q_icl = q_icl_val, q_rai = q_rai_val, q_sno),
         (; ρ = ρ_air, T),
     ) for q_rai_val in q_rain_range
@@ -168,7 +168,7 @@ fig = MK.Figure()
 ax = MK.Axis(fig[1, 1]; xlabel = "q_rain [g/kg]", ylabel = "snow-rain accretion rate [1/s] T>0", limits)
 _accr_snow_rain_warm(q_sno_val) = [
     CM1.accretion_snow_rain(
-        mp.options.rain_snow_accretion, mp, tps,
+        mp.processes.rain_snow_accretion, mp, tps,
         (; q_tot, q_lcl, q_icl, q_rai = q_rai_val, q_sno = q_sno_val),
         (; ρ = ρ_air, T),
     ).S_sno_rai for q_rai_val in q_rain_range
@@ -184,7 +184,7 @@ fig = MK.Figure()
 ax = MK.Axis(fig[1, 1]; xlabel = "q_snow [g/kg]", ylabel = "snow-rain accretion rate [1/s] T<0", limits)
 _accr_snow_rain_cold(q_sno_val) = [
     CM1.accretion_snow_rain(
-        mp.options.rain_snow_accretion, mp, tps,
+        mp.processes.rain_snow_accretion, mp, tps,
         (; q_tot, q_lcl, q_icl, q_rai, q_sno = q_sno_val),
         (; ρ = ρ_air, T),
     ).S_rai_sno for q_rai_val in q_snow_range
@@ -216,7 +216,7 @@ MK.lines!(
     q_rain_range * 1e3,
     (
         q_rai -> CM1.conv_q_rai_to_q_vap(
-            mp.options.rain_condensation_evaporation, mp, tps,
+            mp.processes.rain_condensation_evaporation, mp, tps,
             (; q_tot, q_lcl = q_lcl - q_rai, q_icl, q_rai, q_sno),
             (; ρ, T),
         )
@@ -250,7 +250,7 @@ R = TDI.Rₘ(tps, q_tot, q_lcl + q_rai, q_icl)
 rate =
     (
         q_sno -> CM1.conv_q_sno_to_q_vap(
-            mp.options.snow_deposition_sublimation, mp, tps,
+            mp.processes.snow_deposition_sublimation, mp, tps,
             (; q_tot, q_lcl, q_icl = q_icl - q_sno, q_rai, q_sno),
             (; ρ, T),
         )
@@ -275,7 +275,7 @@ R = TDI.Rₘ(tps, q_tot, q_lcl + q_rai, q_icl)
 rate =
     (
         q_sno -> CM1.conv_q_sno_to_q_vap(
-            mp.options.snow_deposition_sublimation, mp, tps,
+            mp.processes.snow_deposition_sublimation, mp, tps,
             (; q_tot, q_lcl, q_icl = q_icl - q_sno, q_rai, q_sno),
             (; ρ, T),
         )
@@ -293,7 +293,7 @@ ax = MK.Axis(fig[1, 1]; xlabel = "q_snow [g/kg]", ylabel = "snow melt rate [1/s]
 T = 273.15
 _snow_melt(ΔT) = map(
     q_sno -> CM1.conv_q_sno_to_q_rai(
-        mp.options.snow_melt,
+        mp.processes.snow_melt,
         mp,
         tps,
         (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno),

--- a/src/BulkMicrophysicsTendencies.jl
+++ b/src/BulkMicrophysicsTendencies.jl
@@ -151,7 +151,7 @@ processes are pre-routed by temperature, so consumers never need `is_warm`.
     q_sno = UT.clamp_to_nonneg(q_sno)
 
     FT = UT.promote_typeof(ρ, T, q_tot, q_lcl, q_icl, q_rai, q_sno)
-    opts = mp.options
+    procs = mp.processes
 
     # Construct state tuples (reused across all process calls)
     micro = (; q_tot, q_lcl, q_icl, q_rai, q_sno)
@@ -163,47 +163,47 @@ processes are pre-routed by temperature, so consumers never need `is_warm`.
     sd = CM1.size_distr_parameters(mp, micro, thermo)
 
     # --- Phase change: vapor ↔ cloud condensate (bidirectional, ±) ---
-    S_phase_change_vap_lcl = CMNonEq.conv_q_vap_to_q_lcl(opts.cloud_liquid_formation, mp, tps, micro, thermo)
-    S_phase_change_vap_icl = CMNonEq.conv_q_vap_to_q_icl(opts.cloud_ice_formation, mp, tps, micro, thermo)
+    S_phase_change_vap_lcl = CMNonEq.conv_q_vap_to_q_lcl(procs.cloud_liquid_formation, mp, tps, micro, thermo)
+    S_phase_change_vap_icl = CMNonEq.conv_q_vap_to_q_icl(procs.cloud_ice_formation, mp, tps, micro, thermo)
 
     # --- Autoconversion (cloud → precipitation, ≥ 0) ---
-    S_acnv_lcl_rai = CM1.conv_q_lcl_to_q_rai(opts.rain_autoconversion, mp, tps, micro, thermo)
-    S_acnv_icl_sno = CM1.conv_q_icl_to_q_sno(opts.snow_autoconversion, mp, tps, micro, thermo, sd)
+    S_acnv_lcl_rai = CM1.conv_q_lcl_to_q_rai(procs.rain_autoconversion, mp, tps, micro, thermo)
+    S_acnv_icl_sno = CM1.conv_q_icl_to_q_sno(procs.snow_autoconversion, mp, tps, micro, thermo, sd)
 
     # --- Accretion (collisions between species) ---
     is_warm = T >= TDI.T_freeze(tps)
 
     # Cloud liquid + rain → rain
-    S_accr_lcl_rai = CM1.accretion(opts.cloud_liquid_rain_accretion, mp, tps, micro, thermo, sd)
+    S_accr_lcl_rai = CM1.accretion(procs.cloud_liquid_rain_accretion, mp, tps, micro, thermo, sd)
 
     # Cloud liquid + snow: product goes to sno (cold) or rai (warm), plus thermal melt
-    (; S_accr, S_melt) = CM1.accretion(opts.cloud_liquid_snow_accretion, mp, tps, micro, thermo, sd)
+    (; S_accr, S_melt) = CM1.accretion(procs.cloud_liquid_snow_accretion, mp, tps, micro, thermo, sd)
     S_accr_lcl_sno_cold = ifelse(is_warm, zero(FT), S_accr)    # lcl → sno (cold)
     S_accr_lcl_sno_warm = ifelse(is_warm, S_accr, zero(FT))    # lcl → rai (warm)
     S_accr_melt_lcl_sno = S_melt                                # thermal melt of sno from warm lcl (already zero when cold)
 
     # Cloud ice + rain → snow (ice-side sink)
-    S_accr_icl_rai = CM1.accretion(opts.cloud_ice_rain_accretion, mp, tps, micro, thermo, sd)
+    S_accr_icl_rai = CM1.accretion(procs.cloud_ice_rain_accretion, mp, tps, micro, thermo, sd)
 
     # Rain frozen in cloud ice + rain collision → snow (rain sink)
-    S_accr_freeze_icl_rai = CM1.accretion_rain_sink(opts.cloud_ice_rain_accretion, mp, tps, micro, thermo, sd)
+    S_accr_freeze_icl_rai = CM1.accretion_rain_sink(procs.cloud_ice_rain_accretion, mp, tps, micro, thermo, sd)
 
     # Cloud ice + snow → snow
-    S_accr_icl_sno = CM1.accretion(opts.cloud_ice_snow_accretion, mp, tps, micro, thermo, sd)
+    S_accr_icl_sno = CM1.accretion(procs.cloud_ice_snow_accretion, mp, tps, micro, thermo, sd)
 
     # Rain-snow collisions: split into cold/warm arms (inactive arm = zero)
-    (; S_rai_sno, S_sno_rai, S_melt) = CM1.accretion_snow_rain(opts.rain_snow_accretion, mp, tps, micro, thermo, sd)
+    (; S_rai_sno, S_sno_rai, S_melt) = CM1.accretion_snow_rain(procs.rain_snow_accretion, mp, tps, micro, thermo, sd)
     S_accr_rai_sno_cold = ifelse(is_warm, zero(FT), S_rai_sno) # cold arm: rai freezes → sno
     S_accr_rai_sno_warm = ifelse(is_warm, S_sno_rai, zero(FT)) # warm arm: sno melts → rai
     S_accr_melt_rai_sno = ifelse(is_warm, S_melt, zero(FT))    # thermal melt of sno from warm rai
 
     # --- Phase change: precipitation ↔ vapor ---
-    S_phase_change_vap_rai = CM1.conv_q_rai_to_q_vap(opts.rain_condensation_evaporation, mp, tps, micro, thermo, sd)
-    S_phase_change_vap_sno = CM1.conv_q_sno_to_q_vap(opts.snow_deposition_sublimation, mp, tps, micro, thermo, sd)
+    S_phase_change_vap_rai = CM1.conv_q_rai_to_q_vap(procs.rain_condensation_evaporation, mp, tps, micro, thermo, sd)
+    S_phase_change_vap_sno = CM1.conv_q_sno_to_q_vap(procs.snow_deposition_sublimation, mp, tps, micro, thermo, sd)
 
     # --- Melting ---
-    S_melt_icl_lcl = CM1.conv_q_icl_to_q_lcl(opts.cloud_ice_melt, mp, tps, micro, thermo, sd)
-    S_melt_sno_rai = CM1.conv_q_sno_to_q_rai(opts.snow_melt, mp, tps, micro, thermo, sd)
+    S_melt_icl_lcl = CM1.conv_q_icl_to_q_lcl(procs.cloud_ice_melt, mp, tps, micro, thermo, sd)
+    S_melt_sno_rai = CM1.conv_q_sno_to_q_rai(procs.snow_melt, mp, tps, micro, thermo, sd)
 
     return (;
         S_phase_change_vap_lcl, S_phase_change_vap_icl,

--- a/src/parameters/Microphysics1MOptions.jl
+++ b/src/parameters/Microphysics1MOptions.jl
@@ -394,3 +394,23 @@ microphysics_1m_process_params(td::CP.ParamDict, o::Microphysics1MOptions) = (;
     cloud_ice_snow_accretion = process_params_for(o.cloud_ice_snow_accretion, td),
     rain_snow_accretion = process_params_for(o.rain_snow_accretion, td),
 )
+
+# ═══════════════════════════════════════════════════════════════════
+# Deprecated TOML-dict constructors
+#
+# Option types no longer carry parameters, so they take no TOML dict.
+# These shims keep downstream callers that still pass `toml_dict`
+# working (the argument is ignored). Drop the argument to migrate.
+# ═══════════════════════════════════════════════════════════════════
+@deprecate CloudLiquidFormation(::CP.ParamDict) CloudLiquidFormation() false
+@deprecate ConstantTimescale(::CP.ParamDict) ConstantTimescale() false
+@deprecate TemperatureDependent(::CP.ParamDict) TemperatureDependent() false
+@deprecate Kessler1M(::CP.ParamDict) Kessler1M() false
+@deprecate PrescribedNd(::CP.ParamDict) PrescribedNd() false
+@deprecate NoSupersaturation(::CP.ParamDict) NoSupersaturation() false
+@deprecate WithSupersaturation(::CP.ParamDict) WithSupersaturation() false
+@deprecate CloudLiquidRainAccretion(::CP.ParamDict) CloudLiquidRainAccretion() false
+@deprecate CloudLiquidSnowAccretion(::CP.ParamDict) CloudLiquidSnowAccretion() false
+@deprecate CloudIceRainAccretion(::CP.ParamDict) CloudIceRainAccretion() false
+@deprecate CloudIceSnowAccretion(::CP.ParamDict) CloudIceSnowAccretion() false
+@deprecate RainSnowAccretion(::CP.ParamDict) RainSnowAccretion() false

--- a/src/parameters/Microphysics1MParams.jl
+++ b/src/parameters/Microphysics1MParams.jl
@@ -39,20 +39,20 @@ Base.show(io::IO, mime::MIME"text/plain", x::PrecipPhaseParams1M) =
 
 Unified parameter container for 1-moment bulk microphysics.
 
-`options` selects which variant of each process runs. The parameter values each
-selected variant needs live in `process_params`, whose fields mirror `options`
-one-to-one. For example, `options.rain_autoconversion = Kessler1M()` picks the
+`processes` selects which variant of each process runs. The parameter values each
+selected variant needs live in `process_params`, whose fields mirror `processes`
+one-to-one. For example, `processes.rain_autoconversion = Kessler1M()` picks the
 Kessler scheme, and its `τ`, threshold, and `k` live in
 `process_params.rain_autoconversion`. Turning a process off with `nothing` (e.g.
-`options.cloud_ice_melt = nothing`) gives it a `nothing` slot in
+`processes.cloud_ice_melt = nothing`) gives it a `nothing` slot in
 `process_params`, as does any option that needs no parameters. Shared parameters
 (particle size distributions, air properties, terminal velocities) are stored
 directly.
 
 # Fields
-- `options::OPT`: Microphysics1MOptions — process selection
+- `processes::OPT`: Microphysics1MOptions — process selection
 - `process_params::PPR`: parameter data for each selected process, mirroring
-  `options` (`nothing` when a process is disabled with `nothing` or needs no
+  `processes` (`nothing` when a process is disabled with `nothing` or needs no
   parameters)
 - `cloud::CP`: CloudPhaseParams1M — cloud liquid and ice parameters
 - `precip::PP`: PrecipPhaseParams1M — rain and snow parameters
@@ -82,7 +82,7 @@ mp = CMP.Microphysics1MParams(Float64;
 ```
 """
 @kwdef struct Microphysics1MParams{OPT, PPR, CP, PP, AP, VL} <: ParametersType
-    options::OPT
+    processes::OPT
     process_params::PPR
     cloud::CP
     precip::PP
@@ -102,10 +102,10 @@ Create a `Microphysics1MParams` object from a ClimaParams TOML dictionary.
 - `options_kwargs...`: Keyword arguments forwarded to `Microphysics1MOptions`
 """
 function Microphysics1MParams(toml_dict::CP.ParamDict; options_kwargs...)
-    options = Microphysics1MOptions(; options_kwargs...)
+    processes = Microphysics1MOptions(; options_kwargs...)
     return Microphysics1MParams(;
-        options,
-        process_params = microphysics_1m_process_params(toml_dict, options),
+        processes,
+        process_params = microphysics_1m_process_params(toml_dict, processes),
         cloud = CloudPhaseParams1M(;
             liquid = CloudLiquid(toml_dict),
             ice = CloudIce(toml_dict),

--- a/test/bulk_tendencies_tests.jl
+++ b/test/bulk_tendencies_tests.jl
@@ -224,7 +224,7 @@ function test_bulk_microphysics_1m_tendencies(FT)
         # Compute autoconversion separately using the same option-dispatched function
         micro_acnv = (; q_tot, q_lcl, q_icl, q_rai, q_sno)
         thermo_acnv = (; ρ, T)
-        S_acnv_lcl = CM1.conv_q_lcl_to_q_rai(mp.options.rain_autoconversion, mp, tps, micro_acnv, thermo_acnv)
+        S_acnv_lcl = CM1.conv_q_lcl_to_q_rai(mp.processes.rain_autoconversion, mp, tps, micro_acnv, thermo_acnv)
 
         # Rain tendency should be positive and include autoconversion
         @test tendencies.dq_rai_dt > FT(0)
@@ -257,7 +257,7 @@ function test_bulk_microphysics_1m_tendencies(FT)
         # Compute autoconversion separately using the option-dispatched function
         micro_acnv = (; q_tot, q_lcl, q_icl, q_rai, q_sno)
         thermo_acnv = (; ρ, T)
-        S_acnv_2m = CM1.conv_q_lcl_to_q_rai(mp_2m.options.rain_autoconversion, mp_2m, tps, micro_acnv, thermo_acnv)
+        S_acnv_2m = CM1.conv_q_lcl_to_q_rai(mp_2m.processes.rain_autoconversion, mp_2m, tps, micro_acnv, thermo_acnv)
 
         # Rain tendency should be positive and dominated by autoconversion
         @test tendencies_2m.dq_rai_dt > FT(0)

--- a/test/gpu_tests.jl
+++ b/test/gpu_tests.jl
@@ -144,14 +144,14 @@ end
     i = @index(Global, Linear)
     micro = (; q_tot = zero(ql[i]), q_lcl = ql[i], q_icl = zero(ql[i]), q_rai = zero(ql[i]), q_sno = zero(ql[i]))
     thermo = (; ρ = zero(ql[i]), T = zero(ql[i]))
-    output[i] = CM1.conv_q_lcl_to_q_rai(mp.options.rain_autoconversion, mp, tps, micro, thermo)
+    output[i] = CM1.conv_q_lcl_to_q_rai(mp.processes.rain_autoconversion, mp, tps, micro, thermo)
 end
 
 @kernel inbounds = true function test_1_moment_micro_acnv2M_kernel!(mp, tps, output, ql)
     i = @index(Global, Linear)
     micro = (; q_tot = zero(ql[i]), q_lcl = ql[i], q_icl = zero(ql[i]), q_rai = zero(ql[i]), q_sno = zero(ql[i]))
     thermo = (; ρ = zero(ql[i]), T = zero(ql[i]))
-    output[i] = CM1.conv_q_lcl_to_q_rai(mp.options.rain_autoconversion, mp, tps, micro, thermo)
+    output[i] = CM1.conv_q_lcl_to_q_rai(mp.processes.rain_autoconversion, mp, tps, micro, thermo)
 end
 
 @kernel inbounds = true function test_1_moment_micro_accretion_kernel!(
@@ -178,12 +178,12 @@ end
     i = @index(Global, Linear)
     micro = (; q_tot = zero(ρ[i]), q_lcl = ql[i], q_icl = qi[i], q_rai = qr[i], q_sno = qs[i])
     thermo = (; ρ = ρ[i], T = T[i])
-    liq_rai = CM1.accretion(mp.options.cloud_liquid_rain_accretion, mp, tps, micro, thermo)
-    liq_sno = CM1.accretion(mp.options.cloud_liquid_snow_accretion, mp, tps, micro, thermo).S_accr
-    ice_rai = CM1.accretion(mp.options.cloud_ice_rain_accretion, mp, tps, micro, thermo)
-    ice_sno = CM1.accretion(mp.options.cloud_ice_snow_accretion, mp, tps, micro, thermo)
-    rai_sink = CM1.accretion_rain_sink(mp.options.cloud_ice_rain_accretion, mp, tps, micro, thermo)
-    r_sr = CM1.accretion_snow_rain(mp.options.rain_snow_accretion, mp, tps, micro, thermo)
+    liq_rai = CM1.accretion(mp.processes.cloud_liquid_rain_accretion, mp, tps, micro, thermo)
+    liq_sno = CM1.accretion(mp.processes.cloud_liquid_snow_accretion, mp, tps, micro, thermo).S_accr
+    ice_rai = CM1.accretion(mp.processes.cloud_ice_rain_accretion, mp, tps, micro, thermo)
+    ice_sno = CM1.accretion(mp.processes.cloud_ice_snow_accretion, mp, tps, micro, thermo)
+    rai_sink = CM1.accretion_rain_sink(mp.processes.cloud_ice_rain_accretion, mp, tps, micro, thermo)
+    r_sr = CM1.accretion_snow_rain(mp.processes.rain_snow_accretion, mp, tps, micro, thermo)
     output[i] = (; liq_rai, ice_sno, liq_sno, ice_rai, rai_sink,
         sno_rai = r_sr.S_rai_sno, rai_sno = r_sr.S_sno_rai)
 end
@@ -193,7 +193,7 @@ end
     i = @index(Global, Linear)
     micro = (; q_tot = zero(ρ[i]), q_lcl = zero(ρ[i]), q_icl = zero(ρ[i]), q_rai = zero(ρ[i]), q_sno = qs[i])
     thermo = (; ρ = ρ[i], T = T[i])
-    output[i] = CM1.conv_q_sno_to_q_rai(mp.options.snow_melt, mp, tps, micro, thermo)
+    output[i] = CM1.conv_q_sno_to_q_rai(mp.processes.snow_melt, mp, tps, micro, thermo)
 end
 
 @kernel inbounds = true function test_2_moment_acnv_kernel!(

--- a/test/microphysics1M_tests.jl
+++ b/test/microphysics1M_tests.jl
@@ -208,11 +208,11 @@ function test_microphysics1M(FT)
         thermo = (; ρ = FT(1), T = FT(280))
 
         # Below threshold → near zero (smooth logistic)
-        TT.@test CM1.conv_q_lcl_to_q_rai(mp.options.rain_autoconversion, mp, tps, micro_s, thermo) ≈
+        TT.@test CM1.conv_q_lcl_to_q_rai(mp.processes.rain_autoconversion, mp, tps, micro_s, thermo) ≈
                  FT(0.0) atol = 0.15 * q_lcl_threshold / τ_acnv_rai
 
         # Above threshold → ≈ 0.5 * q_threshold / τ (smooth logistic)
-        TT.@test CM1.conv_q_lcl_to_q_rai(mp.options.rain_autoconversion, mp, tps, micro_b, thermo) ≈
+        TT.@test CM1.conv_q_lcl_to_q_rai(mp.processes.rain_autoconversion, mp, tps, micro_b, thermo) ≈
                  FT(0.5) * q_lcl_threshold / τ_acnv_rai atol =
             FT(0.15) * q_lcl_threshold / τ_acnv_rai
 
@@ -227,18 +227,18 @@ function test_microphysics1M(FT)
 
         # Zero cloud liquid → zero rate
         micro_0 = (; q_tot = FT(0), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
-        TT.@test CM1.conv_q_lcl_to_q_rai(mp_2m.options.rain_autoconversion, mp_2m, tps, micro_0, thermo) == FT(0)
+        TT.@test CM1.conv_q_lcl_to_q_rai(mp_2m.processes.rain_autoconversion, mp_2m, tps, micro_0, thermo) == FT(0)
 
         # Negative cloud liquid → zero rate (max(0, q_lcl))
         micro_neg = (; q_tot = FT(0), q_lcl = FT(-1e-4), q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
-        TT.@test CM1.conv_q_lcl_to_q_rai(mp_2m.options.rain_autoconversion, mp_2m, tps, micro_neg, thermo) == FT(0)
+        TT.@test CM1.conv_q_lcl_to_q_rai(mp_2m.processes.rain_autoconversion, mp_2m, tps, micro_neg, thermo) == FT(0)
 
         # Positive cloud liquid → positive rate
         q_lcl = FT(2e-3)
         N_d = mp_2m.process_params.rain_autoconversion.Nc
         (; τ, α) = mp_2m.process_params.rain_autoconversion
         micro = (; q_tot = FT(0), q_lcl, q_icl = FT(0), q_rai = FT(0), q_sno = FT(0))
-        rate = CM1.conv_q_lcl_to_q_rai(mp_2m.options.rain_autoconversion, mp_2m, tps, micro, thermo)
+        rate = CM1.conv_q_lcl_to_q_rai(mp_2m.processes.rain_autoconversion, mp_2m, tps, micro, thermo)
         TT.@test rate > FT(0)
         # Rate should match the formula: q_lcl / (τ * (N_d / 1e8)^α)
         TT.@test rate ≈ q_lcl / (τ * (N_d / 100_000_000)^α)
@@ -268,14 +268,14 @@ function test_microphysics1M(FT)
         micro_s = (; q_tot = FT(0), q_lcl = FT(0), q_icl = q_icl_small, q_rai = FT(0), q_sno = FT(0))
         thermo_s = (; ρ = FT(1), T = FT(250))
         TT.@test CM1.conv_q_icl_to_q_sno(
-            mp.options.snow_autoconversion, mp, tps, micro_s, thermo_s,
+            mp.processes.snow_autoconversion, mp, tps, micro_s, thermo_s,
         ) ≈ FT(0.0) atol = FT(0.15) * q_icl_threshold / τ_acnv_sno
 
         # Above threshold → positive rate
         q_icl_big = FT(1.5) * q_icl_threshold
         micro_b = (; q_tot = FT(0), q_lcl = FT(0), q_icl = q_icl_big, q_rai = FT(0), q_sno = FT(0))
         TT.@test CM1.conv_q_icl_to_q_sno(
-            mp.options.snow_autoconversion, mp, tps, micro_b, thermo_s,
+            mp.processes.snow_autoconversion, mp, tps, micro_b, thermo_s,
         ) ≈ FT(0.5) * q_icl_threshold / τ_acnv_sno atol =
             FT(0.15) * q_icl_threshold / τ_acnv_sno
 
@@ -301,7 +301,7 @@ function test_microphysics1M(FT)
         T = T_freeze + FT(30)
         micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
         thermo = (; ρ, T)
-        TT.@test CM1.conv_q_icl_to_q_sno(mp_ss.options.snow_autoconversion, mp_ss, tps, micro, thermo) ==
+        TT.@test CM1.conv_q_icl_to_q_sno(mp_ss.processes.snow_autoconversion, mp_ss, tps, micro, thermo) ==
                  FT(0)
 
         # no cloud ice -> no snow
@@ -310,7 +310,7 @@ function test_microphysics1M(FT)
         T = T_freeze - FT(30)
         micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
         thermo = (; ρ, T)
-        TT.@test CM1.conv_q_icl_to_q_sno(mp_ss.options.snow_autoconversion, mp_ss, tps, micro, thermo) ==
+        TT.@test CM1.conv_q_icl_to_q_sno(mp_ss.processes.snow_autoconversion, mp_ss, tps, micro, thermo) ==
                  FT(0)
 
         # no supersaturation -> no snow
@@ -320,7 +320,7 @@ function test_microphysics1M(FT)
         qₜ = q_sat_ice
         micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
         thermo = (; ρ, T)
-        TT.@test CM1.conv_q_icl_to_q_sno(mp_ss.options.snow_autoconversion, mp_ss, tps, micro, thermo) ≈ FT(0)
+        TT.@test CM1.conv_q_icl_to_q_sno(mp_ss.processes.snow_autoconversion, mp_ss, tps, micro, thermo) ≈ FT(0)
 
         # Regression test: keep result constant when code changes
         T = T_freeze - FT(10)
@@ -331,7 +331,7 @@ function test_microphysics1M(FT)
         ref = FT(2.5408135723057333e-9)
         micro = (; q_tot = qₜ, q_lcl = qₗ, q_icl = qᵢ, q_rai = qᵣ, q_sno = qₛ)
         thermo = (; ρ, T)
-        TT.@test CM1.conv_q_icl_to_q_sno(mp_ss.options.snow_autoconversion, mp_ss, tps, micro, thermo) ≈ ref
+        TT.@test CM1.conv_q_icl_to_q_sno(mp_ss.processes.snow_autoconversion, mp_ss, tps, micro, thermo) ≈ ref
     end
 
     TT.@testset "RainLiquidAccretion" begin
@@ -470,26 +470,26 @@ function test_microphysics1M(FT)
         thermo_cold = (; ρ, T = T_cold)
 
         # CloudLiquidRainAccretion: scalar, matches internal kernel
-        TT.@test CM1.accretion(mp.options.cloud_liquid_rain_accretion, mp, tps, micro, thermo_warm) ≈
+        TT.@test CM1.accretion(mp.processes.cloud_liquid_rain_accretion, mp, tps, micro, thermo_warm) ≈
                  FT(1.4150106417043544e-6)
 
         # CloudIceRainAccretion: scalar, matches internal kernel
-        TT.@test CM1.accretion(mp.options.cloud_ice_rain_accretion, mp, tps, micro, thermo_warm) ≈
+        TT.@test CM1.accretion(mp.processes.cloud_ice_rain_accretion, mp, tps, micro, thermo_warm) ≈
                  FT(1.768763302130443e-6)
 
         # CloudIceSnowAccretion: scalar, matches internal kernel
-        TT.@test CM1.accretion(mp.options.cloud_ice_snow_accretion, mp, tps, micro, thermo_warm) ≈
+        TT.@test CM1.accretion(mp.processes.cloud_ice_snow_accretion, mp, tps, micro, thermo_warm) ≈
                  FT(2.453070979562392e-7)
 
         # CloudLiquidSnowAccretion: NamedTuple (; S_accr, S_melt)
         # S_accr matches the internal lcl×sno kernel; S_melt = α * S_accr (α > 0 warm)
-        (; S_accr, S_melt) = CM1.accretion(mp.options.cloud_liquid_snow_accretion, mp, tps, micro, thermo_warm)
+        (; S_accr, S_melt) = CM1.accretion(mp.processes.cloud_liquid_snow_accretion, mp, tps, micro, thermo_warm)
         TT.@test S_accr ≈ FT(2.453070979562392e-7)
         TT.@test S_melt >= FT(0)      # α >= 0
         TT.@test S_melt <= S_accr     # melt ≤ S_accr (α ≤ 1 for reasonable ΔT)
 
         # Cold: melt should be zero (T < T_freeze → α = 0)
-        let r = CM1.accretion(mp.options.cloud_liquid_snow_accretion, mp, tps, micro, thermo_cold)
+        let r = CM1.accretion(mp.processes.cloud_liquid_snow_accretion, mp, tps, micro, thermo_cold)
             TT.@test r.S_accr ≈ FT(2.453070979562392e-7)
             TT.@test r.S_melt == FT(0)
         end
@@ -497,13 +497,13 @@ function test_microphysics1M(FT)
         # RainSnowAccretion: NamedTuple (; S_rai_sno, S_sno_rai, S_melt)
         # cold arm S_rai_sno matches internal (sno, rai) call
         # warm arm S_sno_rai matches internal (rai, sno) call
-        let r = CM1.accretion_snow_rain(mp.options.rain_snow_accretion, mp, tps, micro, thermo_warm)
+        let r = CM1.accretion_snow_rain(mp.processes.rain_snow_accretion, mp, tps, micro, thermo_warm)
             TT.@test r.S_rai_sno ≈ FT(2.466313958248222e-4)
             TT.@test r.S_sno_rai ≈ FT(6.830957197816771e-5)
             TT.@test r.S_melt >= FT(0)
         end
         # Cold: S_melt = 0 (α = 0 below freezing)
-        let r = CM1.accretion_snow_rain(mp.options.rain_snow_accretion, mp, tps, micro, thermo_cold)
+        let r = CM1.accretion_snow_rain(mp.processes.rain_snow_accretion, mp, tps, micro, thermo_cold)
             TT.@test r.S_melt == FT(0)
         end
 
@@ -513,13 +513,14 @@ function test_microphysics1M(FT)
         TT.@test CM1.accretion_snow_rain(nothing, mp, tps, micro_zero, thermo_warm).S_rai_sno == FT(0)
         TT.@test CM1.accretion_snow_rain(nothing, mp, tps, micro_zero, thermo_warm).S_sno_rai == FT(0)
         # Active variants: zero inputs → zero rates
-        TT.@test CM1.accretion(mp.options.cloud_liquid_rain_accretion, mp, tps, micro_zero, thermo_warm) == FT(0)
-        TT.@test CM1.accretion(mp.options.cloud_ice_rain_accretion, mp, tps, micro_zero, thermo_warm) == FT(0)
-        TT.@test CM1.accretion(mp.options.cloud_ice_snow_accretion, mp, tps, micro_zero, thermo_warm) == FT(0)
-        TT.@test CM1.accretion(mp.options.cloud_liquid_snow_accretion, mp, tps, micro_zero, thermo_warm).S_accr == FT(0)
-        TT.@test CM1.accretion_snow_rain(mp.options.rain_snow_accretion, mp, tps, micro_zero, thermo_warm).S_rai_sno ==
+        TT.@test CM1.accretion(mp.processes.cloud_liquid_rain_accretion, mp, tps, micro_zero, thermo_warm) == FT(0)
+        TT.@test CM1.accretion(mp.processes.cloud_ice_rain_accretion, mp, tps, micro_zero, thermo_warm) == FT(0)
+        TT.@test CM1.accretion(mp.processes.cloud_ice_snow_accretion, mp, tps, micro_zero, thermo_warm) == FT(0)
+        TT.@test CM1.accretion(mp.processes.cloud_liquid_snow_accretion, mp, tps, micro_zero, thermo_warm).S_accr ==
                  FT(0)
-        TT.@test CM1.accretion_snow_rain(mp.options.rain_snow_accretion, mp, tps, micro_zero, thermo_warm).S_sno_rai ==
+        TT.@test CM1.accretion_snow_rain(mp.processes.rain_snow_accretion, mp, tps, micro_zero, thermo_warm).S_rai_sno ==
+                 FT(0)
+        TT.@test CM1.accretion_snow_rain(mp.processes.rain_snow_accretion, mp, tps, micro_zero, thermo_warm).S_sno_rai ==
                  FT(0)
     end
 

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -176,9 +176,9 @@ function benchmark_test(FT)
         P3.P3State,
         P3.P3State,
         (params_P3, L_ice, N_ice, F_rim, ρ_rim),
-        220,
+        400,
     )
-    bench_press(FT, P3.get_distribution_logλ, (state,), 100_000)  # 10 (F64) / 8 (F32) FixedIterations BrentsMethod, zero warp divergence
+    bench_press(FT, P3.get_distribution_logλ, (state,), 220_000)  # 10 (F64) / 8 (F32) FixedIterations BrentsMethod, zero warp divergence
     # The weighted-velocity integrals build a nested terminal-velocity closure
     # that escapes into `integrate`. With `ice_particle_terminal_velocity`
     # returning a single (concretely-typed) closure, this path is type-stable
@@ -187,7 +187,7 @@ function benchmark_test(FT)
     bench_press(FT, P3.ice_terminal_velocity_number_weighted, (ch2022, ρ_air, state, logλ), 170_000)
     bench_press(FT, P3.ice_terminal_velocity_mass_weighted, (ch2022, ρ_air, state, logλ), 200_000)
     bench_press(FT, P3.integrate, (x -> x^4, FT(0), FT(1)), 7_000)
-    bench_press(FT, P3.D_m, (state, logλ), 8_000)
+    bench_press(FT, P3.D_m, (state, logλ), 18_000)
 
     @info "P3 Ice Nucleation"
     bench_press(
@@ -260,16 +260,16 @@ function benchmark_test(FT)
         (mp_1m_2M.processes.rain_autoconversion, mp_1m_2M, tps, micro_1m, thermo_1m),
         500,
     )
-    bench_press(FT, CM1.accretion, (liquid, rain, blk1mvel.rain, E_lcl_rai, q_liq, q_rai, ρ_air), 360)
-    bench_press(FT, CM1.accretion, (mp_1m.processes.cloud_liquid_rain_accretion, mp_1m, tps, micro_1m, thermo_1m), 360)
+    bench_press(FT, CM1.accretion, (liquid, rain, blk1mvel.rain, E_lcl_rai, q_liq, q_rai, ρ_air), 650)
+    bench_press(FT, CM1.accretion, (mp_1m.processes.cloud_liquid_rain_accretion, mp_1m, tps, micro_1m, thermo_1m), 650)
     bench_press(
         @NamedTuple{S_accr::FT, S_melt::FT},
         CM1.accretion,
         (mp_1m.processes.cloud_liquid_snow_accretion, mp_1m, tps, micro_1m, thermo_1m),
-        360,
+        650,
     )
-    bench_press(FT, CM1.accretion, (mp_1m.processes.cloud_ice_rain_accretion, mp_1m, tps, micro_1m, thermo_1m), 360)
-    bench_press(FT, CM1.accretion, (mp_1m.processes.cloud_ice_snow_accretion, mp_1m, tps, micro_1m, thermo_1m), 360)
+    bench_press(FT, CM1.accretion, (mp_1m.processes.cloud_ice_rain_accretion, mp_1m, tps, micro_1m, thermo_1m), 650)
+    bench_press(FT, CM1.accretion, (mp_1m.processes.cloud_ice_snow_accretion, mp_1m, tps, micro_1m, thermo_1m), 650)
     bench_press(
         @NamedTuple{S_rai_sno::FT, S_sno_rai::FT, S_melt::FT},
         CM1.accretion_snow_rain,

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -252,28 +252,28 @@ function benchmark_test(FT)
     thermo_1m = (; ρ = ρ_air, T = T_air)
     bench_press(
         FT, CM1.conv_q_lcl_to_q_rai,
-        (mp_1m.options.rain_autoconversion, mp_1m, tps, micro_1m, thermo_1m),
+        (mp_1m.processes.rain_autoconversion, mp_1m, tps, micro_1m, thermo_1m),
         500,
     )
     bench_press(
         FT, CM1.conv_q_lcl_to_q_rai,
-        (mp_1m_2M.options.rain_autoconversion, mp_1m_2M, tps, micro_1m, thermo_1m),
+        (mp_1m_2M.processes.rain_autoconversion, mp_1m_2M, tps, micro_1m, thermo_1m),
         500,
     )
     bench_press(FT, CM1.accretion, (liquid, rain, blk1mvel.rain, E_lcl_rai, q_liq, q_rai, ρ_air), 360)
-    bench_press(FT, CM1.accretion, (mp_1m.options.cloud_liquid_rain_accretion, mp_1m, tps, micro_1m, thermo_1m), 360)
+    bench_press(FT, CM1.accretion, (mp_1m.processes.cloud_liquid_rain_accretion, mp_1m, tps, micro_1m, thermo_1m), 360)
     bench_press(
         @NamedTuple{S_accr::FT, S_melt::FT},
         CM1.accretion,
-        (mp_1m.options.cloud_liquid_snow_accretion, mp_1m, tps, micro_1m, thermo_1m),
+        (mp_1m.processes.cloud_liquid_snow_accretion, mp_1m, tps, micro_1m, thermo_1m),
         360,
     )
-    bench_press(FT, CM1.accretion, (mp_1m.options.cloud_ice_rain_accretion, mp_1m, tps, micro_1m, thermo_1m), 360)
-    bench_press(FT, CM1.accretion, (mp_1m.options.cloud_ice_snow_accretion, mp_1m, tps, micro_1m, thermo_1m), 360)
+    bench_press(FT, CM1.accretion, (mp_1m.processes.cloud_ice_rain_accretion, mp_1m, tps, micro_1m, thermo_1m), 360)
+    bench_press(FT, CM1.accretion, (mp_1m.processes.cloud_ice_snow_accretion, mp_1m, tps, micro_1m, thermo_1m), 360)
     bench_press(
         @NamedTuple{S_rai_sno::FT, S_sno_rai::FT, S_melt::FT},
         CM1.accretion_snow_rain,
-        (mp_1m.options.rain_snow_accretion, mp_1m, tps, micro_1m, thermo_1m),
+        (mp_1m.processes.rain_snow_accretion, mp_1m, tps, micro_1m, thermo_1m),
         1400,
     )
     bench_press(FT, CMD.radar_reflectivity_1M, (rain, q_rai, ρ_air), 300)


### PR DESCRIPTION
The previous PR #767 would require a minor (breaking) release because it removed the toml-based constructors for 1M options ( e.g. `CloudLiquidFormation(::CP.ParamDict)`). This PR adds the constructors back in with deprecations.