### PR TITLE
1M correctness and robustness fixes

### DIFF
--- a/docs/src/Microphysics1M.md
+++ b/docs/src/Microphysics1M.md
@@ -299,8 +299,8 @@ For snow, for simplicity, we first compute the
   and then treat this as constant when computing the group terminal velocity.
 
 !!! note
-    For snow, we only use the B4 coefficients from [Chen2022](@cite).
-    We should switch to doing partial integrals and include also the B2 coefficients.
+    For snow, we only use the B5 coefficients from [Chen2022](@cite).
+    We should switch to doing partial integrals and include also the B3 coefficients.
 
 ## Rain autoconversion
 
@@ -663,8 +663,10 @@ where:
 - saturation S is computed over water or ice
 
 For snow, both deposition (``S > 1``) and sublimation (``S < 1``) are
-  allowed by default; a `SublimationOnly` option is also available that
-  clamps the rate to be non-positive (sublimation only).
+  allowed by default, except that deposition is suppressed above freezing,
+  where ice does not grow by vapor deposition;
+  a `SublimationOnly` option is also available that
+  clamps the rate to be non-positive (sublimation only) at all temperatures.
 
 The final integral is:
 

--- a/src/Common.jl
+++ b/src/Common.jl
@@ -283,8 +283,8 @@ Compute the coefficients for the Chen 2022 terminal velocity parametrization.
 # Arguments
  - `coeffs`: a struct with terminal velocity free parameters
     - [`CMP.Chen2022VelTypeRain`](@ref): Fetch from Table B1
-    - [`CMP.Chen2022VelTypeSmallIce`](@ref): Fetch from Table B2
-    - [`CMP.Chen2022VelTypeLargeIce`](@ref): Fetch from Table B4
+    - [`CMP.Chen2022VelTypeSmallIce`](@ref): Fetch from Table B3
+    - [`CMP.Chen2022VelTypeLargeIce`](@ref): Fetch from Table B5
  - `ρₐ`: air density [kg/m³]
  - `ρᵢ`: apparent density of ice particles [kg/m³],
     only used for [`CMP.Chen2022VelTypeSmallIce`](@ref) and [`CMP.Chen2022VelTypeLargeIce`](@ref)
@@ -322,7 +322,7 @@ end
     Es = E[1] - E[2] * log_ρᵢ^2 + E[3] * sqrt_ρᵢ
     Fs = -exp(F[1] - F[2] * log_ρᵢ^2 + F[3] * log_ρᵢ)
     Gs = 1 / (G[1] + G[2] / log_ρᵢ - G[3] * log_ρᵢ / ρᵢ)
-    # Table B2
+    # Table B3
     ai = (Es * ρₐ^As, Fs * ρₐ^As)
     bi = (Bs + ρₐ * Cs, Bs + ρₐ * Cs)
     ci = (FT(0), Gs)
@@ -346,7 +346,7 @@ end
     Fl = F[1] + F[2] * log_ρᵢ - exp(log(-F[3]) - ρᵢ)
     Gl = 1 / (G[1] + G[2] * log_ρᵢ * sqrt_ρᵢ + G[3] / sqrt_ρᵢ)
     Hl = H[1] + H[2] * ρᵢ^2 * sqrt_ρᵢ + exp(log(-H[3]) - ρᵢ)  # ρᵢ^(5/2) = ρᵢ^2 * sqrt(ρᵢ)
-    # Table B4
+    # Table B5
     ai = (Bl * ρₐ^Al, El * ρₐ^Al * exp(Hl * ρₐ))
     bi = (Cl, Fl)
     ci = (FT(0), Gl)

--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -82,11 +82,13 @@ Returns the intercept parameter of the assumed Marshall-Palmer distribution
 - `q_sno`: snow specific content (snow only)
 - `ρ`: air density (snow only)
 """
-@inline function get_n0((; ν, μ)::CMP.ParticlePDFSnow{FT}, q_sno::FT, ρ::FT) where {FT}
-    safe_q_sno = max(q_sno, UT.ϵ_numerics(FT))
-    return ifelse(q_sno > UT.ϵ_numerics(FT), μ * (ρ * safe_q_sno)^ν, zero(FT))
+@inline function get_n0((; ν, μ)::CMP.ParticlePDFSnow, q_sno, ρ)
+    ϵ = UT.ϵ_numerics(q_sno)
+    safe_q_sno = max(q_sno, ϵ)
+    n0 = μ * (ρ * safe_q_sno)^ν
+    return ifelse(q_sno > ϵ, n0, zero(n0))
 end
-@inline get_n0((; n0)::CMP.ParticlePDFIceRain{FT}, args...) where {FT} = n0
+@inline get_n0((; n0)::CMP.ParticlePDFIceRain, args...) = n0
 
 """
     get_v0(vel::Blk1MVelTypeRain, ρ)
@@ -100,12 +102,16 @@ Guards against unphysical density ratios (ρ > ρw) that would cause sqrt of neg
 - `vel`: terminal velocity parameters (contains `C_drag`, `ρw`, `grav`, `r0`, `gamma_term` for rain; `v0`, `gamma_term` for snow)
 - `ρ`: air density (rain only)
 """
-@inline function get_v0((; C_drag, ρw, grav, r0)::CMP.Blk1MVelTypeRain{FT}, ρ::FT) where {FT}
-    # Guard against ρ > ρw (unphysical but could occur from numerical errors)
-    density_factor = max(ρw / ρ - 1, zero(FT))
-    return sqrt(FT(8 / 3) / C_drag * density_factor * grav * r0)
+@inline function get_v0((; C_drag, ρw, grav, r0)::CMP.Blk1MVelTypeRain, ρ)
+    # Guard against ρ > ρw (unphysical but possible from numerical errors).
+    # The floor is ϵ > 0 rather than 0: sqrt has an infinite derivative at
+    # 0, so a zero floor turns Dual (ForwardDiff) partials into Inf/NaN.
+    density_factor = max(ρw / ρ - 1, UT.ϵ_numerics(ρ))
+    # Integer literals keep this in the arguments' own type
+    # (no Float64 promotion).
+    return sqrt(8 * density_factor * grav * r0 / (3 * C_drag))
 end
-@inline get_v0((; v0)::CMP.Blk1MVelTypeSnow{FT}, args...) where {FT} = v0
+@inline get_v0((; v0)::CMP.Blk1MVelTypeSnow, args...) = v0
 
 """
     lambda_inverse(pdf, mass::ParticleMass, q, ρ)
