### PR TITLE
Prescribed N_ice for vapor -> ice formation in non-eq microphysics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ MLJ = "add582a8-e3ab-11e8-2d5e-e98b27df1bc7"
 EmulatorModelsExt = ["DataFrames", "MLJ"]
 
 [compat]
-ClimaParams = "1.0.18"
+ClimaParams = "1.1"
 DataFrames = "1.6"
 DocStringExtensions = "0.8, 0.9"
 FastGaussQuadrature = "1"

--- a/docs/src/MicrophysicsNonEq.md
+++ b/docs/src/MicrophysicsNonEq.md
@@ -21,10 +21,12 @@ They consist of:
 
 !!! note
     For ice, the deposition timescale ``\tau_{dep}`` can optionally be computed
-    from the [Frostenberg2023](@cite) INP parameterization (see
-    [below](@ref ice-relaxation-timescale-frostenberg-et-al-2023)),
-    while the sublimation timescale ``\tau_{sub}`` remains at the constant
-    ``\tau_i``.
+    from the prescribed cloud-ice number concentration ``N_0`` (see
+    [below](@ref ice-relaxation-timescale-prescribed-ice-number)) or from the
+    [Frostenberg2023](@cite) INP parameterization (see
+    [below](@ref ice-relaxation-timescale-frostenberg-et-al-2023)).
+    With the Frostenberg option, the sublimation timescale ``\tau_{sub}`` remains
+    at the constant ``\tau_i``.
 
 ## Condensation/evaporation and deposition/sublimation from Morrison and Milbrandt 2015
 
