### PR TITLE
Clarify 1M docs language

### DIFF
--- a/docs/src/Microphysics1M.md
+++ b/docs/src/Microphysics1M.md
@@ -26,7 +26,7 @@ The coefficients are defined in the
   [ClimaParams.jl](https://github.com/CliMA/ClimaParams.jl) package
   and are shown in the table below.
 For rain and ice they correspond to spherical liquid water drops
-  and ice particles, respectively.
+  and spherical ice particles, respectively.
 There is no assumed particle shape for snow, and the relationships are
   empirical.
 


### PR DESCRIPTION
## Purpose 
In the following sentence, it is not clear to a reader whether the adjective "spherical" applies to both or only the first of the following nouns, and either interpretation could be correct depending on implementation details.

"For rain and ice they correspond to *spherical* liquid water drops and ice particles, respectively. "

This commit attempts to remedy this by implementing the wide-scope (both particles spherical) interpretation in the 1M scheme documentation. Please correct this commit if this is in fact an incorrect interpretation.

## To-do
- [ ] Review from package author


## Content
This PR adds a single word to the 1M scheme docs.

- [X] I have read and checked the items on the review checklist.