@@ -127,13 +133,14 @@ average particles. The value is clipped at `r0 * 1e-5` to prevent numerical issu
 """
 @inline function lambda_inverse(
     #(; pdf, mass)::Union{CMP.Snow{FT}, CMP.Rain{FT}, CMP.CloudIce{FT}},
-    pdf::Union{CMP.ParticlePDFIceRain{FT}, CMP.ParticlePDFSnow{FT}},
-    mass::CMP.ParticleMass{FT},
-    q::FT,
-    ρ::FT,
-) where {FT}
+    pdf::Union{CMP.ParticlePDFIceRain, CMP.ParticlePDFSnow},
+    mass::CMP.ParticleMass,
+    q,
+    ρ,
+)
+    FT = UT.promote_typeof(q, ρ)
     # size distribution
-    n0::FT = get_n0(pdf, q, ρ)
+    n0 = get_n0(pdf, q, ρ)
     # mass(size)
     (; r0, m0, me, Δm, χm, gamma_coeff) = mass
 
@@ -148,7 +155,7 @@ average particles. The value is clipped at `r0 * 1e-5` to prevent numerical issu
     # ParticleMass constructor for GPU performance.
     qp = UT.clamp_to_nonneg(q)
     ρp = UT.clamp_to_nonneg(ρ)
-    denom = χm * m0 * max(n0, UT.ϵ_numerics(FT)) * gamma_coeff
+    denom = χm * m0 * max(n0, UT.ϵ_numerics(n0)) * gamma_coeff
     λ_inv = (ρp * qp * r0^(me + Δm) / denom)^(1 / (me + Δm + 1))
     return max(r0 * FT(1e-5), λ_inv)
 end
@@ -170,12 +177,16 @@ terminal velocity parameterization (κ=1/3 for oblate, κ=-1/6 for prolate).
 """
 @inline function aspect_ratio_coeffs(
     snow_shape::Oblate,
-    (; r0, m0, me, Δm, χm)::CMP.ParticleMass{FT},
-    (; a0, ae, Δa, χa)::CMP.ParticleArea{FT},
-    ρᵢ::FT,
-) where {FT}
+    (; r0, m0, me, Δm, χm)::CMP.ParticleMass,
+    (; a0, ae, Δa, χa)::CMP.ParticleArea,
+    ρᵢ,
+)
+    FT = UT.promote_typeof(m0, a0)
     # ϕ(r) = 3 * sqrt(FT(π)) * mᵢ(r) / (4 * ρᵢ * aᵢ(r)^(3/2)
-    α = me + Δm - 3 / 2 * (ae + Δa)
+    # Integer literals only: a `3 / 2` float literal would promote α (and
+    # hence ϕ₀) to Float64, and α is reused as an exponent here and in
+    # `terminal_velocity`
+    α = me + Δm - 3 * (ae + Δa) / 2
     ϕ₀ = 3 * sqrt(FT(π)) / 4 / ρᵢ * χm * m0 / (χa * a0)^FT(3 / 2) / (2 * r0)^α
     κ = FT(1 / 3)
     return (; ϕ₀, α, κ)
@@ -183,10 +194,11 @@ end
 
 @inline function aspect_ratio_coeffs(
     snow_shape::Prolate,
-    (; r0, m0, me, Δm, χm)::CMP.ParticleMass{FT},
-    (; a0, ae, Δa, χa)::CMP.ParticleArea{FT},
-    ρᵢ::FT,
-) where {FT}
+    (; r0, m0, me, Δm, χm)::CMP.ParticleMass,
+    (; a0, ae, Δa, χa)::CMP.ParticleArea,
+    ρᵢ,
+)
+    FT = UT.promote_typeof(m0, a0)
     # ϕ(r) = 16 * ρᵢ^2 * aᵢ(r)^3 / (9 * π * mᵢ(r)^2)
     α = 3 * (ae + Δa) - 2 * (me + Δm)
     ϕ₀ = 16 * ρᵢ^2 / 9 / FT(π) * (χa * a0)^3 / (χm * m0)^2 / (2 * r0)^α
@@ -227,27 +239,27 @@ Fall velocity of individual particles is parameterized:
 """
 @inline function terminal_velocity(
     (; pdf, mass)::Union{CMP.Rain, CMP.Snow},
-    vel::Union{CMP.Blk1MVelTypeRain{FT}, CMP.Blk1MVelTypeSnow{FT}},
-    ρ::FT,
-    q::FT,
-    v0::FT,
-    λ_inv::FT,
-) where {FT}
+    vel::Union{CMP.Blk1MVelTypeRain, CMP.Blk1MVelTypeSnow},
+    ρ,
+    q,
+    v0,
+    λ_inv,
+)
     (; χv, ve, Δv, gamma_term) = vel
     (; r0, me, Δm, χm, gamma_coeff) = mass
 
     # gamma_term = SF.gamma(me + ve + Δm + Δv + 1) (pre-computed in vel)
     # gamma_coeff = SF.gamma(me + Δm + 1) (pre-computed in mass)
     fall_w = χv * v0 * (λ_inv / r0)^(ve + Δv) * gamma_term / gamma_coeff
-    return ifelse(q > UT.ϵ_numerics(FT), fall_w, zero(FT))
+    return ifelse(q > UT.ϵ_numerics(q), fall_w, zero(fall_w))
 end
 
 @inline function terminal_velocity(
     precip::Union{CMP.Rain, CMP.Snow},
-    vel::Union{CMP.Blk1MVelTypeRain{FT}, CMP.Blk1MVelTypeSnow{FT}},
-    ρ::FT,
-    q::FT,
-) where {FT}
+    vel::Union{CMP.Blk1MVelTypeRain, CMP.Blk1MVelTypeSnow},
+    ρ,
+    q,
+)
     v0 = get_v0(vel, ρ)
     λ_inv = lambda_inverse(precip.pdf, precip.mass, q, ρ)
     return terminal_velocity(precip, vel, ρ, q, v0, λ_inv)
@@ -255,14 +267,14 @@ end
 
 @inline function terminal_velocity(
     (; pdf, mass)::CMP.Rain,
-    vel::CMP.Chen2022VelTypeRain{FT},
-    ρₐ::FT,
-    q::FT,
-) where {FT}
+    vel::CMP.Chen2022VelTypeRain,
+    ρₐ,
+    q,
+)
     # coefficients from Table B1 from Chen et. al. 2022
     aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρₐ)
     # size distribution parameter
-    λ_inv_radius::FT = lambda_inverse(pdf, mass, q, ρₐ)
+    λ_inv_radius = lambda_inverse(pdf, mass, q, ρₐ)
     λ_inv_diameter = 2 * λ_inv_radius
     # eq 20 from Chen et al 2022 (loop unrolled for GPU performance)
     fall_w =
@@ -270,23 +282,23 @@ end
         CO.Chen2022_exponential_pdf(aiu[2], bi[2], ciu[2], λ_inv_diameter, 3) +
         CO.Chen2022_exponential_pdf(aiu[3], bi[3], ciu[3], λ_inv_diameter, 3)
     # It should be ϕ^κ * fall_w, but for rain drops ϕ = 1 and κ = 0
-    fall_w = max(FT(0), fall_w)
-    return ifelse(q > UT.ϵ_numerics(FT), fall_w, zero(FT))
+    fall_w = UT.clamp_to_nonneg(fall_w)
+    return ifelse(q > UT.ϵ_numerics(q), fall_w, zero(fall_w))
 end
 
 @inline function terminal_velocity(
     (; pdf, mass, area, ρᵢ, aspr)::CMP.Snow,
-    vel::CMP.Chen2022VelTypeLargeIce{FT},
-    ρₐ::FT,
-    q::FT,
-) where {FT}
+    vel::CMP.Chen2022VelTypeLargeIce,
+    ρₐ,
+    q,
+)
     # We assume the B4 table coeffs for snow and B2 table coeffs for cloud ice.
     # Instead we should do partial integrals
     # from D=125um to D=625um using B2 and D=625um to inf using B4.
     # coefficients from Table B4 from Chen et. al. 2022
     aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρₐ, ρᵢ)
     # size distribution parameter
-    λ_inv_radius::FT = lambda_inverse(pdf, mass, q, ρₐ)
+    λ_inv_radius = lambda_inverse(pdf, mass, q, ρₐ)
     λ_inv_diameter = 2 * λ_inv_radius
 
     # As a next step, we could keep ϕ(r) under the integrals
@@ -297,35 +309,38 @@ end
     fall_w =
         ϕ^κ * CO.Chen2022_exponential_pdf(aiu[1], bi[1], ciu[1], λ_inv_diameter, 3) +
         ϕ^κ * CO.Chen2022_exponential_pdf(aiu[2], bi[2], ciu[2], λ_inv_diameter, 3)
-    fall_w = max(FT(0), fall_w)
-    return ifelse(q > UT.ϵ_numerics(FT), fall_w, zero(FT))
+    fall_w = UT.clamp_to_nonneg(fall_w)
+    return ifelse(q > UT.ϵ_numerics(q), fall_w, zero(fall_w))
 end
 
 @inline function terminal_velocity(
     (; pdf, mass, area, ρᵢ, gamma_aspect_oblate, gamma_aspect_prolate)::CMP.Snow,
-    vel::CMP.Chen2022VelTypeLargeIce{FT},
-    ρₐ::FT,
-    q::FT,
+    vel::CMP.Chen2022VelTypeLargeIce,
+    ρₐ,
+    q,
     snow_shape::AbstractSnowShape,
-) where {FT}
+)
     # see comments above about B2 vs B4 coefficients
     # coefficients from Table B4 from Chen et. al. 2022
     aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρₐ, ρᵢ)
     # size distribution parameter
-    λ_inv_radius::FT = lambda_inverse(pdf, mass, q, ρₐ)
+    λ_inv_radius = lambda_inverse(pdf, mass, q, ρₐ)
     λ_inv_diameter = 2 * λ_inv_radius
     # Compute the mass weighted average aspect ratio ϕ_av
-    # As a next step, we could keep ϕ(r) under the integrals
+    # As a next step, we could keep ϕ(D) under the integrals
     (ϕ₀, α, κ) = aspect_ratio_coeffs(snow_shape, mass, area, ρᵢ)
     # Use pre-computed gamma_aspect from Snow struct
     gamma_aspect = snow_shape isa Oblate ? gamma_aspect_oblate : gamma_aspect_prolate
-    ϕ_av = ϕ₀ * λ_inv_radius^α * gamma_aspect
+    # `aspect_ratio_coeffs` defines ϕ as a function of diameter, ϕ(D) = ϕ₀ D^α
+    # (ϕ₀ absorbs (2r0)^α), so the moment ⟨D^α⟩ uses the diameter-based slope.
+    # Using λ_inv_radius here instead drops a factor 2^α from ϕ_av.
+    ϕ_av = ϕ₀ * λ_inv_diameter^α * gamma_aspect
     # eq 20 from Chen 2022 (loop unrolled for GPU performance)
     fall_w =
         ϕ_av^κ * CO.Chen2022_exponential_pdf(aiu[1], bi[1], ciu[1], λ_inv_diameter, 3) +
         ϕ_av^κ * CO.Chen2022_exponential_pdf(aiu[2], bi[2], ciu[2], λ_inv_diameter, 3)
-    fall_w = max(FT(0), fall_w)
-    return ifelse(q > UT.ϵ_numerics(FT), fall_w, zero(FT))
+    fall_w = UT.clamp_to_nonneg(fall_w)
+    return ifelse(q > UT.ϵ_numerics(q), fall_w, zero(fall_w))
 end
 
 """
