### PR TITLE
Bulk tendencies: limit vapor to condensate sources

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
-version = "0.38.0"
+version = "0.38.1"
 authors = ["Climate Modeling Alliance"]
 
 [deps]

--- a/docs/src/BulkTendencies.md
+++ b/docs/src/BulkTendencies.md
@@ -60,6 +60,35 @@ The average tendency is then:
 
 ---
 
+## Vapor-budget cap on vapor → condensate sources
+
+Vapor → condensate processes (condensation on cloud liquid, deposition on
+cloud ice, deposition on snow — the positive contributions to `e_1`, `e_2`,
+`e_4`) are treated as constant sources over the substep. If their combined
+rate is fast enough, an unlimited substep can drive `q_v` below saturation
+or even negative. To prevent this, all three positive `e` terms are
+uniformly scaled by
+
+```math
+\alpha = \min\!\left(1,\; \frac{\max(0,\, q_v - q^\star_{\min})}
+                                 {\Delta t\;(e_1 + e_2 + e_4)}\right),
+\qquad
+q^\star_{\min} = \min\!\bigl(q^\star_{\mathrm{liq}}, q^\star_{\mathrm{ice}}\bigr),
+```
+
+so that `q_v` cannot be driven below `q^\star_{\min}` over one substep.
+Preserving the common scale factor `\alpha` keeps the relative rates of the
+three processes unchanged. Sinks (`M` blocks) are unaffected.
+
+- Below freezing: `q^\star_{\min} = q^\star_{\mathrm{ice}}`, the natural
+  ice-saturation floor (permits the Bergeron process to drive `q_v` below
+  liquid saturation).
+- Above freezing: `q^\star_{\min} = q^\star_{\mathrm{liq}}`, so the liquid
+  floor is enforced (mathematical `q^\star_{\mathrm{ice}}` is unphysical
+  there).
+
+---
+
 ## Sparse 4×4 structure
 
 The system has a fixed sparse structure:

--- a/src/BulkMicrophysicsTendencies.jl
+++ b/src/BulkMicrophysicsTendencies.jl
@@ -409,6 +409,19 @@ exponential decays over the substep.
 
     invΔt = one(FT) / Δt
 
+    # Cap vap→condensate sources jointly so the substep cannot drive
+    # `q_v` below `min(q_sat_liq, q_sat_ice)`. Preserves relative rates.
+    q_sat_min = min(
+        TDI.saturation_vapor_specific_content_over_liquid(tps, T, ρ),
+        TDI.saturation_vapor_specific_content_over_ice(tps, T, ρ),
+    )
+    q_v = q_tot - q_lcl - q_icl - q_rai - q_sno
+    α = min(
+        one(FT),
+        max(zero(FT), q_v - q_sat_min) * invΔt /
+        max(lin.e1 + lin.e2 + lin.e4, eps(FT)),
+    )
+
     # A = I/Δt - M
     a11 = invΔt - lin.M11
     a12 = -lin.M12
@@ -421,12 +434,12 @@ exponential decays over the substep.
     a43 = -lin.M43
     a44 = invΔt - lin.M44
 
-    # rhs = e + q_0/Δt
+    # rhs = e + q_0/Δt (vap→condensate `e` terms scaled by `α` above)
     # e3 = 0 by the 1m model
-    b1 = lin.e1 + invΔt * q_lcl
-    b2 = lin.e2 + invΔt * q_icl
+    b1 = α * lin.e1 + invΔt * q_lcl
+    b2 = α * lin.e2 + invΔt * q_icl
     b3 = invΔt * q_rai
-    b4 = lin.e4 + invΔt * q_sno
+    b4 = α * lin.e4 + invΔt * q_sno
 
     # Solve 2×2 system for q_lcl, q_icl (coupled via ice melt M12)
     det12 = a11 * a22  # a21 = 0


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Bulk tendencies: cap vapor to condensate sources so q_v stays ≥ min(q_sat_liq, q_sat_ice)


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