@@ -123,6 +125,49 @@ include("plots/NonEqCondEvapRate.jl")
 ```
 ![](condensation_evaporation_ql_z.svg)
 ![](condensation_evaporation_ql_T.svg)
+
+## [Ice relaxation timescale — prescribed ice number](@id ice-relaxation-timescale-prescribed-ice-number)
+
+Instead of using a constant ice relaxation timescale, the `PrescribedIceNumber`
+  option derives ``\tau_i`` from the fixed cloud-ice number concentration
+  ``N_0`` stored in `CloudIce` (the same value used for cloud-ice sedimentation).
+
+The number concentration ``N_0`` is stored in volumetric units (``1/\text{m}^3``).
+For the radius computation it is converted to specific units:
+```math
+\begin{equation}
+  n = N_0 / \rho
+\end{equation}
+```
+where ``\rho`` is the air density.
+
+Given ``n`` and the cloud ice specific content ``q_{icl}`` (kg/kg),
+  the mean crystal radius is computed assuming spherical ice particles
+  with a monodisperse size distribution:
+```math
+\begin{equation}
+  r = \left(\frac{3 \, q_{icl}}{4 \pi \, n \, \rho_i}\right)^{1/3}
+\end{equation}
+```
+A minimum radius ``r_0 = 1\,\mu m`` is enforced.
+
+The relaxation timescale uses the volumetric ``N_0`` (``1/\text{m}^3``)
+  to keep the result in seconds:
+```math
+\begin{equation}
+  \tau_{i} = \frac{1}{4 \pi \, D_v \, N_0 \, r_{safe}}
+\end{equation}
+```
+where ``D_v`` is the water vapor diffusivity (``\text{m}^2/\text{s}``)
+  and ``r_{safe} = \max(r, r_0)``.
+
+Unlike the `TemperatureDependent` (Frostenberg) option, this approach uses the
+  **same timescale for both deposition and sublimation**.
+
+```@example
+include("plots/plotting_tau_relax_prescribed_N0.jl")
+```
+![](tau_relax_prescribed_N0.svg)
 
 ## [Ice relaxation timescale — Frostenberg et al. (2023)](@id ice-relaxation-timescale-frostenberg-et-al-2023)
 

--- a/docs/src/plots/plotting_tau_relax_frostenberg.jl
+++ b/docs/src/plots/plotting_tau_relax_frostenberg.jl
@@ -50,7 +50,7 @@ for (j, q_icl) in enumerate(q_icl_values)
 
         if T < T_freeze
             # Deposition branch: τ_dep × Γᵢ
-            τ_dep = CMNe.τ_relax(ice, aps, frs, q_icl, T)
+            τ_dep = CMNe.τ_relax(ice, aps, frs, q_icl, T, ρ)
             τ_data[i, j] = τ_dep * Γᵢ
         else
             # Sublimation branch: τ_sub × Γᵢ

--- a/docs/src/plots/plotting_tau_relax_prescribed_N0.jl
+++ b/docs/src/plots/plotting_tau_relax_prescribed_N0.jl
@@ -1,0 +1,74 @@
+import CairoMakie as MK
+CairoMakie = MK
+
+import CloudMicrophysics.Parameters as CMP
+import CloudMicrophysics.MicrophysicsNonEq as CMNe
+
+FT = Float64
+
+# Parameters
+aps = CMP.AirProperties(FT)
+ρ = FT(0.8)   # representative mid-troposphere air density
+
+# Cloud ice density (from defaults)
+ice_default = CMP.CloudIce(FT)
+ρᵢ = ice_default.ρᵢ
+
+# Build CloudIce structs with different N_0 values
+# (reuse the default struct's other fields, only vary N_0)
+N_0_values = [FT(1e7), FT(5e7), FT(1e8), FT(5e8)]   # 1/m³
+N_0_labels = ["10⁷", "5×10⁷", "10⁸", "5×10⁸"]
+
+# q_icl range: 10⁻⁸ to 10⁻² kg/kg (log-spaced)
+q_icl_range = 10 .^ range(-8, -2, length = 300)
+
+# Compute τ for each (N_0, q_icl) pair
+τ_data = Matrix{FT}(undef, length(q_icl_range), length(N_0_values))
+for (j, N_0) in enumerate(N_0_values)
+    ice_j = CMP.CloudIce(;
+        pdf = ice_default.pdf,
+        mass = ice_default.mass,
+        ρᵢ = ice_default.ρᵢ,
+        r_eff = ice_default.r_eff,
+        N_0 = N_0,
+    )
+    for (i, q_icl) in enumerate(q_icl_range)
+        τ_data[i, j] = CMNe.τ_relax(ice_j, aps, q_icl, ρ)
+    end
+end
+
+# Colors — distinct, colorblind-friendly
+colors = [
+    MK.RGBf(0.12, 0.47, 0.71),  # blue
+    MK.RGBf(1.0, 0.50, 0.05),   # orange
+    MK.RGBf(0.17, 0.63, 0.17),  # green
+    MK.RGBf(0.84, 0.15, 0.16),  # red
+]
+
+linestyles = [:solid, :dash, :dot, :dashdot]
+
+# Plot
+fig = MK.Figure(size = (800, 550))
+ax = MK.Axis(
+    fig[1, 1],
+    xlabel = "Cloud ice specific content q_icl [kg/kg]",
+    ylabel = "Relaxation timescale τ [s]",
+    title = "Ice relaxation timescale — prescribed N₀\n(ρ = $(ρ) kg/m³)",
+    xscale = log10,
+    yscale = log10,
+)
+
+for (j, (N_0, label)) in enumerate(zip(N_0_values, N_0_labels))
+    MK.lines!(
+        ax, q_icl_range, τ_data[:, j],
+        label = "N₀ = $(label) m⁻³",
+        color = colors[j],
+        linewidth = 2.5,
+        linestyle = linestyles[j],
+    )
+end
+
+MK.axislegend(ax, position = :rt)
+MK.save("tau_relax_prescribed_N0.svg", fig)
+
+println("Plot saved to tau_relax_prescribed_N0.svg")

--- a/src/BulkMicrophysicsTendencies.jl
+++ b/src/BulkMicrophysicsTendencies.jl
@@ -176,8 +176,13 @@ processes are pre-routed by temperature, so consumers never need `is_warm`.
     # Cloud liquid + rain → rain
     S_accr_lcl_rai = CM1.accretion(procs.cloud_liquid_rain_accretion, mp, tps, micro, thermo, sd)
 
-    # Cloud liquid + snow: product goes to sno (cold) or rai (warm), plus thermal melt
-    (; S_accr, S_melt) = CM1.accretion(procs.cloud_liquid_snow_accretion, mp, tps, micro, thermo, sd)
+    # Cloud liquid + snow: product goes to sno (cold) or rai (warm), plus thermal melt.
+    # The previous accretion versions return a single number, this one has to return a tuple.
+    (; S_accr, S_melt) = if isnothing(procs.cloud_liquid_snow_accretion)
+        (; S_accr = zero(FT), S_melt = zero(FT))
+    else
+        CM1.accretion(procs.cloud_liquid_snow_accretion, mp, tps, micro, thermo, sd)
+    end
     S_accr_lcl_sno_cold = ifelse(is_warm, zero(FT), S_accr)    # lcl → sno (cold)
     S_accr_lcl_sno_warm = ifelse(is_warm, S_accr, zero(FT))    # lcl → rai (warm)
     S_accr_melt_lcl_sno = S_melt                                # thermal melt of sno from warm lcl (already zero when cold)

--- a/src/MicrophysicsNonEq.jl
+++ b/src/MicrophysicsNonEq.jl
@@ -25,29 +25,59 @@ export dqcld_dT
 export gamma_helper
 
 """
-    τ_relax(ice, air_properties, frostenberg, q_icl, T)
+    τ_relax(ice, air_properties, q_icl, ρ)
+    τ_relax(ice, air_properties, frostenberg, q_icl, T, ρ)
 
-Computes the deposition relaxation timescale through
-the Frostenberg et al., (2023) parameterization.
+Computes the deposition/sublimation relaxation timescale.
+
+The first method uses the prescribed cloud-ice number concentration
+`N_0` from `CloudIce`; the second derives the ice-crystal
+number from the Frostenberg et al. (2023) INP parameterization.
 See DOI: 10.5194/acp-23-10883-2023
+
+Arguments:
+  - cloud microphysics and air parameters
+  - q_icl [kg/kg] - cloud ice specific humidity
+  - T [K] - air temperature (Frostenberg only)
+  - ρ [kg/m³] - air density
 """
 @inline function τ_relax(
-    (; ρᵢ)::CMP.CloudIce, (; D_vapor)::CMP.AirProperties,
-    ip::CMP.Frostenberg2023, q_icl, T,
+    (; ρᵢ, N_0)::CMP.CloudIce, (; D_vapor)::CMP.AirProperties, q_icl, ρ,
 )
-    FT = UT.promote_typeof(q_icl, T, ρᵢ)
-    # Get the estimated number of INPs
-    N_icl = exp(IN.INP_concentration_mean(ip, T))
+    FT = UT.promote_typeof(q_icl, N_0, ρᵢ)
+
+    # Convert N_0 from 1/m³ to 1/kg for the radius computation
+    N_specific = N_0 / ρ
 
     # Compute the radius assuming spherical particles and
-    # mono-modal distribution
-    safe_N_icl = max(N_icl, UT.ϵ_numerics(FT))
-    r = ifelse(N_icl > UT.ϵ_numerics(FT), cbrt((3 * q_icl) / (4 * FT(π) * safe_N_icl * ρᵢ)), zero(FT))
-    r0 = FT(1e-6)
+    # mono-modal distribution (q in kg/kg, N in 1/kg)
+    r = cbrt((3 * q_icl) / (4 * FT(π) * N_specific * ρᵢ))
+    r0 = FT(1e-6) # TODO - make a parameter
     r_safe = max(r, r0)
 
-    # Compute the relaxation timescale
-    τ = (4 * FT(π) * D_vapor * N_icl * r_safe)^(-1)
+    # Compute the relaxation timescale (D_vapor in m²/s, N in 1/m³, r in m → τ in s)
+    τ = (4 * FT(π) * D_vapor * N_0 * r_safe)^(-1)
+    return τ
+end
+@inline function τ_relax(
+    (; ρᵢ)::CMP.CloudIce, (; D_vapor)::CMP.AirProperties,
+    ip::CMP.Frostenberg2023, q_icl, T, ρ,
+)
+    FT = UT.promote_typeof(q_icl, T, ρᵢ, ρ)
+    # Get the estimated number of INPs in 1/m³
+    N_vol = exp(IN.INP_concentration_mean(ip, T))
+    # Convert to 1/kg for the radius computation
+    N_icl = N_vol / ρ
+
+    # Compute the radius assuming spherical particles and
+    # mono-modal distribution (q in kg/kg, N in 1/kg)
+    safe_N_icl = max(N_icl, UT.ϵ_numerics(FT))
+    r = ifelse(N_icl > UT.ϵ_numerics(FT), cbrt((3 * q_icl) / (4 * FT(π) * safe_N_icl * ρᵢ)), zero(FT))
+    r0 = FT(1e-6) # TODO - make a parameter
+    r_safe = max(r, r0)
+
+    # Compute the relaxation timescale (D_vapor in m²/s, N in 1/m³, r in m → τ in s)
+    τ = (4 * FT(π) * D_vapor * N_vol * r_safe)^(-1)
     return τ
 end
 
@@ -143,6 +173,7 @@ end
 
 """
     conv_q_vap_to_q_icl(opt::ConstantTimescale, mp, tps, micro, thermo)
+    conv_q_vap_to_q_icl(opt::PrescribedIceNumber, mp, tps, micro, thermo)
     conv_q_vap_to_q_icl(opt::TemperatureDependent, mp, tps, micro, thermo)
     conv_q_vap_to_q_icl(::Nothing, mp, tps, micro, thermo)
 
@@ -151,7 +182,7 @@ Morrison & Grabowski (2008), https://doi.org/10.1175/2007JAS2374.1, and
 Morrison & Milbrandt (2015), https://doi.org/10.1175/JAS-D-14-0065.1.
 
 # Arguments
-- `opt`: `ConstantTimescale()`, `TemperatureDependent()`, or `nothing` (disabled)
+- `opt`: `ConstantTimescale()`, PrescribedIceNumber(), `TemperatureDependent()`, or `nothing` (disabled)
 - `mp`: 1-moment microphysics parameters
 - `tps`: thermodynamics parameters
 - `micro`: microphysics state `(; q_tot, q_lcl, q_icl, q_rai, q_sno)`
@@ -165,6 +196,13 @@ Morrison & Milbrandt (2015), https://doi.org/10.1175/JAS-D-14-0065.1.
     ::CMP.ConstantTimescale, mp, tps::TDI.PS, micro, thermo) =
     _conv_q_vap_to_q_icl_const(
         mp.process_params.cloud_ice_formation.τ_relax, tps, micro, thermo)
+@inline function conv_q_vap_to_q_icl(
+    ::CMP.PrescribedIceNumber, mp, tps::TDI.PS, micro, thermo)
+    (; q_icl) = micro
+    (; ρ) = thermo
+    τ = τ_relax(mp.cloud.ice, mp.air_properties, q_icl, ρ)
+    return _conv_q_vap_to_q_icl_const(τ, tps, micro, thermo)
+end
 
 # Kernel for `conv_q_vap_to_q_icl` with a constant relaxation timescale `τ`
 @inline function _conv_q_vap_to_q_icl_const(τ, tps::TDI.PS, micro, thermo)
@@ -199,7 +237,7 @@ end
     (; ρ, T) = thermo
     pp = mp.process_params.cloud_ice_formation
     τ_sub = pp.τ_relax
-    τ_dep = τ_relax(mp.cloud.ice, mp.air_properties, pp.frostenberg, q_icl, T)
+    τ_dep = τ_relax(mp.cloud.ice, mp.air_properties, pp.frostenberg, q_icl, T, ρ)
 
     Rᵥ = TDI.Rᵥ(tps)
     Lₛ = TDI.Lₛ(tps, T)

--- a/src/parameters/Microphysics1MOptions.jl
+++ b/src/parameters/Microphysics1MOptions.jl
@@ -3,6 +3,7 @@ export Microphysics1MOptions,
     CloudLiquidFormation,
     CloudIceFormation,
     ConstantTimescale,
+    PrescribedIceNumber,
     TemperatureDependent,
     CloudIceMelt,
     RainAutoconversion,
@@ -41,7 +42,8 @@ abstract type MicrophysicsOption end
     CloudIceFormation <: MicrophysicsOption
 
 Abstract type for cloud ice formation (deposition/sublimation) methods.
-See subtypes: [`ConstantTimescale`](@ref), [`TemperatureDependent`](@ref).
+See subtypes: [`ConstantTimescale`](@ref), [`PrescribedIceNumber`](@ref),
+[`TemperatureDependent`](@ref).
 """
 abstract type CloudIceFormation <: MicrophysicsOption end
 
@@ -96,11 +98,22 @@ Parameters (`τ_relax`) are stored in `process_params.cloud_ice_formation` in
 struct ConstantTimescale <: CloudIceFormation end
 
 """
+    PrescribedIceNumber <: CloudIceFormation
+
+Ice deposition/sublimation timescale derived from the prescribed cloud-ice
+number concentration `N_0` in `CloudIce` (the same `N_0` used for
+sedimentation).  Both deposition and sublimation use the dynamically
+computed timescale.  No additional process parameters are required.
+"""
+struct PrescribedIceNumber <: CloudIceFormation end
+
+"""
     TemperatureDependent <: CloudIceFormation
 
 INP-dependent Frostenberg (2023) timescale for deposition,
 with constant timescale for sublimation. Parameters (`τ_relax`, `frostenberg`)
-are stored in `process_params.cloud_ice_formation` in [`Microphysics1MParams`](@ref).
+are stored in `process_params.cloud_ice_formation` in
+[`Microphysics1MParams`](@ref).
 """
 struct TemperatureDependent <: CloudIceFormation end
 
@@ -404,6 +417,7 @@ microphysics_1m_process_params(td::CP.ParamDict, o::Microphysics1MOptions) = (;
 # ═══════════════════════════════════════════════════════════════════
 @deprecate CloudLiquidFormation(::CP.ParamDict) CloudLiquidFormation() false
 @deprecate ConstantTimescale(::CP.ParamDict) ConstantTimescale() false
+@deprecate PrescribedIceNumber(::CP.ParamDict) PrescribedIceNumber() false
 @deprecate TemperatureDependent(::CP.ParamDict) TemperatureDependent() false
 @deprecate Kessler1M(::CP.ParamDict) Kessler1M() false
 @deprecate PrescribedNd(::CP.ParamDict) PrescribedNd() false

--- a/test/microphysics_noneq_tests.jl
+++ b/test/microphysics_noneq_tests.jl
@@ -25,12 +25,32 @@ function test_microphysics_noneq(FT)
     TT.@testset "τ_relax Frostenberg" begin
         q_icl = FT(1e-4)
         T_cold = FT(250)
-        τ_frs = CMNe.τ_relax(ice, aps, frs, q_icl, T_cold)
+        ρ_frs = FT(0.8)
+        τ_frs = CMNe.τ_relax(ice, aps, frs, q_icl, T_cold, ρ_frs)
         TT.@test τ_frs > FT(0)
         TT.@test isfinite(τ_frs)
         # Increasing ice content should decrease τ (larger crystals → faster relaxation)
-        τ_frs_more = CMNe.τ_relax(ice, aps, frs, FT(10) * q_icl, T_cold)
+        τ_frs_more = CMNe.τ_relax(ice, aps, frs, FT(10) * q_icl, T_cold, ρ_frs)
         TT.@test τ_frs_more < τ_frs
+    end
+
+    TT.@testset "τ_relax PrescribedIceNumber" begin
+        q_icl = FT(1e-4)
+        ρ_pin = FT(0.8)
+
+        # Basic smoke test
+        τ_pin = CMNe.τ_relax(ice, aps, q_icl, ρ_pin)
+        TT.@test τ_pin > FT(0)
+        TT.@test isfinite(τ_pin)
+
+        # Increasing ice content should decrease τ (larger crystals → faster relaxation)
+        τ_pin_more = CMNe.τ_relax(ice, aps, FT(10) * q_icl, ρ_pin)
+        TT.@test τ_pin_more < τ_pin
+
+        # Higher density (same q) → more ice mass per m³ → larger r
+        # Since τ = 1/(4π D_v N_0 r) with N_0 fixed, larger r → smaller τ
+        τ_dense = CMNe.τ_relax(ice, aps, q_icl, FT(1.2))
+        TT.@test τ_dense < τ_pin
     end
 
     TT.@testset "CondEvap_DepSub" begin
@@ -137,6 +157,43 @@ function test_microphysics_noneq(FT)
         TT.@test dep_a ≈ dep_b  # τ_sub doesn't affect deposition
 
         #! format: on
+    end
+
+    TT.@testset "PrescribedIceNumber conv_q_vap_to_q_icl" begin
+        ρ = FT(0.8)
+        T = FT(273 - 10)
+
+        pᵥ_si = TDI.saturation_vapor_pressure_over_ice(tps, T)
+        qᵥ_si = TDI.p2q(tps, T, ρ, pᵥ_si)
+
+        #! format: off
+        _conv_pin(q_tot, q_lcl, q_icl, ρ, T) = CMNe.conv_q_vap_to_q_icl(
+            CMP.PrescribedIceNumber(),
+            (; cloud = (; ice), air_properties = aps, process_params = (;)),
+            tps,
+            (; q_tot, q_lcl, q_icl, q_rai = FT(0), q_sno = FT(0)),
+            (; ρ, T)
+        )
+        #! format: on
+
+        # Sign tests
+        TT.@test _conv_pin(FT(0.5 * qᵥ_si), FT(0), FT(0), ρ, T) == FT(0)
+        TT.@test _conv_pin(FT(1.5 * qᵥ_si), FT(0), FT(0), ρ, T) > FT(0)
+        TT.@test _conv_pin(qᵥ_si, FT(0), FT(0), ρ, T) ≈ FT(0)
+
+        # INP limiter: above freezing, positive ice deposition should be zero
+        T_warm = FT(280)
+        pᵥ_si_w = TDI.saturation_vapor_pressure_over_ice(tps, T_warm)
+        qᵥ_si_w = TDI.p2q(tps, T_warm, ρ, pᵥ_si_w)
+        TT.@test _conv_pin(FT(1.5 * qᵥ_si_w), FT(0), FT(0), ρ, T_warm) == FT(0)
+
+        # Ice sublimation above freezing should NOT be limited
+        TT.@test _conv_pin(FT(0.5 * qᵥ_si_w), FT(0), FT(0.001), ρ, T_warm) <= FT(0)
+
+        # The tendency should differ from a constant-timescale result (τ depends on q_icl, ρ)
+        rate_a = _conv_pin(FT(1.5 * qᵥ_si), FT(0), FT(1e-5), ρ, T)
+        rate_b = _conv_pin(FT(1.5 * qᵥ_si), FT(0), FT(1e-3), ρ, T)
+        TT.@test rate_a != rate_b  # timescale changes with q_icl
     end
 
 

--- a/test/performance_tests.jl
+++ b/test/performance_tests.jl
@@ -232,7 +232,7 @@ function benchmark_test(FT)
     bench_press(FT, CMI_hom.homogeneous_J_linear, (ip.homogeneous, Delta_a_w), 230)
 
     @info "Non-equilibrium Microphysics"
-    bench_press(FT, CMN.τ_relax, (ice, aps, ip_frostenberg, FT(1e-4), FT(250)), 300)
+    bench_press(FT, CMN.τ_relax, (ice, aps, ip_frostenberg, FT(1e-4), FT(250), FT(0.8)), 300)
 
     mp_mock = (;
         cloud = (; liquid = liquid),

--- a/test/return_type_tests.jl
+++ b/test/return_type_tests.jl
@@ -74,7 +74,11 @@ end
     @test concrete_for_all_mixes(UT._regularised_ratio, (), 2)
     @test concrete_for_all_mixes(
         CMNonEq.τ_relax,
-        (P(CMP.CloudIce(FT64)), P(CMP.AirProperties(FT64)), P(mp.ice.ice_nucleation)), 2,
+        (P(CMP.CloudIce(FT64)), P(CMP.AirProperties(FT64)), P(mp.ice.ice_nucleation)), 3,
+    )
+    @test concrete_for_all_mixes(
+        CMNonEq.τ_relax,
+        (P(CMP.CloudIce(FT64)), P(CMP.AirProperties(FT64))), 2,
     )
     @test concrete_for_all_mixes(P3.loggamma_inc_moment, (), 4)
     # P3 aspect ratio: plain state with Dual D and vice versa


### PR DESCRIPTION
This PR adds vapor to cloud ice timescale based on prescribed number concentration. The number concentration we already had in parameters, because we use it in sedimentation. 

I also fixed a bug in Frostenberg that was using number concentration per m3 rather than kg (doesn't really improve the results)

I also also fixed a dispatch issue when you want to switch off cloud liquid snow collisions. 

To be tested in AMIP, but deep convection tests show that with prescribed N we can get much better liquid - ice partitioning.