@@ -446,8 +461,8 @@ end
         exp(-r_ice_snow / λ_inv) *
         (r_ice_snow^2 / (me + Δm) + (r_ice_snow / λ_inv + 1) * λ_inv^2)
 
-    cond = q_icl > UT.ϵ_numerics(FT) && S > FT(0) && T < T_freeze
-    return ifelse(cond, acnv_rate, zero(FT))
+    cond = q_icl > UT.ϵ_numerics(q_icl) && S > 0 && T < T_freeze
+    return ifelse(cond, acnv_rate, zero(acnv_rate))
 end
 
 """
@@ -470,11 +485,13 @@ contribution of warm liquid on snow.
 end
 
 # Gating convention for the process-rate kernels below: the rate is computed
-# unconditionally and then gated with `ifelse(cond, rate, zero(FT))` instead of an
-# `if` guard, so the kernel stays branchless (no warp divergence) on the GPU. The
-# `max(x, ϵ_numerics)` clamps on denominators (e.g. `lambda_inverse`'s floor, the
-# Schmidt-number guard) keep the discarded `ifelse` branch finite — important for
-# ForwardDiff/Dual gradients and to avoid Inf/NaN handling cost.
+# unconditionally and then gated with `ifelse(cond, rate, zero(rate))`, so the 
+# kernel stays branchless on the GPU. `zero(rate)` types the fallback from the 
+# live branch, so both `ifelse` arms agree for any argument mix (plain floats, 
+# ForwardDiff Duals). The `max(x, ϵ_numerics)` clamps on denominators (e.g.,
+# `lambda_inverse`'s floor, the Schmidt-number guard) keep the discarded
+# `ifelse` branch finite (important for ForwardDiff/Dual gradients and to
+# avoid Inf/NaN handling cost).
 
 """
     accretion(cloud, precip, vel, E, q_clo, q_pre, ρ, n0, v0, λ_inv)
@@ -501,15 +518,15 @@ distribution before calling the 10-argument kernel.
 @inline function accretion(
     cloud::CMP.CloudCondensateType,
     precip::CMP.PrecipitationType,
-    vel::Union{CMP.Blk1MVelTypeRain{FT}, CMP.Blk1MVelTypeSnow{FT}},
-    E::FT,
-    q_clo::FT,
-    q_pre::FT,
-    ρ::FT,
-    n0::FT,
-    v0::FT,
-    λ_inv::FT,
-) where {FT}
+    vel::Union{CMP.Blk1MVelTypeRain, CMP.Blk1MVelTypeSnow},
+    E,
+    q_clo,
+    q_pre,
+    ρ,
+    n0,
+    v0,
+    λ_inv,
+)
     (; r0) = precip.mass
     (; χv, ve, Δv, gamma_accr) = vel
     (; a0, ae, χa, Δa) = precip.area
@@ -519,21 +536,22 @@ distribution before calling the 10-argument kernel.
         q_clo * E * n0 * a0 * v0 * χa * χv * λ_inv *
         gamma_accr / (r0 / λ_inv)^(ae + ve + Δa + Δv)
 
-    cond = q_clo > UT.ϵ_numerics(FT) && q_pre > UT.ϵ_numerics(FT)
-    return ifelse(cond, accr_rate, zero(FT))
+    ϵ = UT.ϵ_numerics(UT.promote_typeof(q_clo, q_pre))
+    cond = q_clo > ϵ && q_pre > ϵ
+    return ifelse(cond, accr_rate, zero(accr_rate))
 end
 
 @inline function accretion(
     cloud::CMP.CloudCondensateType,
     precip::CMP.PrecipitationType,
-    vel::Union{CMP.Blk1MVelTypeRain{FT}, CMP.Blk1MVelTypeSnow{FT}},
-    E::FT,
-    q_clo::FT,
-    q_pre::FT,
-    ρ::FT,
-) where {FT}
-    n0::FT = get_n0(precip.pdf, q_pre, ρ)
-    v0::FT = get_v0(vel, ρ)
+    vel::Union{CMP.Blk1MVelTypeRain, CMP.Blk1MVelTypeSnow},
+    E,
+    q_clo,
+    q_pre,
+    ρ,
+)
+    n0 = get_n0(precip.pdf, q_pre, ρ)
+    v0 = get_v0(vel, ρ)
     λ_inv = lambda_inverse(precip.pdf, precip.mass, q_pre, ρ)
     return accretion(cloud, precip, vel, E, q_clo, q_pre, ρ, n0, v0, λ_inv)
 end
