### PR TITLE
Use bulk ice density in the snow aspect-ratio relation (as in P3)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CloudMicrophysics"
 uuid = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
-version = "0.38.2"
+version = "0.38.3"
 authors = ["Climate Modeling Alliance"]
 
 [deps]

--- a/docs/src/Microphysics1M.md
+++ b/docs/src/Microphysics1M.md
@@ -297,6 +297,11 @@ where ``\delta = 4`` for the case of an exponential size distribution and the ma
 For snow, for simplicity, we first compute the
   mass-weighted mean aspect ratio over the size distribution of particles ``\phi_\text{avg}``
   and then treat this as constant when computing the group terminal velocity.
+The aspect ratio is obtained by inverting the assumed mass and area laws for
+  the particle thickness at the bulk ice density, as in the P3 scheme.
+Because the mass and area laws are independent parameterizations,
+  ``\phi_\text{avg}`` is an effective parameter of the [Chen2022](@cite)
+  velocity correction rather than a true geometric aspect ratio.
 
 !!! note
     For snow, we only use the B5 coefficients from [Chen2022](@cite).
@@ -330,6 +335,7 @@ where:
 An alternative rain autoconversion option with a prescribed cloud droplet
   number concentration ``N_c`` is also available
   (`PrescribedNd`, following Azimi et al. (2023)):
+
 ```math
 \begin{equation}
   \left. \frac{d \, q_\text{rai}}{dt} \right|_\text{acnv} =
@@ -757,7 +763,6 @@ For implicit time integration, the process rates are linearized with respect
 This linearization is implemented in the bulk tendencies module;
   see the Bulk tendencies documentation page for details.
 
-
 ## Example figures
 
 ```@example
@@ -772,6 +777,3 @@ include("plots/Microphysics1M_plots.jl")
 ![](rain_evaporation_rate.svg)
 ![](snow_sublimation_deposition_rate.svg)
 ![](snow_melt_rate.svg)
-
-
-

--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -169,11 +169,20 @@ and particle diameter φ(D) = φ₀ D^α.
 Also returns the coefficient κ for the aspect ratio in Chen et al. (2022)
 terminal velocity parameterization (κ=1/3 for oblate, κ=-1/6 for prolate).
 
+The spheroid relations invert the mass and area laws for the particle
+thickness at the given density. Because those laws are independent
+parameterizations, the resulting φ is an effective parameter of the
+Chen et al. (2022) velocity correction rather than a true geometric
+aspect ratio. Callers pass the bulk ice density (as the P3 scheme does
+for the same relation), which keeps the mass-weighted φ of the Oblate
+option below 1 and makes both shape options consistent with the
+prescribed-φ default to within about 20%.
+
 # Arguments
 - `snow_shape`: assumed snow particle shape (Oblate or Prolate)
 - `mass`: mass(radius) parameters (contains `r0`, `m0`, `me`, `Δm`, `χm`, `gamma_coeff`)
 - `area`: area(radius) parameters (contains `a0`, `ae`, `Δa`, `χa`)
