### PR TITLE
Bumping the version for a breaking release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
-version = "0.37.2"
+version = "0.38.0"
 authors = ["Climate Modeling Alliance"]
 
 [deps]


### PR DESCRIPTION
PR https://github.com/CliMA/CloudMicrophysics.jl/pull/767 changes interface with ClimaAtmos. Preparing to make a breaking release. 

We just have to wait to register v0.37.2: https://github.com/JuliaRegistries/General/pull/162884 before making v0.38