@@ -545,17 +563,17 @@ end
 @inline function accretion_rain_sink(
     rain::CMP.Rain,
     ice::CMP.CloudIce,
-    vel::CMP.Blk1MVelTypeRain{FT},
-    E::FT,
-    q_icl::FT,
-    q_rai::FT,
-    ρ::FT,
-    n0_ice::FT,
-    λ_ice_inv::FT,
-    n0::FT,
-    v0::FT,
-    λ_inv::FT,
-) where {FT}
+    vel::CMP.Blk1MVelTypeRain,
+    E,
+    q_icl,
+    q_rai,
+    ρ,
+    n0_ice,
+    λ_ice_inv,
+    n0,
+    v0,
+    λ_inv,
+)
     (; r0, m0, me, Δm, χm) = rain.mass
     (; χv, ve, Δv, gamma_accr_rain_sink) = vel
     (; a0, ae, χa, Δa) = rain.area
@@ -564,21 +582,22 @@ end
     accr_rate =
         E / ρ * n0 * n0_ice * m0 * a0 * v0 * χm * χa * χv * λ_ice_inv * λ_inv *
         gamma_accr_rain_sink /
-        (r0 / λ_inv)^FT(me + ae + ve + Δm + Δa + Δv)
+        (r0 / λ_inv)^(me + ae + ve + Δm + Δa + Δv)
 
-    cond = q_icl > UT.ϵ_numerics(FT) && q_rai > UT.ϵ_numerics(FT)
-    return ifelse(cond, accr_rate, zero(FT))
+    ϵ = UT.ϵ_numerics(UT.promote_typeof(q_icl, q_rai))
+    cond = q_icl > ϵ && q_rai > ϵ
+    return ifelse(cond, accr_rate, zero(accr_rate))
 end
 
 @inline function accretion_rain_sink(
     rain::CMP.Rain,
     ice::CMP.CloudIce,
-    vel::CMP.Blk1MVelTypeRain{FT},
-    E::FT,
-    q_icl::FT,
-    q_rai::FT,
-    ρ::FT,
-) where {FT}
+    vel::CMP.Blk1MVelTypeRain,
+    E,
+    q_icl,
+    q_rai,
+    ρ,
+)
     n0_ice = get_n0(ice.pdf)
     λ_ice_inv = lambda_inverse(ice.pdf, ice.mass, q_icl, ρ)
     n0 = get_n0(rain.pdf, q_rai, ρ)
@@ -630,18 +649,18 @@ deviations are proportional to the mean fall velocities, with coefficient
     type_j::CMP.PrecipitationType,
     blk1mveltype_ti,
     blk1mveltype_tj,
-    E_ij::FT,
-    coeff_disp::FT,
-    q_i::FT,
-    q_j::FT,
-    ρ::FT,
-    n0_i::FT,
-    n0_j::FT,
-    v0_i::FT,
-    v0_j::FT,
-    λ_i_inv::FT,
-    λ_j_inv::FT,
-) where {FT}
+    E_ij,
+    coeff_disp,
+    q_i,
+    q_j,
+    ρ,
+    n0_i,
+    n0_j,
+    v0_i,
+    v0_j,
+    λ_i_inv,
+    λ_j_inv,
+)
     (; r0, m0, me, Δm, χm, gamma_coeff) = type_j.mass
     δ = me + Δm
 
@@ -656,15 +675,16 @@ deviations are proportional to the mean fall velocities, with coefficient
     # We use the recurrence relation Γ(x+1) = xΓ(x) to simplify gamma terms.
     # gamma_coeff = Γ(δ + 1) is pre-computed.
     accr_rate =
-        FT(π) / ρ * n0_i * n0_j * m0 * χm * E_ij * Δv_eff * gamma_coeff /
+        π / ρ * n0_i * n0_j * m0 * χm * E_ij * Δv_eff * gamma_coeff /
         r0^δ * (
             2 * λ_i_inv^3 * λ_j_inv^(δ + 1) +
             2 * (δ + 1) * λ_i_inv^2 * λ_j_inv^(δ + 2) +
             (δ + 2) * (δ + 1) * λ_i_inv * λ_j_inv^(δ + 3)
         )
 
-    cond = q_i > UT.ϵ_numerics(FT) && q_j > UT.ϵ_numerics(FT)
-    return ifelse(cond, accr_rate, zero(FT))
+    ϵ = UT.ϵ_numerics(UT.promote_typeof(q_i, q_j))
+    cond = q_i > ϵ && q_j > ϵ
+    return ifelse(cond, accr_rate, zero(accr_rate))
 end
 
 @inline function accretion_snow_rain(
@@ -672,12 +692,12 @@ end
     type_j::CMP.PrecipitationType,
     blk1mveltype_ti,
     blk1mveltype_tj,
-    E_ij::FT,
-    coeff_disp::FT,
-    q_i::FT,
-    q_j::FT,
-    ρ::FT,
-) where {FT}
+    E_ij,
+    coeff_disp,
+    q_i,
+    q_j,
+    ρ,
+)
     n0_i = get_n0(type_i.pdf, q_i, ρ)
     n0_j = get_n0(type_j.pdf, q_j, ρ)
     v0_i = get_v0(blk1mveltype_ti, ρ)
@@ -973,7 +993,7 @@ Only evaporation is considered (sub-saturated over liquid); result is clamped �
     a_vent = vent.a
     b_vent = vent.b
 
-    Sc = ν_air / max(D_vapor, UT.ϵ_numerics(FT))
+    Sc = ν_air / max(D_vapor, UT.ϵ_numerics(D_vapor))
 
     evap_rate =
         4 * FT(π) * n0 / ρ * S * G * λ_inv^2 *
@@ -985,8 +1005,8 @@ Only evaporation is considered (sub-saturated over liquid); result is clamped �
             gamma_vent
         )
 
-    cond = q_rai > UT.ϵ_numerics(FT) && S < FT(0)
-    return min(zero(FT), ifelse(cond, evap_rate, zero(FT)))
+    cond = q_rai > UT.ϵ_numerics(q_rai) && S < 0
+    return min(0, ifelse(cond, evap_rate, zero(evap_rate)))
 end
 
 """
@@ -1050,7 +1070,7 @@ end
     a_vent = vent.a
     b_vent = vent.b
 
-    Sc = ν_air / max(D_vapor, UT.ϵ_numerics(FT))
+    Sc = ν_air / max(D_vapor, UT.ϵ_numerics(D_vapor))
 
     subl_rate =
         4 * FT(π) * n0 / ρ * S * G * λ_inv^2 *
@@ -1062,8 +1082,8 @@ end
             gamma_vent
         )
 
-    cond = q_sno > UT.ϵ_numerics(FT)
-    return ifelse(cond, subl_rate, zero(FT))
+    cond = q_sno > UT.ϵ_numerics(q_sno)
+    return ifelse(cond, subl_rate, zero(subl_rate))
 end
 
 
@@ -1102,8 +1122,8 @@ Returns the tendency due to cloud ice melt.
     λ_inv = sd.λ_inv_icl
     cloud_ice_melt_rate = 4 * FT(π) * n0 / ρ * K_therm / L * (T - T_freeze) * λ_inv^2
 
-    cond = q_icl > UT.ϵ_numerics(FT) && T > T_freeze
-    return ifelse(cond, cloud_ice_melt_rate, zero(FT))
+    cond = q_icl > UT.ϵ_numerics(q_icl) && T > T_freeze
+    return ifelse(cond, cloud_ice_melt_rate, zero(cloud_ice_melt_rate))
 end
 
 """