-- `ρᵢ`: particle density
+- `ρᵢ`: bulk ice density [kg/m³]
 """
 @inline function aspect_ratio_coeffs(
     snow_shape::Oblate,
@@ -321,7 +330,7 @@ end
 end
 
 @inline function terminal_velocity(
-    (; pdf, mass, area, ρᵢ, gamma_aspect_oblate, gamma_aspect_prolate)::CMP.Snow,
+    (; pdf, mass, area, ρᵢ, ρᵢ_bulk, gamma_aspect_oblate, gamma_aspect_prolate)::CMP.Snow,
     vel::CMP.Chen2022VelTypeLargeIce,
     ρₐ,
     q,
@@ -335,7 +344,12 @@ end
     λ_inv_diameter = 2 * λ_inv_radius
     # Compute the mass weighted average aspect ratio ϕ_av
     # As a next step, we could keep ϕ(D) under the integrals
-    (ϕ₀, α, κ) = aspect_ratio_coeffs(snow_shape, mass, area, ρᵢ)
+    # The spheroid relation takes the BULK ice density (as in P3), not the
+    # snow apparent density ρᵢ that feeds the Chen coefficients: with
+    # ρᵢ = 100 kg/m³, the mass/area laws would imply ϕ > 1 at all mass-bearing
+    # sizes, outside the domain of Chen's oblate correction, and the two
+    # snow-shape options disagree with the prescribed-ϕ default by 2-3x.
+    (ϕ₀, α, κ) = aspect_ratio_coeffs(snow_shape, mass, area, ρᵢ_bulk)
     # Use pre-computed gamma_aspect from Snow struct
     gamma_aspect = snow_shape isa Oblate ? gamma_aspect_oblate : gamma_aspect_prolate
     # `aspect_ratio_coeffs` defines ϕ as a function of diameter, ϕ(D) = ϕ₀ D^α

--- a/src/parameters/Microphysics1M.jl
+++ b/src/parameters/Microphysics1M.jl
@@ -282,8 +282,10 @@ $(DocStringExtensions.FIELDS)
     vent::VT
     "a struct with aspect ratio parameters"
     aspr::AP
-    "snow apparent density [kg/m³]"
+    "snow apparent density [kg/m³], used in the Chen et al. (2022) coefficients"
     ρᵢ::FT
+    "bulk ice density [kg/m³], used in the spheroid aspect-ratio relation"
+    ρᵢ_bulk::FT
     "pre-computed gamma(α+4)/6 for oblate aspect ratio [-]"
     gamma_aspect_oblate::FT
     "pre-computed gamma(α+4)/6 for prolate aspect ratio [-]"
@@ -293,6 +295,7 @@ end
 function Snow(toml_dict::CP.ParamDict)
     name_map = (;
         :snow_apparent_density => :ρᵢ,
+        :density_ice_water => :ρᵢ_bulk,
         :snow_flake_size_distribution_coefficient_mu => :μ,
         :snow_flake_size_distribution_coefficient_nu => :ν,
         :snow_ventilation_coefficient_a => :a,
@@ -319,6 +322,7 @@ function Snow(toml_dict::CP.ParamDict)
         vent = Ventilation(p.a, p.b),
         aspr = SnowAspectRatio(p.ϕ, p.κ),
         p.ρᵢ,
+        p.ρᵢ_bulk,
         gamma_aspect_oblate = SF.gamma(α_oblate + 4) / SF.gamma(FT(4)),
         gamma_aspect_prolate = SF.gamma(α_prolate + 4) / SF.gamma(FT(4)),
     )

--- a/test/microphysics1M_tests.jl
+++ b/test/microphysics1M_tests.jl
@@ -105,8 +105,15 @@ function test_microphysics1M(FT)
 
         # reference values. `ϕ` is a function of diameter, so the mass-weighted
         # ⟨ϕ⟩ must use the diameter-based slope: checking here for consistency.
-        TT.@test vt_oblate ≈ FT(1.6992) rtol = 1e-4
-        TT.@test vt_prolate ≈ FT(1.4875) rtol = 1e-4
+        # The values assume the bulk ice density in the spheroid relation.
+        TT.@test vt_oblate ≈ FT(0.81191) rtol = 1e-4
+        TT.@test vt_prolate ≈ FT(0.71074) rtol = 1e-4
+
+        # with the bulk ice density in the spheroid relation, both shape
+        # options must stay consistent with the prescribed-ϕ default
+        vt_default = CM1.terminal_velocity(snow, Ch2022.large_ice, ρ, q_sno)
+        TT.@test 0.8 < vt_oblate / vt_default < 1.25
+        TT.@test 0.8 < vt_prolate / vt_default < 1.25
     end
 
     TT.@testset "1M_microphysics - 1M snow terminal velocity" begin


### PR DESCRIPTION
The shape-based snow terminal velocity derives an aspect ratio `ϕ` from the assumed mass and area laws via a spheroid relation. With the snow apparent density (100 kg/m³), the implied `ϕ` exceeds 1, which lies outside the domain of the Chen et al. (2022) oblate correction ; the correction (unphysically) enhanced fall speed. 

This PR passes the bulk ice density (916.7 kg/m³, the P3 scheme's convention for the same relation) into the spheroid relation; the apparent density is still used in other places in the Chen coefficients. The resulting ϕ is documented as an effective parameter of the velocity correction, not a true geometry factor

Implication: shape-based snow fall speeds decrease by ~2×, bringing all three snow-velocity options (Oblate, Prolate, prescribed-ϕ default) into agreement within 5–17%, where they previously disagreed by a factor of 2–3. The default (non-shape) variant is unchanged. 