@@ -1152,7 +1172,7 @@ Returns the tendency due to snow melt.
     b_vent = vent.b
 
     # Schmidt number (guard against division by near-zero D_vapor)
-    Sc = ν_air / max(D_vapor, UT.ϵ_numerics(FT))
+    Sc = ν_air / max(D_vapor, UT.ϵ_numerics(D_vapor))
 
     snow_melt_rate =
         4 * FT(π) * n0 / ρ * K_therm / L * (T - T_freeze) * λ_inv^2 *
@@ -1164,8 +1184,8 @@ Returns the tendency due to snow melt.
             gamma_vent
         )
 
-    cond = q_sno > UT.ϵ_numerics(FT) && T > T_freeze
-    return ifelse(cond, snow_melt_rate, zero(FT))
+    cond = q_sno > UT.ϵ_numerics(q_sno) && T > T_freeze
+    return ifelse(cond, snow_melt_rate, zero(snow_melt_rate))
 end
 
 end #module Microphysics1M.jl

--- a/src/Microphysics1M.jl
+++ b/src/Microphysics1M.jl
@@ -236,6 +236,13 @@ Fall velocity of individual particles is parameterized:
 
 # Returns
 - Mass-weighted terminal velocity [m/s]
+
+# Notes
+- The `q > ϵ_numerics` presence gate returns exactly 0 for absent tracers,
+  while the fall speed just above the gate is finite (about 0.4 m/s in
+  Float32), so `v_t` is discontinuous there. The associated mass flux
+  `q v_t` is below 1e-13 kg/kg m/s, so physically negligible, but treat `v_t`
+  near the gate with care.
 """
 @inline function terminal_velocity(
     (; pdf, mass)::Union{CMP.Rain, CMP.Snow},
@@ -292,10 +299,10 @@ end
     ρₐ,
     q,
 )
-    # We assume the B4 table coeffs for snow and B2 table coeffs for cloud ice.
+    # We assume the B5 table coeffs for snow and B3 table coeffs for cloud ice.
     # Instead we should do partial integrals
-    # from D=125um to D=625um using B2 and D=625um to inf using B4.
-    # coefficients from Table B4 from Chen et. al. 2022
+    # from D=125um to D=625um using B3 and D=625um to inf using B5.
+    # coefficients from Table B5 from Chen et. al. 2022
     aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρₐ, ρᵢ)
     # size distribution parameter
     λ_inv_radius = lambda_inverse(pdf, mass, q, ρₐ)
@@ -320,8 +327,8 @@ end
     q,
     snow_shape::AbstractSnowShape,
 )
-    # see comments above about B2 vs B4 coefficients
-    # coefficients from Table B4 from Chen et. al. 2022
+    # see comments above about B3 vs B5 coefficients
+    # coefficients from Table B5 from Chen et. al. 2022
     aiu, bi, ciu = CO.Chen2022_vel_coeffs(vel, ρₐ, ρᵢ)
     # size distribution parameter
     λ_inv_radius = lambda_inverse(pdf, mass, q, ρₐ)
@@ -341,6 +348,24 @@ end
         ϕ_av^κ * CO.Chen2022_exponential_pdf(aiu[2], bi[2], ciu[2], λ_inv_diameter, 3)
     fall_w = UT.clamp_to_nonneg(fall_w)
     return ifelse(q > UT.ϵ_numerics(q), fall_w, zero(fall_w))
+end
+
+# The option argument selects the parameterization, but the shape of
+# `mp.process_params` is fixed by the options `mp` was constructed with.
+# This guard turns an option/parameter mismatch into an actionable error
+# instead of an obscure field-access failure; the `isa` check folds away at
+# compile time when the types are consistent.
+@noinline _throw_option_params_mismatch(opt, pp, field::Symbol) = throw(
+    ArgumentError(
+        "$(typeof(opt)) requires `mp.process_params.$field` built for this " *
+        "option, got $(typeof(pp)). Construct the parameters with the " *
+        "matching option, e.g. " *
+        "`Microphysics1MParams(FT; $field = $(nameof(typeof(opt)))())`.",
+    ),
+)
+@inline function _consistent_params(pp, ::Type{T}, opt, field::Symbol) where {T}
+    pp isa T || _throw_option_params_mismatch(opt, pp, field)
+    return pp
 end
 
 """
@@ -371,15 +396,17 @@ using the prescribed cloud droplet number concentration.
 """
 @inline conv_q_lcl_to_q_rai(::Nothing, mp, tps, micro, thermo) = zero(micro.q_lcl)
 
-@inline function conv_q_lcl_to_q_rai(::CMP.Kessler1M, mp, tps, micro, thermo)
+@inline function conv_q_lcl_to_q_rai(opt::CMP.Kessler1M, mp, tps, micro, thermo)
     q_lcl = micro.q_lcl
-    (; τ, q_threshold, k) = mp.process_params.rain_autoconversion
+    pp = _consistent_params(mp.process_params.rain_autoconversion, CMP.Acnv1M, opt, :rain_autoconversion)
+    (; τ, q_threshold, k) = pp
     return CO.logistic_function_integral(q_lcl, q_threshold, k) / τ
 end
 
-@inline function conv_q_lcl_to_q_rai(::CMP.PrescribedNd, mp, tps, micro, thermo)
+@inline function conv_q_lcl_to_q_rai(opt::CMP.PrescribedNd, mp, tps, micro, thermo)
     q_lcl = micro.q_lcl
-    (; τ, α, Nc) = mp.process_params.rain_autoconversion
+    pp = _consistent_params(mp.process_params.rain_autoconversion, CMP.VarTimescaleAcnv, opt, :rain_autoconversion)
+    (; τ, α, Nc) = pp
     return max(0, q_lcl) / (τ * (Nc / 100_000_000)^α)
 end
 
@@ -431,8 +458,9 @@ Harrington et al. (1995) and Kaul et al. (2015).
 """
 @inline conv_q_icl_to_q_sno(::Nothing, mp, tps, micro, thermo, sd = nothing) = zero(micro.q_icl)
 
-@inline function conv_q_icl_to_q_sno(::CMP.NoSupersaturation, mp, tps, micro, thermo, sd = nothing)
-    (; τ, q_threshold, k) = mp.process_params.snow_autoconversion
+@inline function conv_q_icl_to_q_sno(opt::CMP.NoSupersaturation, mp, tps, micro, thermo, sd = nothing)
+    pp = _consistent_params(mp.process_params.snow_autoconversion, CMP.Acnv1M, opt, :snow_autoconversion)
+    (; τ, q_threshold, k) = pp
     q_icl = micro.q_icl
     return CO.logistic_function_integral(q_icl, q_threshold, k) / τ
 end
@@ -442,7 +470,11 @@ end
 )
     (; q_tot, q_lcl, q_icl, q_rai, q_sno) = micro
     (; ρ, T) = thermo
-    r_ice_snow = mp.process_params.snow_autoconversion.r_ice_snow
+    pp = _consistent_params(
+        mp.process_params.snow_autoconversion, NamedTuple{(:r_ice_snow,)},
+        CMP.WithSupersaturation(), :snow_autoconversion,
+    )
+    r_ice_snow = pp.r_ice_snow
     (; pdf, mass) = mp.cloud.ice
     aps = mp.air_properties
     FT = eltype(ρ)
@@ -469,7 +501,7 @@ end
     warm_accretion_melt_factor(tps, T)
 
 Ratio of sensible heat from warm collected liquid to latent heat for melting:
-`α = cv_l / L_f × (T - T_freeze)`, returning 0 when `T ≤ T_freeze`.
+`α = cp_l / L_f × (T - T_freeze)`, returning 0 when `T ≤ T_freeze`.
 
 Used by `accretion(::CloudLiquidSnowAccretion, ...)` and
 `accretion_snow_rain(::RainSnowAccretion, ...)` to compute the thermal melt
@@ -477,11 +509,11 @@ contribution of warm liquid on snow.
 """
 @inline function warm_accretion_melt_factor(tps, T)
     L_f = TDI.Lf(tps, T)
-    cv_l = TDI.cv_l(tps)
+    cp_l = TDI.cp_l(tps)
     T_freeze = TDI.T_freeze(tps)
     ΔT = T - T_freeze
     is_cold = (T <= T_freeze)
-    return ifelse(is_cold, zero(T), cv_l / L_f * ΔT)
+    return ifelse(is_cold, zero(T), cp_l / L_f * ΔT)
 end
 
 # Gating convention for the process-rate kernels below: the rate is computed
@@ -1045,7 +1077,13 @@ end
     thermo,
     sd = size_distr_parameters(mp, micro, thermo),
 )
-    return _snow_subl_dep_rate(mp, tps, micro, thermo, sd)
+    rate = _snow_subl_dep_rate(mp, tps, micro, thermo, sd)
+    # No deposition above freezing: ice does not grow by vapor deposition
+    # in the melting regime, even if the air is supersaturated over ice
+    # (possible for transient supersaturation spikes). Sublimation stays
+    # active at all temperatures.
+    is_warm = thermo.T > TDI.T_freeze(tps)
+    return ifelse(is_warm, min(0, rate), rate)
 end
 
 """Internal helper: snow sublimation/deposition physics kernel."""

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -310,13 +310,17 @@ end
 
 """
     ϵ_numerics(FT)
+    ϵ_numerics(x::Real)
 
 Physical smallness threshold for the **1-moment** scheme: below this a tracer is
-treated as absent. Returns `cbrt(floatmin(FT))`, a floatmin-derived floor that
-also keeps `cbrt`/`^` arguments above `floatmin`. See the note above for how this
-relates to the 2-moment/P3 thresholds.
+treated as absent. Returns `cbrt(floatmin(float(FT)))`, a floatmin-derived floor
+that also keeps `cbrt`/`^` arguments above `floatmin`. The `float` guard maps
+integer types to their float counterpart, so gates accept integer inputs. The
+value method keys the threshold to the argument's own type, `ϵ_numerics(q)`.
+See the note above for how this relates to the 2-moment/P3 thresholds.
 """
-@inline ϵ_numerics(FT) = cbrt(floatmin(FT))
+@inline ϵ_numerics(FT) = cbrt(floatmin(float(FT)))
+@inline ϵ_numerics(x::Real) = ϵ_numerics(typeof(x))
 
 """
     ϵ_numerics_2M_M(FT)

--- a/test/ad_compat_tests.jl
+++ b/test/ad_compat_tests.jl
@@ -8,6 +8,7 @@ import CloudMicrophysics.P3Scheme as P3
 import CloudMicrophysics.Common as CO
 import CloudMicrophysics.DistributionTools as DT
 import CloudMicrophysics.Microphysics2M as CM2
+import CloudMicrophysics.Microphysics1M as CM1
 import CloudMicrophysics.ThermodynamicsInterface as TDI
 import ForwardDiff as FD
 import SpecialFunctions as SF
@@ -187,3 +188,134 @@ end
 
 test_ad_compatibility(Float64)
 test_ad_compatibility(Float32)
+
+# ForwardDiff compatibility of the 1-moment process rates. The 1M kernels take
+# parameters (plain floats) and state alongside each other, so a `::FT ...
+# where {FT}` signature would bind both to one type and reject a `Dual`
+# state; the rates are duck-typed instead, with `zero(rate)` fallbacks and
+# value-keyed `ϵ_numerics` gates.
+function test_ad_compatibility_1M(FT)
+    tps = TDI.TD.Parameters.ThermodynamicsParameters(FT)
+    mp = CMP.Microphysics1MParams(FT)
+    mpS = CMP.Microphysics1MParams(FT; snow_autoconversion = CMP.WithSupersaturation())
+    chen = CMP.Chen2022VelType(FT)
+    rain, snow = mp.precip.rain, mp.precip.snow
+    ρ0, T_cold, T_warm = FT(1.2), FT(270), FT(280)
+    state(q) = (; q_tot = q + FT(5e-3), q_lcl = q, q_icl = q, q_rai = q, q_sno = q)
+
+    # (name, f) pairs differentiated w.r.t. a single scalar
+    rates_q = (
+        (
+            "accretion lcl-rai",
+            q -> CM1.accretion(CMP.CloudLiquidRainAccretion(), mp, tps, state(q), (; ρ = ρ0, T = T_cold)),
+        ),
+        (
+            "accretion icl-sno",
+            q -> CM1.accretion(CMP.CloudIceSnowAccretion(), mp, tps, state(q), (; ρ = ρ0, T = T_cold)),
+        ),
+        (
+            "accretion rain sink",
+            q -> CM1.accretion_rain_sink(CMP.CloudIceRainAccretion(), mp, tps, state(q), (; ρ = ρ0, T = T_cold)),
+        ),
+        (
+            "accretion snow-rain",
+            q ->
+                CM1.accretion_snow_rain(CMP.RainSnowAccretion(), mp, tps, state(q), (; ρ = ρ0, T = T_cold)).S_rai_sno,
+        ),
+        ("snow melt", q -> CM1.conv_q_sno_to_q_rai(CMP.SnowMelt(), mp, tps, state(q), (; ρ = ρ0, T = T_warm))),
+        ("cloud ice melt", q -> CM1.conv_q_icl_to_q_lcl(CMP.CloudIceMelt(), mp, tps, state(q), (; ρ = ρ0, T = T_warm))),
+        (
+            "rain autoconversion",
+            q -> CM1.conv_q_lcl_to_q_rai(CMP.Kessler1M(), mp, tps, state(q), (; ρ = ρ0, T = T_cold)),
+        ),
+        (
+            "snow autoconversion",
+            q -> CM1.conv_q_icl_to_q_sno(CMP.NoSupersaturation(), mp, tps, state(q), (; ρ = ρ0, T = T_cold)),
+        ),
+        (
+            "snow autoconversion supersat",
+            q -> CM1.conv_q_icl_to_q_sno(CMP.WithSupersaturation(), mpS, tps, state(q), (; ρ = ρ0, T = T_cold)),
+        ),
+        ("v_t rain blk1m", q -> CM1.terminal_velocity(rain, mp.terminal_velocity.rain, ρ0, q)),
+        ("v_t snow blk1m", q -> CM1.terminal_velocity(snow, mp.terminal_velocity.snow, ρ0, q)),
+        ("v_t rain Chen", q -> CM1.terminal_velocity(rain, chen.rain, ρ0, q)),
+        ("v_t snow Chen", q -> CM1.terminal_velocity(snow, chen.large_ice, ρ0, q)),
+        ("v_t snow Oblate", q -> CM1.terminal_velocity(snow, chen.large_ice, ρ0, q, CM1.Oblate())),
+        ("v_t snow Prolate", q -> CM1.terminal_velocity(snow, chen.large_ice, ρ0, q, CM1.Prolate())),
+        ("lambda_inverse", q -> CM1.lambda_inverse(rain.pdf, rain.mass, q, ρ0)),
+    )
+
+    @testset "1M ForwardDiff w.r.t. q, $name ($FT)" for (name, f) in rates_q
+        q0 = FT(1e-4)
+        d = FD.derivative(f, q0)
+        @test isfinite(d)
+        # value must be unchanged by seeding a Dual
+        @test FD.value(f(FD.Dual{:ad_1m}(q0, one(FT)))) ≈ f(q0) rtol = 10 * eps(FT)
+        # Agreement with a central difference. `cbrt(eps)` is the step that
+        # balances truncation against round-off. The tolerance is set by the
+        # difference quotient's accuracy, not the derivative's: where |f'|
+        # is large relative to |f| (the Chen velocities, f' ~ 8e3 with
+        # f ~ O(1)) cancellation leaves ~0.2% in Float32. An AD defect (a
+        # dropped term or a wrong chain rule) is an O(1) relative error, so
+        # 1% still catches every failure mode this test exists to catch.
+        # The atol scales with the observed magnitudes so the comparison
+        # stays meaningful for small derivatives.
+        h = q0 * cbrt(eps(FT))
+        fd = (f(q0 + h) - f(q0 - h)) / (2h)
+        rtol_fd = FT === Float32 ? FT(1e-2) : FT(1e-4)
+        @test d ≈ fd rtol = rtol_fd atol = rtol_fd * max(abs(d), abs(fd))
+    end
+
+    # The Dual now arrives through a *different* argument than above, which
+    # a single-argument `eltype(q)` would type incorrectly.
+    rates_ρ = (
+        ("v_t rain blk1m", r -> CM1.terminal_velocity(rain, mp.terminal_velocity.rain, r, FT(1e-4))),
+        ("v_t rain Chen", r -> CM1.terminal_velocity(rain, chen.rain, r, FT(1e-4))),
+        ("v_t snow Chen", r -> CM1.terminal_velocity(snow, chen.large_ice, r, FT(1e-4))),
+        ("v_t snow Oblate", r -> CM1.terminal_velocity(snow, chen.large_ice, r, FT(1e-4), CM1.Oblate())),
+        ("lambda_inverse", r -> CM1.lambda_inverse(rain.pdf, rain.mass, FT(1e-4), r)),
+        ("get_v0", r -> CM1.get_v0(mp.terminal_velocity.rain, r)),
+    )
+    @testset "1M ForwardDiff w.r.t. ρ, $name ($FT)" for (name, f) in rates_ρ
+        @test isfinite(FD.derivative(f, ρ0))
+    end
+    @testset "1M ForwardDiff w.r.t. ρ, sign and guards ($FT)" begin
+        # denser air slows the fall speed
+        @test FD.derivative(r -> CM1.terminal_velocity(rain, mp.terminal_velocity.rain, r, FT(1e-4)), ρ0) < 0
+        # the ρ ≥ ρw density guard must not poison the derivative
+        ρw = mp.terminal_velocity.rain.ρw
+        @test isfinite(FD.derivative(r -> CM1.get_v0(mp.terminal_velocity.rain, r), ρw))
+        @test isfinite(FD.derivative(r -> CM1.get_v0(mp.terminal_velocity.rain, r), 2 * ρw))
+    end
+
+    # Process rates must stay concretely typed with Dual state and plain
+    # thermo (kernel-level argument mixes are swept in return_type_tests.jl).
+    @testset "1M rates concretely typed under Dual state ($FT)" begin
+        DT = FD.Dual{:ad_1m, FT, 1}
+        for (opt, f) in (
+            (CMP.CloudLiquidRainAccretion(), CM1.accretion),
+            (CMP.RainSnowAccretion(), CM1.accretion_snow_rain),
+            (CMP.CloudIceRainAccretion(), CM1.accretion_rain_sink),
+            (CMP.RainEvaporation(), CM1.conv_q_rai_to_q_vap),
+            (CMP.DepositionAndSublimation(), CM1.conv_q_sno_to_q_vap),
+            (CMP.SnowMelt(), CM1.conv_q_sno_to_q_rai),
+            (CMP.CloudIceMelt(), CM1.conv_q_icl_to_q_lcl),
+            (CMP.Kessler1M(), CM1.conv_q_lcl_to_q_rai),
+        )
+            rts = Base.return_types(
+                f,
+                Tuple{
+                    typeof(opt),
+                    typeof(mp),
+                    typeof(tps),
+                    NamedTuple{(:q_tot, :q_lcl, :q_icl, :q_rai, :q_sno), NTuple{5, DT}},
+                    NamedTuple{(:ρ, :T), NTuple{2, FT}},
+                },
+            )
+            @test length(rts) == 1 && isconcretetype(rts[1])
+        end
+    end
+end
+
+test_ad_compatibility_1M(Float64)
+test_ad_compatibility_1M(Float32)

--- a/test/microphysics1M_tests.jl
+++ b/test/microphysics1M_tests.jl
@@ -102,6 +102,11 @@ function test_microphysics1M(FT)
         TT.@test v_bigger_prolate > vt_prolate
         # both shapes give reasonable velocities (within an order of magnitude of each other)
         TT.@test 0.1 < vt_oblate / vt_prolate < 10
+
+        # reference values. `ϕ` is a function of diameter, so the mass-weighted
+        # ⟨ϕ⟩ must use the diameter-based slope: checking here for consistency.
+        TT.@test vt_oblate ≈ FT(1.6992) rtol = 1e-4
+        TT.@test vt_prolate ≈ FT(1.4875) rtol = 1e-4
     end
 
     TT.@testset "1M_microphysics - 1M snow terminal velocity" begin

--- a/test/microphysics1M_tests.jl
+++ b/test/microphysics1M_tests.jl
@@ -263,6 +263,38 @@ function test_microphysics1M(FT)
 
     end
 
+    TT.@testset "OptionParamsMismatch" begin
+        # passing an option inconsistent with how `mp` was built must fail
+        # with an actionable error, not an obscure field-access failure
+        mpS = CMP.Microphysics1MParams(FT; snow_autoconversion = CMP.WithSupersaturation())
+        mpNd = CMP.Microphysics1MParams(FT; rain_autoconversion = CMP.PrescribedNd())
+        micro = (; q_tot = FT(1e-2), q_lcl = FT(1e-3), q_icl = FT(1e-3), q_rai = FT(0), q_sno = FT(0))
+        thermo = (; ρ = FT(1.2), T = FT(260))
+        TT.@test_throws ArgumentError CM1.conv_q_icl_to_q_sno(CMP.WithSupersaturation(), mp, tps, micro, thermo)
+        TT.@test_throws ArgumentError CM1.conv_q_icl_to_q_sno(CMP.NoSupersaturation(), mpS, tps, micro, thermo)
+        TT.@test_throws ArgumentError CM1.conv_q_lcl_to_q_rai(CMP.PrescribedNd(), mp, tps, micro, thermo)
+        TT.@test_throws ArgumentError CM1.conv_q_lcl_to_q_rai(CMP.Kessler1M(), mpNd, tps, micro, thermo)
+        # matched combinations still work
+        TT.@test CM1.conv_q_icl_to_q_sno(CMP.WithSupersaturation(), mpS, tps, micro, thermo) isa FT
+        TT.@test CM1.conv_q_lcl_to_q_rai(CMP.PrescribedNd(), mpNd, tps, micro, thermo) isa FT
+    end
+
+    TT.@testset "NoSnowDepositionAboveFreezing" begin
+        # strongly ice-supersaturated air just above freezing: deposition must
+        # be suppressed (only sublimation or zero), while the same state below
+        # freezing deposits
+        micro = (; q_tot = FT(2e-2), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno = FT(1e-3))
+        warm = (; ρ = FT(1.2), T = FT(274))
+        cold = (; ρ = FT(1.2), T = FT(272))
+        dep_warm = CM1.conv_q_sno_to_q_vap(CMP.DepositionAndSublimation(), mp, tps, micro, warm)
+        dep_cold = CM1.conv_q_sno_to_q_vap(CMP.DepositionAndSublimation(), mp, tps, micro, cold)
+        TT.@test dep_warm <= 0
+        TT.@test dep_cold > 0
+        # sublimation stays active above freezing
+        dry = (; q_tot = FT(1e-4), q_lcl = FT(0), q_icl = FT(0), q_rai = FT(0), q_sno = FT(1e-3))
+        TT.@test CM1.conv_q_sno_to_q_vap(CMP.DepositionAndSublimation(), mp, tps, dry, warm) < 0
+    end
+
     TT.@testset "SnowAutoconversionNoSupersat" begin
 
         q_icl_threshold = mp.process_params.snow_autoconversion.q_threshold
@@ -642,11 +674,12 @@ function test_microphysics1M(FT)
 
     TT.@testset "SnowSublimation and Deposition" begin
         # Regression test: keep results constant when code changes
-        # Uses DepositionSublimation() and original reference values that include deposition
+        # Uses DepositionSublimation(). Above freezing, deposition is
+        # suppressed (zero), while sublimation stays active.
         cnt = 0
         ref_val = [
             FT(-1.9756907119482267e-7),
-            FT(1.9751292385808357e-7),
+            FT(0),
             FT(-1.6641552112891826e-7),
             FT(1.663814937710236e-7),
         ]

--- a/test/return_type_tests.jl
+++ b/test/return_type_tests.jl
@@ -5,6 +5,7 @@ import CloudMicrophysics as CM
 import CloudMicrophysics.Parameters as CMP
 import CloudMicrophysics.BulkMicrophysicsTendencies as BMT
 import CloudMicrophysics.Microphysics2M as CM2
+import CloudMicrophysics.Microphysics1M as CM1
 import CloudMicrophysics.MicrophysicsNonEq as CMNonEq
 import CloudMicrophysics.DistributionTools as DT
 import CloudMicrophysics.P3Scheme as P3
@@ -107,4 +108,35 @@ end
     # leaves (Microphysics1M.jl) carry their own single-argument-typed
     # returns. The 1M leaves share this pattern and are out of scope for
     # this 2M/P3 sweep (the BMT-level source-terms FT is fixed).
+end
+
+@testset "1M kernels are concretely typed under mixed Dual/plain args" begin
+    mp1 = CMP.Microphysics1MParams(FT64)
+    chen = CMP.Chen2022VelType(FT64)
+    rain, snow, ice = mp1.precip.rain, mp1.precip.snow, mp1.cloud.ice
+    velr, vels = mp1.terminal_velocity.rain, mp1.terminal_velocity.snow
+
+    P = typeof
+    @test concrete_for_all_mixes(CM1.get_n0, (P(snow.pdf),), 2)
+    @test concrete_for_all_mixes(CM1.get_v0, (P(velr),), 1)
+    @test concrete_for_all_mixes(CM1.lambda_inverse, (P(rain.pdf), P(rain.mass)), 2)
+    @test concrete_for_all_mixes(CM1.lambda_inverse, (P(snow.pdf), P(snow.mass)), 2)
+    @test concrete_for_all_mixes(CM1.terminal_velocity, (P(rain), P(velr)), 2)
+    @test concrete_for_all_mixes(CM1.terminal_velocity, (P(snow), P(vels)), 2)
+    @test concrete_for_all_mixes(CM1.terminal_velocity, (P(rain), P(velr)), 4)
+    @test concrete_for_all_mixes(CM1.terminal_velocity, (P(rain), P(chen.rain)), 2)
+    @test concrete_for_all_mixes(CM1.terminal_velocity, (P(snow), P(chen.large_ice)), 2)
+    @test concrete_for_all_mixes(
+        CM1.terminal_velocity, (P(snow), P(chen.large_ice)), 2; post = (P(CM1.Oblate()),),
+    )
+    @test concrete_for_all_mixes(
+        CM1.terminal_velocity, (P(snow), P(chen.large_ice)), 2; post = (P(CM1.Prolate()),),
+    )
+    @test concrete_for_all_mixes(CM1.accretion, (P(mp1.cloud.liquid), P(rain), P(velr)), 7)
+    # the full kernels: 9 and 11 numeric arguments respectively
+    @test concrete_for_all_mixes(CM1.accretion_rain_sink, (P(rain), P(ice), P(velr)), 9)
+    @test concrete_for_all_mixes(CM1.accretion_snow_rain, (P(snow), P(rain), P(vels), P(velr)), 11)
+    # and their argument-computing wrappers
+    @test concrete_for_all_mixes(CM1.accretion_rain_sink, (P(rain), P(ice), P(velr)), 4)
+    @test concrete_for_all_mixes(CM1.accretion_snow_rain, (P(snow), P(rain), P(vels), P(velr)), 5)
 end


### PR DESCRIPTION
- **Fix a factor `2^α` in the snow aspect-ratio average**: `ϕ_av` used the
  radius-based PSD slope for a diameter-based power law, inflating shape-based
  (`Oblate`/`Prolate`) snow terminal velocities by ~26%. 
- **Make the 1M rates ForwardDiff-differentiable**: removed the
  `::FT ... where {FT}` annotations for consistency with ForwardDiff and other Clima repos,
  with `zero(rate)` fallbacks and `ϵ_numerics` filters; the  integer-hardening happens now 
  inside `Utilities.ϵ_numerics`. New AD tests check rates against central differences in
  both precisions, plus mixed-Dual return-type sweeps in `return_type_tests.jl`.
- **Suppress snow deposition above freezing** (sublimation stays active):
  closes an unphysical (but tiny) vapor→ice growth path reachable during transient
  supersaturation spikes. 
- **Fail clearly on option/parameter mismatches**: passing e.g.
  `WithSupersaturation()` with parameters built for `NoSupersaturation` now
  throws an actionable `ArgumentError` instead of an obscure field error.
- Comment/doc fixes: Chen et al. (2022) table references corrected to
  B1/B3/B5, `cp_l` in the melt factor.

**Results change** only for the shape-based snow terminal velocity (−26%) and for
snow deposition in ice-supersaturated air above freezing (now 0).

Merge this *before* #779 